### PR TITLE
refactor: fix const-correctness and parameter naming

### DIFF
--- a/src/core/sgprocessing/SGProcessingBridge.cpp
+++ b/src/core/sgprocessing/SGProcessingBridge.cpp
@@ -196,7 +196,7 @@ namespace sgns::neoswarm::core
 
         // Derive output URI from input URI (replace extension with _output.raw)
         std::string output_uri = abs_input_uri;
-        auto dot_pos = output_uri.rfind( '.' );
+        const auto dotPos = output_uri.rfind( '.' );
         if ( dot_pos != std::string::npos )
         {
             output_uri = output_uri.substr( 0, dot_pos ) + "_output.raw";
@@ -283,7 +283,7 @@ namespace sgns::neoswarm::core
 
         if ( cfg_.network_mode_ )
         {
-            auto result = SubmitNetwork( json_res.value() );
+            const auto result = SubmitNetwork( json_res.value() );
             if ( !result.has_value() )
             {
                 // Auto-fallback to local MNN on network failure

--- a/src/security/MessageSigning.cpp
+++ b/src/security/MessageSigning.cpp
@@ -69,17 +69,17 @@ namespace sgns::neoswarm::security
     // -----------------------------------------------------------------------
     bool MessageSigning::Verify( const std::string& payload,
                                  const std::vector<uint8_t>& signature,
-                                 const std::string& pub_key_hex )
+                                 const std::string& pubKeyHex )
     {
 #ifdef GENIUS_HAS_SECP256K1
         // Validate inputs
-        if ( payload.empty() || signature.empty() || pub_key_hex.empty() )
+        if ( payload.empty() || signature.empty() || pubKeyHex.empty() )
         {
             return false;
         }
 
         // Parse public key from hex
-        auto pubBytes = FromHex( pub_key_hex );
+        auto pubBytes = FromHex( pubKeyHex );
         if ( pubBytes.size() != NodeIdentity::kPubKeySize )
         {
             return false;
@@ -131,7 +131,7 @@ namespace sgns::neoswarm::security
 #else
         (void) payload;
         (void) signature;
-        (void) pub_key_hex;
+        (void) pubKeyHex;
         SigningLogger()->error( "MessageSigning::Verify — secp256k1 not available, REJECTING signature" );
         return false;
 #endif
@@ -200,7 +200,7 @@ namespace sgns::neoswarm::security
     // -----------------------------------------------------------------------
     // VerifyAndStrip
     // -----------------------------------------------------------------------
-    bool MessageSigning::VerifyAndStrip( std::string& payload, const std::string& pub_key_hex )
+    bool MessageSigning::VerifyAndStrip( std::string& payload, const std::string& pubKeyHex )
     {
         // Step 1: Extract sig field (last field appended by AttachSignature)
         auto sigPos = payload.rfind( ",\"sig\":\"" );
@@ -253,7 +253,7 @@ namespace sgns::neoswarm::security
         }
 
         // Step 5: Verify signature on the full payload (includes nonce+ts)
-        if ( !Verify( verifyPayload, sigBytes, pub_key_hex ) )
+        if ( !Verify( verifyPayload, sigBytes, pubKeyHex ) )
         {
             return false;
         }

--- a/src/security/MessageSigning.hpp
+++ b/src/security/MessageSigning.hpp
@@ -44,7 +44,7 @@ namespace sgns::neoswarm::security
          */
         static bool Verify( const std::string& payload,
                             const std::vector<uint8_t>& signature,
-                            const std::string& pub_key_hex );
+                            const std::string& pubKeyHex );
 
         /// Replay protection window in seconds.
         static constexpr int64_t kReplayWindowSec = 30;
@@ -74,7 +74,7 @@ namespace sgns::neoswarm::security
          * @param         pub_key_hex Hex-encoded public key of the expected signer.
          * @return                    True if the signature is valid.
          */
-        static bool VerifyAndStrip( std::string& payload, const std::string& pub_key_hex );
+        static bool VerifyAndStrip( std::string& payload, const std::string& pubKeyHex );
 
         private:
         const NodeIdentity& identity_;


### PR DESCRIPTION
## Summary
Small fixes — const-correctness and parameter naming.

## Changes
- SGProcessingBridge: add const where values don't change
- MessageSigning: pub_key_hex → pubKeyHex

3 files, 20 lines