### PR TITLE
refactor: fix magic numbers and remove platform ifdefs

### DIFF
--- a/src/core/engine/mnn_inference_engine.cpp
+++ b/src/core/engine/mnn_inference_engine.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <boost/asio/io_context.hpp>
 #include <chrono>
+namespace { constexpr size_t kDefaultVocabSize = 32000U; }
 #include <cmath>
 #include <numeric>
 #include <random>
@@ -517,7 +518,7 @@ namespace sgns::neoswarm::core
         if ( !session_ )
         {
             // Stub: return random logits using dynamic vocab size
-            const size_t kVocabSize = tokenizer_ ? tokenizer_->VocabSize() : 32000;
+            const size_t kVocabSize = tokenizer_ ? tokenizer_->VocabSize() : kDefaultVocabSize;
             std::vector<float> logits( kVocabSize, 0.0f );
             static std::mt19937 rng( 42 );
             std::normal_distribution<float> dist( 0.0f, 1.0f );
@@ -557,7 +558,7 @@ namespace sgns::neoswarm::core
         return outcome::success( std::move( logits ) );
 #else
         (void) input_ids;
-        const size_t kVocabSize = tokenizer_ ? tokenizer_->VocabSize() : 32000;
+        const size_t kVocabSize = tokenizer_ ? tokenizer_->VocabSize() : kDefaultVocabSize;
         std::vector<float> logits( kVocabSize, 0.0f );
         static std::mt19937 rng( 42 );
         std::normal_distribution<float> dist( 0.0f, 1.0f );

--- a/src/core/engine/mnn_inference_engine.hpp
+++ b/src/core/engine/mnn_inference_engine.hpp
@@ -87,11 +87,16 @@ namespace sgns::neoswarm::core
             int num_threads_ = 4;
 
             /// Generation parameters
-            int max_new_tokens_ = 512;
-            float temperature_ = 0.7f;
-            float top_p_ = 0.9f;
-            int top_k_ = 40;
-            float repetition_penalty_ = 1.1f;
+            static constexpr int   kDefaultMaxTokens         = 512;
+            int   max_new_tokens_     = kDefaultMaxTokens;
+            static constexpr float kDefaultTemperature       = 0.7f;
+            float temperature_        = kDefaultTemperature;
+            static constexpr float kDefaultTopP              = 0.9f;
+            float top_p_              = kDefaultTopP;
+            static constexpr int   kDefaultTopK              = 40;
+            int   top_k_              = kDefaultTopK;
+            static constexpr float kDefaultRepetitionPenalty = 1.1f;
+            float repetition_penalty_ = kDefaultRepetitionPenalty;
 
             /// SGProcessing network mode (Phase 2: dispatch via gRPC to SuperGenius)
             bool sg_network_mode_ = false;

--- a/src/core/sgprocessing/sg_processing_bridge.cpp
+++ b/src/core/sgprocessing/sg_processing_bridge.cpp
@@ -14,12 +14,7 @@
 #include <boost/asio/io_context.hpp>
 #include <nlohmann/json.hpp>
 
-#ifdef __unix__
-#include <unistd.h> // getcwd
-#elif defined( _WIN32 )
-#include <direct.h>
-#define getcwd _getcwd
-#endif
+#include <filesystem>
 
 #ifdef GENIUS_HAS_SGPROCESSING
 #include <Generators.hpp>
@@ -41,7 +36,6 @@ namespace sgns
         RGBA8 = 7
     };
 } // namespace sgns
-#endif
 
 namespace sgns::neoswarm::core
 {
@@ -133,8 +127,8 @@ namespace sgns::neoswarm::core
                     return uri;
                 }
                 // Prepend current working directory
-                char cwd[4096] = {};
-                if ( getcwd( cwd, sizeof( cwd ) ) != nullptr )
+                std::string cwd = std::filesystem::current_path().string();
+                if ( !cwd.empty() )
                 {
                     return std::string( "file://" ) + cwd + "/" + rel;
                 }
@@ -362,7 +356,6 @@ namespace sgns::neoswarm::core
         (void) ioc;
         BridgeLogger()->warn( "SGProcessingBridge: SGProcessingManager not compiled in — stub mode" );
         return outcome::success( std::vector<uint8_t>{} );
-#endif
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Replace magic numbers with named constants and remove platform-specific ifdefs.

## Changes
- **Magic numbers**: kDefaultMaxTokens, kDefaultTemperature, kDefaultTopP, kDefaultTopK, kDefaultRepetitionPenalty, kDefaultVocabSize
- **Platform ifdefs**: replace __unix__/_WIN32 + getcwd with std::filesystem::current_path()

3 files, 33 lines