### PR TITLE
refactor: remove platform ifdefs — use std::filesystem

### DIFF
--- a/src/core/sgprocessing/SGProcessingBridge.cpp
+++ b/src/core/sgprocessing/SGProcessingBridge.cpp
@@ -13,13 +13,7 @@
 
 #include <boost/asio/io_context.hpp>
 #include <nlohmann/json.hpp>
-
-#ifdef __unix__
-#include <unistd.h> // getcwd
-#elif defined( _WIN32 )
-#include <direct.h>
-#define getcwd _getcwd
-#endif
+#include <filesystem>
 
 #ifdef GENIUS_HAS_SGPROCESSING
 #include <Generators.hpp>
@@ -133,11 +127,8 @@ namespace sgns::neoswarm::core
                     return uri;
                 }
                 // Prepend current working directory
-                char cwd[4096] = {};
-                if ( getcwd( cwd, sizeof( cwd ) ) != nullptr )
-                {
-                    return std::string( "file://" ) + cwd + "/" + rel;
-                }
+                std::string cwd = std::filesystem::current_path().string();
+                return std::string( "file://" ) + cwd + "/" + rel;
             }
             return uri;
         }


### PR DESCRIPTION
## Summary
Remove platform-specific `#ifdef __unix__` / `_WIN32` from source files.

## Changes
- SGProcessingBridge.cpp: replace `getcwd()` + platform ifdefs with `std::filesystem::current_path()`
- C++17 cross-platform, no OS checks needed

1 file, 9 lines