### PR TITLE
refactor: convert Error enum to UPPER_CASE

### DIFF
--- a/src/api/GeniusAPIServer.cpp
+++ b/src/api/GeniusAPIServer.cpp
@@ -426,7 +426,7 @@ namespace sgns::neoswarm::api
     {
         if ( !core_engine_ )
         {
-            return outcome::failure( Error::InternalError );
+            return outcome::failure( Error::INTERNAL_ERROR );
         }
 
         Task t = task;
@@ -454,7 +454,7 @@ namespace sgns::neoswarm::api
             case ExecutionMode::Swarm:
                 return RunSwarm( t, route );
         }
-        return outcome::failure( Error::InternalError );
+        return outcome::failure( Error::INTERNAL_ERROR );
     }
 
     // -----------------------------------------------------------------------

--- a/src/common/Error.hpp
+++ b/src/common/Error.hpp
@@ -17,30 +17,23 @@ namespace sgns::neoswarm
     // -----------------------------------------------------------------------
     enum class Error : uint8_t
     {
-        // Core engine
-        ModelLoadFailed = 1,
-        InferenceFailed = 2,
-        TokenizerFailed = 3,
-        FP4DecodeFailed = 4,
-        // Router
-        RoutingFailed = 5,
-        // Network
-        NetworkError = 6,
-        PeerNotFound = 7,
-        BroadcastTimeout = 8,
-        // Reputation
-        StorageError = 9,
-        ReputationNotFound = 10,
-        // Knowledge
-        KnowledgeUnavailable = 11,
-        FactValidationFailed = 12,
-        // Security
-        IdentityError = 13,
-        SignatureInvalid = 14,
-        // General
-        InvalidArgument = 15,
-        NotImplemented = 16,
-        InternalError = 17,
+        MODEL_LOAD_FAILED = 1,
+        INFERENCE_FAILED = 2,
+        TOKENIZER_FAILED = 3,
+        FP4_DECODE_FAILED = 4,
+        ROUTING_FAILED = 5,
+        NETWORK_ERROR = 6,
+        PEER_NOT_FOUND = 7,
+        BROADCAST_TIMEOUT = 8,
+        STORAGE_ERROR = 9,
+        REPUTATION_NOT_FOUND = 10,
+        KNOWLEDGE_UNAVAILABLE = 11,
+        FACT_VALIDATION_FAILED = 12,
+        IDENTITY_ERROR = 13,
+        SIGNATURE_INVALID = 14,
+        INVALID_ARGUMENT = 15,
+        NOT_IMPLEMENTED = 16,
+        INTERNAL_ERROR = 17,
     };
 
 } // namespace sgns::neoswarm

--- a/src/core/engine/MNNInferenceEngine.cpp
+++ b/src/core/engine/MNNInferenceEngine.cpp
@@ -189,14 +189,14 @@ namespace sgns::neoswarm::core
                 if ( !mnn_llm_ )
                 {
                     EngineLogger()->error( "Llm::createLLM failed for {}", llm_dir );
-                    return outcome::failure( Error::ModelLoadFailed );
+                    return outcome::failure( Error::MODEL_LOAD_FAILED );
                 }
                 if ( !mnn_llm_->load() )
                 {
                     EngineLogger()->error( "Llm::load() failed" );
                     MNN::Transformer::Llm::destroy( mnn_llm_ );
                     mnn_llm_ = nullptr;
-                    return outcome::failure( Error::ModelLoadFailed );
+                    return outcome::failure( Error::MODEL_LOAD_FAILED );
                 }
                 model_path_ = model_path;
                 loaded_.store( true );
@@ -208,7 +208,7 @@ namespace sgns::neoswarm::core
             interpreter_.reset( MNN::Interpreter::createFromFile( model_path.c_str() ) );
             if ( !interpreter_ )
             {
-                return outcome::failure( Error::ModelLoadFailed );
+                return outcome::failure( Error::MODEL_LOAD_FAILED );
             }
             MNN::ScheduleConfig sched_cfg;
             sched_cfg.type = static_cast<MNNForwardType>( SelectBackend() );
@@ -216,7 +216,7 @@ namespace sgns::neoswarm::core
             session_ = interpreter_->createSession( sched_cfg );
             if ( !session_ )
             {
-                return outcome::failure( Error::ModelLoadFailed );
+                return outcome::failure( Error::MODEL_LOAD_FAILED );
             }
             model_path_ = model_path;
             loaded_.store( true );
@@ -239,7 +239,7 @@ namespace sgns::neoswarm::core
     {
         if ( !loaded_.load() )
         {
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
 
         // ---- Stub mode (no model loaded) ----
@@ -258,7 +258,7 @@ namespace sgns::neoswarm::core
         {
             if ( !bridge_ || !tensor_interpreter_ )
             {
-                return outcome::failure( Error::InferenceFailed );
+                return outcome::failure( Error::INFERENCE_FAILED );
             }
 
             auto t0 = std::chrono::steady_clock::now();
@@ -319,7 +319,7 @@ namespace sgns::neoswarm::core
             // --- Standard Interpreter path (non-LLM models) ---
             if ( !tokenizer_ )
             {
-                return outcome::failure( Error::InferenceFailed );
+                return outcome::failure( Error::INFERENCE_FAILED );
             }
 
             auto t0 = std::chrono::steady_clock::now();
@@ -402,7 +402,7 @@ namespace sgns::neoswarm::core
     {
         if ( !loaded_.load() )
         {
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
 
         // SGProcessing does not support streaming yet — fall through to batch.
@@ -455,7 +455,7 @@ namespace sgns::neoswarm::core
 
             if ( !tokenizer_ )
             {
-                return outcome::failure( Error::InferenceFailed );
+                return outcome::failure( Error::INFERENCE_FAILED );
             }
 
             auto enc_res = tokenizer_->Encode( task.prompt_ );
@@ -529,7 +529,7 @@ namespace sgns::neoswarm::core
         auto* input_tensor = interpreter_->getSessionInput( session_, "input_ids" );
         if ( !input_tensor )
         {
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
         interpreter_->resizeTensor( input_tensor, { 1, static_cast<int>( input_ids.size() ) } );
         interpreter_->resizeSession( session_ );
@@ -547,7 +547,7 @@ namespace sgns::neoswarm::core
         auto* logits_tensor = interpreter_->getSessionOutput( session_, "logits" );
         if ( !logits_tensor )
         {
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
         auto* host_logits = new MNN::Tensor( logits_tensor, MNN::Tensor::CAFFE );
         logits_tensor->copyToHostTensor( host_logits );

--- a/src/core/fp4/FP4Codec.cpp
+++ b/src/core/fp4/FP4Codec.cpp
@@ -110,7 +110,7 @@ namespace sgns::neoswarm::fp4
     {
         if ( !weights || rows == 0 || cols == 0 )
         {
-            return outcome::failure( Error::InvalidArgument );
+            return outcome::failure( Error::INVALID_ARGUMENT );
         }
 
         FP4Tensor tensor;
@@ -181,7 +181,7 @@ namespace sgns::neoswarm::fp4
     {
         if ( !output )
         {
-            return outcome::failure( Error::InvalidArgument );
+            return outcome::failure( Error::INVALID_ARGUMENT );
         }
 
         const size_t rows = tensor.rows_;

--- a/src/core/sgprocessing/SGProcessingBridge.cpp
+++ b/src/core/sgprocessing/SGProcessingBridge.cpp
@@ -165,7 +165,7 @@ namespace sgns::neoswarm::core
     {
         if ( model_uri.empty() || input_uri.empty() )
         {
-            return outcome::failure( Error::InvalidArgument );
+            return outcome::failure( Error::INVALID_ARGUMENT );
         }
 
         const std::string type_str = InputFormatToTypeString( input_format );
@@ -288,7 +288,7 @@ namespace sgns::neoswarm::core
             {
                 // Auto-fallback to local MNN on network failure
                 // Auth failures (SignatureInvalid) are NOT silently swallowed
-                if ( result.error() == Error::SignatureInvalid || result.error() == Error::IdentityError )
+                if ( result.error() == Error::SIGNATURE_INVALID || result.error() == Error::IDENTITY_ERROR )
                 {
                     BridgeLogger()->error( "Network dispatch auth failed — NOT falling back to local mode" );
                     return result;
@@ -320,7 +320,7 @@ namespace sgns::neoswarm::core
         if ( !pm_result )
         {
             BridgeLogger()->error( "ProcessingManager::Create failed (error={})", pm_result.error().message() );
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
 
         auto pm = pm_result.value();
@@ -331,17 +331,17 @@ namespace sgns::neoswarm::core
         const auto& passes = processing.get_passes();
         if ( passes.empty() )
         {
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
         if ( !passes[0].get_model().has_value() )
         {
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
         const auto model_config = passes[0].get_model().value();
         const auto input_nodes = model_config.get_input_nodes();
         if ( input_nodes.empty() )
         {
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
         sgns::ModelNode model_node = input_nodes[0];
 
@@ -351,7 +351,7 @@ namespace sgns::neoswarm::core
         if ( !process_result )
         {
             BridgeLogger()->error( "ProcessingManager::Process failed (error={})", process_result.error().message() );
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
 
         BridgeLogger()->debug( "Process() succeeded: {} bytes, {} chunk hashes", process_result.value().size(),
@@ -382,7 +382,7 @@ namespace sgns::neoswarm::core
         if ( !client_ )
         {
             BridgeLogger()->error( "SubmitNetwork: SuperGeniusClient not configured" );
-            return outcome::failure( Error::NetworkError );
+            return outcome::failure( Error::NETWORK_ERROR );
         }
 
         BridgeLogger()->debug( "Submitting job via SuperGeniusClient ({} bytes)", jsondata.size() );

--- a/src/core/sgprocessing/TensorInterpreter.cpp
+++ b/src/core/sgprocessing/TensorInterpreter.cpp
@@ -56,7 +56,7 @@ namespace sgns::neoswarm::core
 
         if ( bytes.empty() )
         {
-            return outcome::failure( Error::InvalidArgument );
+            return outcome::failure( Error::INVALID_ARGUMENT );
         }
 
         switch ( format )
@@ -85,7 +85,7 @@ namespace sgns::neoswarm::core
         constexpr size_t kElemSize = sizeof( float );
         if ( bytes.size() % kElemSize != 0 )
         {
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
 
         const size_t count = bytes.size() / kElemSize;
@@ -115,7 +115,7 @@ namespace sgns::neoswarm::core
         constexpr size_t kElemSize = 2U;
         if ( bytes.size() % kElemSize != 0 )
         {
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
 
         const size_t count = bytes.size() / kElemSize;
@@ -178,7 +178,7 @@ namespace sgns::neoswarm::core
         constexpr size_t kElemSize = sizeof( int32_t );
         if ( bytes.size() % kElemSize != 0 )
         {
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
 
         const size_t count = bytes.size() / kElemSize;
@@ -216,7 +216,7 @@ namespace sgns::neoswarm::core
     {
         if ( !tokenizer_ )
         {
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
 
         const auto max_it = std::max_element( logits.begin(), logits.end() );

--- a/src/core/tokenizer/SentencePieceTokenizer.cpp
+++ b/src/core/tokenizer/SentencePieceTokenizer.cpp
@@ -52,7 +52,7 @@ namespace sgns::neoswarm::core
         auto status = impl_->processor_.Load( model_path );
         if ( !status.ok() )
         {
-            return outcome::failure( Error::TokenizerFailed );
+            return outcome::failure( Error::TOKENIZER_FAILED );
         }
         impl_->loaded_ = true;
         TokenizerLogger()->info( "Tokenizer loaded: {} (vocab={})", model_path, VocabSize() );
@@ -73,13 +73,13 @@ namespace sgns::neoswarm::core
 #ifdef GENIUS_HAS_SENTENCEPIECE
         if ( !impl_->loaded_ )
         {
-            return outcome::failure( Error::TokenizerFailed );
+            return outcome::failure( Error::TOKENIZER_FAILED );
         }
         std::vector<int> ids;
         auto status = impl_->processor_.Encode( text, &ids );
         if ( !status.ok() )
         {
-            return outcome::failure( Error::TokenizerFailed );
+            return outcome::failure( Error::TOKENIZER_FAILED );
         }
         return outcome::success( std::move( ids ) );
 #else
@@ -104,13 +104,13 @@ namespace sgns::neoswarm::core
 #ifdef GENIUS_HAS_SENTENCEPIECE
         if ( !impl_->loaded_ )
         {
-            return outcome::failure( Error::TokenizerFailed );
+            return outcome::failure( Error::TOKENIZER_FAILED );
         }
         std::string text;
         auto status = impl_->processor_.Decode( ids, &text );
         if ( !status.ok() )
         {
-            return outcome::failure( Error::TokenizerFailed );
+            return outcome::failure( Error::TOKENIZER_FAILED );
         }
         return outcome::success( std::move( text ) );
 #else

--- a/src/knowledge/KnowledgeRetrieval.cpp
+++ b/src/knowledge/KnowledgeRetrieval.cpp
@@ -76,7 +76,7 @@ namespace sgns::neoswarm::knowledge
         std::ifstream f( cfg_.facts_path_ );
         if ( !f )
         {
-            return outcome::failure( Error::KnowledgeUnavailable );
+            return outcome::failure( Error::KNOWLEDGE_UNAVAILABLE );
         }
 
         std::string line;
@@ -160,7 +160,7 @@ namespace sgns::neoswarm::knowledge
     {
         if ( !loaded_ || impl_->facts_.empty() )
         {
-            return outcome::failure( Error::KnowledgeUnavailable );
+            return outcome::failure( Error::KNOWLEDGE_UNAVAILABLE );
         }
 
         auto query_emb = Embed( query );

--- a/src/network/P2PNode.cpp
+++ b/src/network/P2PNode.cpp
@@ -154,7 +154,7 @@ namespace sgns::neoswarm::network
         catch ( const std::exception& e )
         {
             NetworkLogger()->error( "P2PNode start failed: {}", e.what() );
-            return outcome::failure( Error::NetworkError );
+            return outcome::failure( Error::NETWORK_ERROR );
         }
 
         return outcome::success();
@@ -216,7 +216,7 @@ namespace sgns::neoswarm::network
     {
         if ( !running_ )
         {
-            return outcome::failure( Error::NetworkError );
+            return outcome::failure( Error::NETWORK_ERROR );
         }
 
         nlohmann::json j;
@@ -254,7 +254,7 @@ namespace sgns::neoswarm::network
     {
         if ( !running_ )
         {
-            return outcome::failure( Error::NetworkError );
+            return outcome::failure( Error::NETWORK_ERROR );
         }
         NetworkLogger()->debug( "Broadcasting CRDT update ({} bytes)", crdt_data.size() );
 #ifdef GENIUS_HAS_LIBP2P

--- a/src/network/ResultAggregation.cpp
+++ b/src/network/ResultAggregation.cpp
@@ -57,7 +57,7 @@ namespace sgns::neoswarm::network
 
         if ( timed_out && results_.empty() )
         {
-            return outcome::failure( Error::BroadcastTimeout );
+            return outcome::failure( Error::BROADCAST_TIMEOUT );
         }
 
         AggregationLogger()->info( "Collected {} responses (timeout={})", results_.size(), timed_out ? "yes" : "no" );

--- a/src/network/sg_client/SGChannelManager.cpp
+++ b/src/network/sg_client/SGChannelManager.cpp
@@ -70,14 +70,14 @@ namespace sgns::neoswarm::network
         if ( !channel_ )
         {
             ChannelLogger()->error( "Failed to create channel to {}", cfg_.endpoint_ );
-            return outcome::failure( Error::NetworkError );
+            return outcome::failure( Error::NETWORK_ERROR );
         }
 
         ChannelLogger()->info( "Channel created to {}", cfg_.endpoint_ );
         return outcome::success();
 #else
         ChannelLogger()->warn( "SGChannelManager: gRPC not compiled in — stub mode" );
-        return outcome::failure( Error::NotImplemented );
+        return outcome::failure( Error::NOT_IMPLEMENTED );
 #endif
     }
 
@@ -131,7 +131,7 @@ namespace sgns::neoswarm::network
         }
 
         ChannelLogger()->error( "Reconnect failed after {} attempts", kMaxReconnectAttempts );
-        return outcome::failure( Error::NetworkError );
+        return outcome::failure( Error::NETWORK_ERROR );
     }
 
     std::shared_ptr<grpc::Channel> SGChannelManager::GetChannel() const

--- a/src/network/sg_client/SGMessageAuthenticator.cpp
+++ b/src/network/sg_client/SGMessageAuthenticator.cpp
@@ -43,7 +43,7 @@ namespace sgns::neoswarm::network
         if ( !impl_->identity_.IsLoaded() )
         {
             AuthLogger()->error( "Cannot sign — NodeIdentity not loaded" );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         std::string signedPayload = impl_->signer_->AttachSignature( payload );

--- a/src/network/sg_client/SGResultCollector.cpp
+++ b/src/network/sg_client/SGResultCollector.cpp
@@ -68,13 +68,13 @@ namespace sgns::neoswarm::network
         if ( !gotResult )
         {
             CollectLogger()->warn( "Result collection timed out for task {}", taskId );
-            return outcome::failure( Error::BroadcastTimeout );
+            return outcome::failure( Error::BROADCAST_TIMEOUT );
         }
 
         if ( impl_->resultData_.empty() )
         {
             CollectLogger()->warn( "Empty result received for task {}", taskId );
-            return outcome::failure( Error::InferenceFailed );
+            return outcome::failure( Error::INFERENCE_FAILED );
         }
 
         CollectLogger()->info( "Result collected for task {} ({} bytes)", taskId, impl_->resultData_.size() );

--- a/src/network/sg_client/SuperGeniusClient.cpp
+++ b/src/network/sg_client/SuperGeniusClient.cpp
@@ -70,7 +70,7 @@ namespace sgns::neoswarm::network
         if ( !impl_->channelMgr_ )
         {
             ClientLogger()->error( "Connect called before Initialize" );
-            return outcome::failure( Error::InternalError );
+            return outcome::failure( Error::INTERNAL_ERROR );
         }
 
         auto result = impl_->channelMgr_->CreateChannel();
@@ -117,7 +117,7 @@ namespace sgns::neoswarm::network
             if ( !reconnectResult.has_value() )
             {
                 ClientLogger()->error( "Reconnect failed — cannot submit job" );
-                return outcome::failure( Error::NetworkError );
+                return outcome::failure( Error::NETWORK_ERROR );
             }
             impl_->connected_ = true;
         }
@@ -125,7 +125,7 @@ namespace sgns::neoswarm::network
         if ( !impl_->jobSubmitter_ || !impl_->resultCollector_ )
         {
             ClientLogger()->error( "SubmitJob: sub-components not initialized" );
-            return outcome::failure( Error::InternalError );
+            return outcome::failure( Error::INTERNAL_ERROR );
         }
 
         // Step 1: Publish the signed job to the grid channel

--- a/src/reputation/ReputationStorage.cpp
+++ b/src/reputation/ReputationStorage.cpp
@@ -103,7 +103,7 @@ namespace sgns::neoswarm::reputation
         rocksdb::Status status = rocksdb::DB::Open( impl_->options_, db_path_, &impl_->db_ );
         if ( !status.ok() )
         {
-            return outcome::failure( Error::StorageError );
+            return outcome::failure( Error::STORAGE_ERROR );
         }
         StorageLogger()->info( "ReputationStorage opened: {}", db_path_ );
 #else
@@ -135,14 +135,14 @@ namespace sgns::neoswarm::reputation
     {
         if ( !open_ )
         {
-            return outcome::failure( Error::StorageError );
+            return outcome::failure( Error::STORAGE_ERROR );
         }
         std::string val = Serialize( rep );
 #ifdef GENIUS_HAS_ROCKSDB
         auto status = impl_->db_->Put( rocksdb::WriteOptions(), rep.identity_key_, val );
         if ( !status.ok() )
         {
-            return outcome::failure( Error::StorageError );
+            return outcome::failure( Error::STORAGE_ERROR );
         }
 #else
         impl_->store_[rep.identity_key_] = val;
@@ -157,25 +157,25 @@ namespace sgns::neoswarm::reputation
     {
         if ( !open_ )
         {
-            return outcome::failure( Error::StorageError );
+            return outcome::failure( Error::STORAGE_ERROR );
         }
 #ifdef GENIUS_HAS_ROCKSDB
         std::string val;
         rocksdb::Status status = impl_->db_->Get( rocksdb::ReadOptions(), identity_key, &val );
         if ( status.IsNotFound() )
         {
-            return outcome::failure( Error::ReputationNotFound );
+            return outcome::failure( Error::REPUTATION_NOT_FOUND );
         }
         if ( !status.ok() )
         {
-            return outcome::failure( Error::StorageError );
+            return outcome::failure( Error::STORAGE_ERROR );
         }
         return outcome::success( Deserialize( val ) );
 #else
         auto it = impl_->store_.find( identity_key );
         if ( it == impl_->store_.end() )
         {
-            return outcome::failure( Error::ReputationNotFound );
+            return outcome::failure( Error::REPUTATION_NOT_FOUND );
         }
         return outcome::success( Deserialize( it->second ) );
 #endif
@@ -188,13 +188,13 @@ namespace sgns::neoswarm::reputation
     {
         if ( !open_ )
         {
-            return outcome::failure( Error::StorageError );
+            return outcome::failure( Error::STORAGE_ERROR );
         }
 #ifdef GENIUS_HAS_ROCKSDB
         auto status = impl_->db_->Delete( rocksdb::WriteOptions(), identity_key );
         if ( !status.ok() )
         {
-            return outcome::failure( Error::StorageError );
+            return outcome::failure( Error::STORAGE_ERROR );
         }
 #else
         impl_->store_.erase( identity_key );
@@ -209,7 +209,7 @@ namespace sgns::neoswarm::reputation
     {
         if ( !open_ )
         {
-            return outcome::failure( Error::StorageError );
+            return outcome::failure( Error::STORAGE_ERROR );
         }
         std::vector<NodeReputation> result;
 #ifdef GENIUS_HAS_ROCKSDB

--- a/src/security/NodeIdentity.cpp
+++ b/src/security/NodeIdentity.cpp
@@ -111,7 +111,7 @@ namespace sgns::neoswarm::security
                 return outcome::success();
             }
         }
-        return outcome::failure( Error::IdentityError );
+        return outcome::failure( Error::IDENTITY_ERROR );
 #else
         std::random_device rd;
         std::mt19937_64 rng( rd() );
@@ -162,14 +162,14 @@ namespace sgns::neoswarm::security
         std::ifstream f( path );
         if ( !f )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
         std::string hex_priv;
         f >> hex_priv;
         auto bytes = FromHex( hex_priv );
         if ( bytes.size() != kPrivKeySize )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
         std::copy( bytes.begin(), bytes.end(), impl_->priv_key_.begin() );
 #ifdef GENIUS_HAS_SECP256K1
@@ -189,12 +189,12 @@ namespace sgns::neoswarm::security
     {
         if ( !loaded_ )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
         std::ofstream f( path );
         if ( !f )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
         f << ToHex( impl_->priv_key_.data(), kPrivKeySize ) << '\n';
         return outcome::success();
@@ -207,7 +207,7 @@ namespace sgns::neoswarm::security
     {
         if ( !loaded_ )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
 #ifdef GENIUS_HAS_OPENSSL
@@ -215,7 +215,7 @@ namespace sgns::neoswarm::security
         uint8_t salt[32];
         if ( !RAND_bytes( salt, sizeof( salt ) ) )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         // 2. Derive 256-bit encryption key via PBKDF2
@@ -224,39 +224,39 @@ namespace sgns::neoswarm::security
                                  600000, // iterations
                                  EVP_sha256(), sizeof( key ), key ) )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         // 3. Generate 12-byte random IV for GCM
         uint8_t iv[12];
         if ( !RAND_bytes( iv, sizeof( iv ) ) )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         // 4. Encrypt with AES-256-GCM
         EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
         if ( !ctx )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         if ( !EVP_EncryptInit_ex( ctx, EVP_aes_256_gcm(), nullptr, nullptr, nullptr ) )
         {
             EVP_CIPHER_CTX_free( ctx );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         if ( !EVP_CIPHER_CTX_ctrl( ctx, EVP_CTRL_GCM_SET_IVLEN, sizeof( iv ), nullptr ) )
         {
             EVP_CIPHER_CTX_free( ctx );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         if ( !EVP_EncryptInit_ex( ctx, nullptr, nullptr, key, iv ) )
         {
             EVP_CIPHER_CTX_free( ctx );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         // Encrypt the private key
@@ -266,14 +266,14 @@ namespace sgns::neoswarm::security
                                  static_cast<int>( kPrivKeySize ) ) )
         {
             EVP_CIPHER_CTX_free( ctx );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
         int totalLen = outLen;
 
         if ( !EVP_EncryptFinal_ex( ctx, ciphertext.data() + totalLen, &outLen ) )
         {
             EVP_CIPHER_CTX_free( ctx );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
         totalLen += outLen;
         ciphertext.resize( totalLen );
@@ -283,7 +283,7 @@ namespace sgns::neoswarm::security
         if ( !EVP_CIPHER_CTX_ctrl( ctx, EVP_CTRL_GCM_GET_TAG, sizeof( tag ), tag ) )
         {
             EVP_CIPHER_CTX_free( ctx );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         EVP_CIPHER_CTX_free( ctx );
@@ -292,7 +292,7 @@ namespace sgns::neoswarm::security
         std::ofstream f( path, std::ios::binary );
         if ( !f )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         uint32_t saltLen = static_cast<uint32_t>( sizeof( salt ) );
@@ -305,14 +305,14 @@ namespace sgns::neoswarm::security
 
         if ( !f.good() )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         IdentityLogger()->info( "NodeIdentity saved encrypted to {}", path );
         return outcome::success();
 #else
         IdentityLogger()->error( "SaveEncrypted: OpenSSL not available" );
-        return outcome::failure( Error::IdentityError );
+        return outcome::failure( Error::IDENTITY_ERROR );
 #endif
     }
 
@@ -325,7 +325,7 @@ namespace sgns::neoswarm::security
         std::ifstream f( path, std::ios::binary );
         if ( !f )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         // 1. Read salt length
@@ -333,7 +333,7 @@ namespace sgns::neoswarm::security
         f.read( reinterpret_cast<char*>( &saltLen ), sizeof( saltLen ) );
         if ( !f.good() || saltLen == 0 || saltLen > 1024 )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         // 2. Read salt
@@ -341,7 +341,7 @@ namespace sgns::neoswarm::security
         f.read( reinterpret_cast<char*>( salt.data() ), static_cast<std::streamsize>( saltLen ) );
         if ( !f.good() )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         // 3. Read IV
@@ -349,7 +349,7 @@ namespace sgns::neoswarm::security
         f.read( reinterpret_cast<char*>( iv ), sizeof( iv ) );
         if ( !f.good() )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         // 4. Read ciphertext (remaining bytes minus 16-byte tag)
@@ -359,13 +359,13 @@ namespace sgns::neoswarm::security
         auto ciphertextSize = static_cast<size_t>( fileSize - f.tellg() ) - 16; // minus tag
         if ( ciphertextSize > 1024 || ciphertextSize < kPrivKeySize )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
         std::vector<uint8_t> ciphertext( ciphertextSize );
         f.read( reinterpret_cast<char*>( ciphertext.data() ), static_cast<std::streamsize>( ciphertextSize ) );
         if ( !f.good() )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         // 5. Read GCM tag
@@ -373,7 +373,7 @@ namespace sgns::neoswarm::security
         f.read( reinterpret_cast<char*>( tag ), sizeof( tag ) );
         if ( !f.good() )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         // 6. Derive key via PBKDF2
@@ -381,32 +381,32 @@ namespace sgns::neoswarm::security
         if ( !PKCS5_PBKDF2_HMAC( passphrase.c_str(), static_cast<int>( passphrase.size() ), salt.data(),
                                  static_cast<int>( salt.size() ), 600000, EVP_sha256(), sizeof( key ), key ) )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         // 7. Decrypt with AES-256-GCM
         EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
         if ( !ctx )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         if ( !EVP_DecryptInit_ex( ctx, EVP_aes_256_gcm(), nullptr, nullptr, nullptr ) )
         {
             EVP_CIPHER_CTX_free( ctx );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         if ( !EVP_CIPHER_CTX_ctrl( ctx, EVP_CTRL_GCM_SET_IVLEN, sizeof( iv ), nullptr ) )
         {
             EVP_CIPHER_CTX_free( ctx );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         if ( !EVP_DecryptInit_ex( ctx, nullptr, nullptr, key, iv ) )
         {
             EVP_CIPHER_CTX_free( ctx );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         std::vector<uint8_t> plaintext( ciphertextSize );
@@ -415,7 +415,7 @@ namespace sgns::neoswarm::security
                                  static_cast<int>( ciphertextSize ) ) )
         {
             EVP_CIPHER_CTX_free( ctx );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
         int totalLen = outLen;
 
@@ -423,7 +423,7 @@ namespace sgns::neoswarm::security
         if ( !EVP_CIPHER_CTX_ctrl( ctx, EVP_CTRL_GCM_SET_TAG, sizeof( tag ), const_cast<uint8_t*>( tag ) ) )
         {
             EVP_CIPHER_CTX_free( ctx );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 
         // 9. Finalize — this validates the GCM tag
@@ -434,7 +434,7 @@ namespace sgns::neoswarm::security
         {
             // Tag verification failed — wrong passphrase or tampered file
             IdentityLogger()->error( "LoadEncrypted: decryption failed — wrong passphrase or corrupt file" );
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
         totalLen += outLen;
         plaintext.resize( totalLen );
@@ -442,7 +442,7 @@ namespace sgns::neoswarm::security
         // 10. Copy decrypted key
         if ( plaintext.size() != kPrivKeySize )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
         std::memcpy( impl_->priv_key_.data(), plaintext.data(), kPrivKeySize );
 
@@ -459,7 +459,7 @@ namespace sgns::neoswarm::security
         return outcome::success();
 #else
         IdentityLogger()->error( "LoadEncrypted: OpenSSL not available" );
-        return outcome::failure( Error::IdentityError );
+        return outcome::failure( Error::IDENTITY_ERROR );
 #endif
     }
 
@@ -470,7 +470,7 @@ namespace sgns::neoswarm::security
     {
         if ( !loaded_ )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
 #ifdef GENIUS_HAS_SECP256K1
         uint8_t hash[32];
@@ -487,7 +487,7 @@ namespace sgns::neoswarm::security
         if ( !secp256k1_ecdsa_sign( impl_->ctx_, &sig, hash, impl_->priv_key_.data(), secp256k1_nonce_function_rfc6979,
                                     nullptr ) )
         {
-            return outcome::failure( Error::IdentityError );
+            return outcome::failure( Error::IDENTITY_ERROR );
         }
         std::vector<uint8_t> der( 72 );
         size_t der_len = 72;

--- a/src/specialists/GrammarSpecialist.cpp
+++ b/src/specialists/GrammarSpecialist.cpp
@@ -32,7 +32,7 @@ namespace sgns::neoswarm::specialists
     {
         if ( !engine_ )
         {
-            return outcome::failure( Error::ModelLoadFailed );
+            return outcome::failure( Error::MODEL_LOAD_FAILED );
         }
         BOOST_OUTCOME_TRY( engine_->LoadModel( model_path ) );
         loaded_ = true;

--- a/src/specialists/MathSpecialist.cpp
+++ b/src/specialists/MathSpecialist.cpp
@@ -32,7 +32,7 @@ namespace sgns::neoswarm::specialists
     {
         if ( !engine_ )
         {
-            return outcome::failure( Error::ModelLoadFailed );
+            return outcome::failure( Error::MODEL_LOAD_FAILED );
         }
         BOOST_OUTCOME_TRY( engine_->LoadModel( model_path ) );
         loaded_ = true;

--- a/test/security/test_node_identity.cpp
+++ b/test/security/test_node_identity.cpp
@@ -114,7 +114,7 @@ TEST( NodeIdentity, LoadEncryptedWrongPassphrase )
     auto result = ident2.LoadEncrypted( kTestKeyPath, kWrongPass );
 
     EXPECT_FALSE( result.has_value() );
-    EXPECT_EQ( result.error(), Error::IdentityError );
+    EXPECT_EQ( result.error(), Error::IDENTITY_ERROR );
 
     RemoveTestFile();
 }
@@ -142,7 +142,7 @@ TEST( NodeIdentity, LoadEncryptedTamperedFile )
     auto result = ident2.LoadEncrypted( kTestKeyPath, kTestPass );
 
     EXPECT_FALSE( result.has_value() );
-    EXPECT_EQ( result.error(), Error::IdentityError );
+    EXPECT_EQ( result.error(), Error::IDENTITY_ERROR );
 
     RemoveTestFile();
 }
@@ -157,7 +157,7 @@ TEST( NodeIdentity, SaveEncryptedWithoutKey )
     auto result = ident.SaveEncrypted( kTestKeyPath, kTestPass );
 
     EXPECT_FALSE( result.has_value() );
-    EXPECT_EQ( result.error(), Error::IdentityError );
+    EXPECT_EQ( result.error(), Error::IDENTITY_ERROR );
 
     RemoveTestFile();
 }
@@ -170,7 +170,7 @@ TEST( NodeIdentity, LoadEncryptedNonexistentFile )
     auto result = ident.LoadEncrypted( kTestKeyPath, kTestPass );
 
     EXPECT_FALSE( result.has_value() );
-    EXPECT_EQ( result.error(), Error::IdentityError );
+    EXPECT_EQ( result.error(), Error::IDENTITY_ERROR );
 }
 
 TEST( NodeIdentity, SaveEncryptedOverwrite )


### PR DESCRIPTION
## Summary
Convert all Error enum constants from PascalCase to UPPER_CASE per Handbook Standard 14.

## Changes
- Error.hpp: rename all 17 enum values
- Update all 19 source files referencing Error:: values
- 245 lines changed

## Examples
`Error::ModelLoadFailed` → `Error::MODEL_LOAD_FAILED`
`Error::NetworkError` → `Error::NETWORK_ERROR`