### PR TITLE
refactor: fix magic numbers, platform ifdefs, parameter naming

### DIFF
--- a/src/api/GeniusAPIServer.cpp
+++ b/src/api/GeniusAPIServer.cpp
@@ -218,7 +218,7 @@ namespace sgns::neoswarm::api
     // -----------------------------------------------------------------------
     void GeniusAPIServer::UpdateReputation( const InferenceResponse& resp,
                                             double median_latency_ms,
-                                            const std::string& consensus_output )
+                                            const std::string& consensusOutput )
     {
         if ( !rep_storage_ || !rep_storage_->IsOpen() )
         {
@@ -236,7 +236,7 @@ namespace sgns::neoswarm::api
             rep.identity_key_ = resp.node_id_;
         }
 
-        auto updated = scoring_->Update( rep, resp, median_latency_ms, std::nullopt, consensus_output );
+        auto updated = scoring_->Update( rep, resp, median_latency_ms, std::nullopt, consensusOutput );
         (void)rep_storage_->Put( updated );
         rep_crdt_->Merge( updated );
 

--- a/src/api/GeniusAPIServer.hpp
+++ b/src/api/GeniusAPIServer.hpp
@@ -126,7 +126,7 @@ namespace sgns::neoswarm::api
 
         void UpdateReputation( const InferenceResponse& resp,
                                double median_latency_ms,
-                               const std::string& consensus_output );
+                               const std::string& consensusOutput );
     };
 
 } // namespace sgns::neoswarm::api

--- a/src/core/engine/MNNInferenceEngine.cpp
+++ b/src/core/engine/MNNInferenceEngine.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <boost/asio/io_context.hpp>
 #include <chrono>
+namespace { constexpr size_t kDefaultVocabSize = 32000U; }
 #include <cmath>
 #include <numeric>
 #include <random>
@@ -517,7 +518,7 @@ namespace sgns::neoswarm::core
         if ( !session_ )
         {
             // Stub: return random logits using dynamic vocab size
-            const size_t kVocabSize = tokenizer_ ? tokenizer_->VocabSize() : 32000;
+            const size_t kVocabSize = tokenizer_ ? tokenizer_->VocabSize() : kDefaultVocabSize;
             std::vector<float> logits( kVocabSize, 0.0f );
             static std::mt19937 rng( 42 );
             std::normal_distribution<float> dist( 0.0f, 1.0f );
@@ -557,7 +558,7 @@ namespace sgns::neoswarm::core
         return outcome::success( std::move( logits ) );
 #else
         (void) input_ids;
-        const size_t kVocabSize = tokenizer_ ? tokenizer_->VocabSize() : 32000;
+        const size_t kVocabSize = tokenizer_ ? tokenizer_->VocabSize() : kDefaultVocabSize;
         std::vector<float> logits( kVocabSize, 0.0f );
         static std::mt19937 rng( 42 );
         std::normal_distribution<float> dist( 0.0f, 1.0f );

--- a/src/core/engine/MNNInferenceEngine.hpp
+++ b/src/core/engine/MNNInferenceEngine.hpp
@@ -87,11 +87,17 @@ namespace sgns::neoswarm::core
             int num_threads_ = 4;
 
             /// Generation parameters
-            int max_new_tokens_ = 512;
-            float temperature_ = 0.7f;
-            float top_p_ = 0.9f;
-            int top_k_ = 40;
-            float repetition_penalty_ = 1.1f;
+            static constexpr int   kDefaultMaxTokens         = 512;
+            static constexpr float kDefaultTemperature       = 0.7f;
+            static constexpr float kDefaultTopP              = 0.9f;
+            static constexpr int   kDefaultTopK              = 40;
+            static constexpr float kDefaultRepetitionPenalty = 1.1f;
+
+            int   max_new_tokens_     = kDefaultMaxTokens;
+            float temperature_        = kDefaultTemperature;
+            float top_p_              = kDefaultTopP;
+            int   top_k_              = kDefaultTopK;
+            float repetition_penalty_ = kDefaultRepetitionPenalty;
 
             /// SGProcessing network mode (Phase 2: dispatch via gRPC to SuperGenius)
             bool sg_network_mode_ = false;

--- a/src/core/sgprocessing/SGProcessingBridge.cpp
+++ b/src/core/sgprocessing/SGProcessingBridge.cpp
@@ -12,14 +12,8 @@
 #include "network/sg_client/SuperGeniusClient.hpp"
 
 #include <boost/asio/io_context.hpp>
+#include <filesystem>
 #include <nlohmann/json.hpp>
-
-#ifdef __unix__
-#include <unistd.h> // getcwd
-#elif defined( _WIN32 )
-#include <direct.h>
-#define getcwd _getcwd
-#endif
 
 #ifdef GENIUS_HAS_SGPROCESSING
 #include <Generators.hpp>
@@ -133,8 +127,8 @@ namespace sgns::neoswarm::core
                     return uri;
                 }
                 // Prepend current working directory
-                char cwd[4096] = {};
-                if ( getcwd( cwd, sizeof( cwd ) ) != nullptr )
+                std::string cwd = std::filesystem::current_path().string();
+                if ( !cwd.empty() )
                 {
                     return std::string( "file://" ) + cwd + "/" + rel;
                 }

--- a/src/security/NodeIdentity.cpp
+++ b/src/security/NodeIdentity.cpp
@@ -14,6 +14,7 @@
 #include <sstream>
 
 #ifdef GENIUS_HAS_SECP256K1
+namespace { constexpr int kPbkdf2Iterations = 600000; }
 #include <secp256k1.h>
 #endif
 
@@ -221,7 +222,7 @@ namespace sgns::neoswarm::security
         // 2. Derive 256-bit encryption key via PBKDF2
         uint8_t key[32]; // AES-256
         if ( !PKCS5_PBKDF2_HMAC( passphrase.c_str(), static_cast<int>( passphrase.size() ), salt, sizeof( salt ),
-                                 600000, // iterations
+                                 kPbkdf2Iterations, // iterations
                                  EVP_sha256(), sizeof( key ), key ) )
         {
             return outcome::failure( Error::IdentityError );
@@ -379,7 +380,7 @@ namespace sgns::neoswarm::security
         // 6. Derive key via PBKDF2
         uint8_t key[32];
         if ( !PKCS5_PBKDF2_HMAC( passphrase.c_str(), static_cast<int>( passphrase.size() ), salt.data(),
-                                 static_cast<int>( salt.size() ), 600000, EVP_sha256(), sizeof( key ), key ) )
+                                 static_cast<int>( salt.size() ), kPbkdf2Iterations, EVP_sha256(), sizeof( key ), key ) )
         {
             return outcome::failure( Error::IdentityError );
         }


### PR DESCRIPTION
## Summary
Combined small fixes — 3 categories in one PR.

## Changes
- **Magic numbers**: kDefaultVocabSize, kDefaultMaxTokens, kDefaultTemperature, kDefaultTopP, kDefaultTopK, kDefaultRepetitionPenalty, kPbkdf2Iterations
- **Platform ifdefs**: replace getcwd + #ifdef with std::filesystem::current_path()
- **Parameter naming**: consensus_output → consensusOutput

5 files, 26 lines