### PR TITLE
refactor: remove #ifdef gates from security module — use real crypto

### DIFF
--- a/src/security/message_signing.cpp
+++ b/src/security/message_signing.cpp
@@ -10,15 +10,10 @@
 
 #include <chrono>
 #include <iomanip>
-#include <random>
 #include <sstream>
 
-#ifdef GENIUS_HAS_SECP256K1
 #include <secp256k1.h>
-#endif
-#ifdef GENIUS_HAS_OPENSSL
 #include <openssl/sha.h>
-#endif
 
 namespace sgns::neoswarm::security
 {
@@ -71,7 +66,6 @@ namespace sgns::neoswarm::security
                                  const std::vector<uint8_t>& signature,
                                  const std::string& m_pubKeyhex )
     {
-#ifdef GENIUS_HAS_SECP256K1
         // Validate inputs
         if ( payload.empty() || signature.empty() || m_pubKeyhex.empty() )
         {
@@ -114,27 +108,13 @@ namespace sgns::neoswarm::security
 
         // Hash payload with SHA-256
         uint8_t hash[32];
-#ifdef GENIUS_HAS_OPENSSL
         SHA256( reinterpret_cast<const uint8_t*>( payload.data() ), payload.size(), hash );
-#else
-        std::fill( hash, hash + 32, 0 );
-        for ( size_t i = 0; i < payload.size(); ++i )
-        {
-            hash[i % 32] ^= static_cast<uint8_t>( payload[i] );
-        }
-#endif
 
         // Verify
         int result = secp256k1_ecdsa_verify( ctx, &sig, hash, &pubkey );
         secp256k1_context_destroy( ctx );
         return result == 1;
-#else
-        (void) payload;
-        (void) signature;
-        (void) m_pubKeyhex;
-        SigningLogger()->error( "MessageSigning::Verify — secp256k1 not available, REJECTING signature" );
-        return false;
-#endif
+
     }
 
     // -----------------------------------------------------------------------
@@ -142,13 +122,12 @@ namespace sgns::neoswarm::security
     // -----------------------------------------------------------------------
     std::string MessageSigning::GenerateNonce()
     {
-        std::random_device rd;
-        std::mt19937_64 rng( rd() );
-        std::uniform_int_distribution<uint8_t> dist( 0, 255 );
         std::vector<uint8_t> nonceBytes( 32 );
-        for ( auto& b : nonceBytes )
+        if ( !RAND_bytes( nonceBytes.data(), static_cast<int>( nonceBytes.size() ) ) )
         {
-            b = dist( rng );
+            // Fallback: use time-based nonce if RAND_bytes fails
+            auto ts = CurrentTimestampMs();
+            std::memcpy( nonceBytes.data(), &ts, sizeof( ts ) );
         }
         return ToHex( nonceBytes );
     }

--- a/src/security/node_identity.cpp
+++ b/src/security/node_identity.cpp
@@ -10,18 +10,13 @@
 
 #include <fstream>
 #include <iomanip>
-#include <random>
 #include <sstream>
 
-#ifdef GENIUS_HAS_SECP256K1
 #include <secp256k1.h>
-#endif
 
-#ifdef GENIUS_HAS_OPENSSL
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/sha.h>
-#endif
 #include <cstring>
 
 namespace sgns::neoswarm::security
@@ -60,27 +55,21 @@ namespace sgns::neoswarm::security
     struct NodeIdentity::Impl
     {
         PrivKey m_privKey{};
-#ifdef GENIUS_HAS_SECP256K1
         secp256k1_context* ctx_ = nullptr;
-#endif
     };
 
     NodeIdentity::NodeIdentity()
         : m_impl( std::make_unique<Impl>() )
     {
-#ifdef GENIUS_HAS_SECP256K1
         m_impl->ctx_ = secp256k1_context_create( SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY );
-#endif
     }
 
     NodeIdentity::~NodeIdentity()
     {
-#ifdef GENIUS_HAS_SECP256K1
         if ( m_impl && m_impl->ctx_ )
         {
             secp256k1_context_destroy( m_impl->ctx_ );
         }
-#endif
     }
 
     // -----------------------------------------------------------------------
@@ -88,16 +77,12 @@ namespace sgns::neoswarm::security
     // -----------------------------------------------------------------------
     outcome::result<void> NodeIdentity::Generate()
     {
-#ifdef GENIUS_HAS_SECP256K1
-        std::random_device rd;
-        std::mt19937_64 rng( rd() );
-        std::uniform_int_distribution<uint8_t> dist( 0, 255 );
-
         for ( int attempt = 0; attempt < 100; ++attempt )
         {
-            for ( auto& b : m_impl->m_privKey )
+            if ( !RAND_bytes( m_impl->m_privKey.data(),
+                              static_cast<int>( m_impl->m_privKey.size() ) ) )
             {
-                b = dist( rng );
+                return outcome::failure( Error::IdentityError );
             }
             if ( secp256k1_ec_seckey_verify( m_impl->ctx_, m_impl->m_privKey.data() ) )
             {
@@ -112,23 +97,7 @@ namespace sgns::neoswarm::security
             }
         }
         return outcome::failure( Error::IdentityError );
-#else
-        std::random_device rd;
-        std::mt19937_64 rng( rd() );
-        std::uniform_int_distribution<uint8_t> dist( 0, 255 );
-        for ( auto& b : m_impl->m_privKey )
-        {
-            b = dist( rng );
-        }
-        for ( auto& b : m_pubKey )
-        {
-            b = dist( rng );
-        }
-        m_pubKey[0] = 0x02; // compressed prefix
-        m_loaded = true;
-        IdentityLogger()->warn( "secp256k1 not compiled in — using stub identity" );
-        return outcome::success();
-#endif
+
     }
 
     // -----------------------------------------------------------------------
@@ -140,18 +109,10 @@ namespace sgns::neoswarm::security
         {
             return "";
         }
-#ifdef GENIUS_HAS_OPENSSL
         uint8_t hash[SHA256_DIGEST_LENGTH];
         SHA256( m_pubKey.data(), m_pubKey.size(), hash );
         return ToHex( hash, SHA256_DIGEST_LENGTH );
-#else
-        uint8_t hash[32] = {};
-        for ( size_t i = 0; i < m_pubKey.size(); ++i )
-        {
-            hash[i % 32] ^= m_pubKey[i];
-        }
-        return ToHex( hash, 32 );
-#endif
+
     }
 
     // -----------------------------------------------------------------------
@@ -172,12 +133,10 @@ namespace sgns::neoswarm::security
             return outcome::failure( Error::IdentityError );
         }
         std::copy( bytes.begin(), bytes.end(), m_impl->m_privKey.begin() );
-#ifdef GENIUS_HAS_SECP256K1
         secp256k1_pubkey pubkey;
         (void)secp256k1_ec_pubkey_create( m_impl->ctx_, &pubkey, m_impl->m_privKey.data() );
         size_t pub_len = kPubKeySize;
         secp256k1_ec_pubkey_serialize( m_impl->ctx_, m_pubKey.data(), &pub_len, &pubkey, SECP256K1_EC_COMPRESSED );
-#endif
         m_loaded = true;
         return outcome::success();
     }
@@ -210,7 +169,6 @@ namespace sgns::neoswarm::security
             return outcome::failure( Error::IdentityError );
         }
 
-#ifdef GENIUS_HAS_OPENSSL
         // 1. Generate 32-byte random salt
         uint8_t salt[32];
         if ( !RAND_bytes( salt, sizeof( salt ) ) )
@@ -310,10 +268,7 @@ namespace sgns::neoswarm::security
 
         IdentityLogger()->info( "NodeIdentity saved encrypted to {}", path );
         return outcome::success();
-#else
-        IdentityLogger()->error( "SaveEncrypted: OpenSSL not available" );
-        return outcome::failure( Error::IdentityError );
-#endif
+
     }
 
     // -----------------------------------------------------------------------
@@ -321,7 +276,6 @@ namespace sgns::neoswarm::security
     // -----------------------------------------------------------------------
     outcome::result<void> NodeIdentity::LoadEncrypted( const std::string& path, const std::string& passphrase )
     {
-#ifdef GENIUS_HAS_OPENSSL
         std::ifstream f( path, std::ios::binary );
         if ( !f )
         {
@@ -447,20 +401,15 @@ namespace sgns::neoswarm::security
         std::memcpy( m_impl->m_privKey.data(), plaintext.data(), kPrivKeySize );
 
         // 11. Derive public key from private key
-#ifdef GENIUS_HAS_SECP256K1
         secp256k1_pubkey pubkey;
         (void)secp256k1_ec_pubkey_create( m_impl->ctx_, &pubkey, m_impl->m_privKey.data() );
         size_t pubLen = kPubKeySize;
         secp256k1_ec_pubkey_serialize( m_impl->ctx_, m_pubKey.data(), &pubLen, &pubkey, SECP256K1_EC_COMPRESSED );
-#endif
 
         m_loaded = true;
         IdentityLogger()->info( "NodeIdentity loaded encrypted from {}", path );
         return outcome::success();
-#else
-        IdentityLogger()->error( "LoadEncrypted: OpenSSL not available" );
-        return outcome::failure( Error::IdentityError );
-#endif
+
     }
 
     // -----------------------------------------------------------------------
@@ -472,17 +421,9 @@ namespace sgns::neoswarm::security
         {
             return outcome::failure( Error::IdentityError );
         }
-#ifdef GENIUS_HAS_SECP256K1
         uint8_t hash[32];
-#ifdef GENIUS_HAS_OPENSSL
         SHA256( message.data(), message.size(), hash );
-#else
-        std::fill( hash, hash + 32, 0 );
-        for ( size_t i = 0; i < message.size(); ++i )
-        {
-            hash[i % 32] ^= message[i];
-        }
-#endif
+
         secp256k1_ecdsa_signature sig;
         if ( !secp256k1_ecdsa_sign( m_impl->ctx_, &sig, hash, m_impl->m_privKey.data(), secp256k1_nonce_function_rfc6979,
                                     nullptr ) )
@@ -494,14 +435,7 @@ namespace sgns::neoswarm::security
         secp256k1_ecdsa_signature_serialize_der( m_impl->ctx_, der.data(), &der_len, &sig );
         der.resize( der_len );
         return outcome::success( std::move( der ) );
-#else
-        std::vector<uint8_t> sig( 64, 0 );
-        for ( size_t i = 0; i < message.size(); ++i )
-        {
-            sig[i % 64] ^= message[i];
-        }
-        return outcome::success( std::move( sig ) );
-#endif
+
     }
 
     // -----------------------------------------------------------------------
@@ -513,17 +447,9 @@ namespace sgns::neoswarm::security
         {
             return false;
         }
-#ifdef GENIUS_HAS_SECP256K1
         uint8_t hash[32];
-#ifdef GENIUS_HAS_OPENSSL
         SHA256( message.data(), message.size(), hash );
-#else
-        std::fill( hash, hash + 32, 0 );
-        for ( size_t i = 0; i < message.size(); ++i )
-        {
-            hash[i % 32] ^= message[i];
-        }
-#endif
+
         secp256k1_ecdsa_signature sig;
         if ( !secp256k1_ecdsa_signature_parse_der( m_impl->ctx_, &sig, signature.data(), signature.size() ) )
         {
@@ -535,12 +461,7 @@ namespace sgns::neoswarm::security
             return false;
         }
         return secp256k1_ecdsa_verify( m_impl->ctx_, &sig, hash, &pubkey ) == 1;
-#else
-        (void) message;
-        (void) signature;
-        IdentityLogger()->error( "NodeIdentity::Verify — secp256k1 not compiled in, REJECTING signature" );
-        return false;
-#endif
+
     }
 
 } // namespace sgns::neoswarm::security


### PR DESCRIPTION
## Summary
Removes all 19 #ifdef GENIUS_HAS_SECP256K1 / GENIUS_HAS_OPENSSL feature gates from security module. 
Libraries are already required in CMake — no runtime stubs needed.

## Changes
- **node_identity.cpp**: Remove 15 #ifdef blocks, replace mt19937 → RAND_bytes for key generation
- **message_signing.cpp**: Remove 4 #ifdef blocks, replace mt19937 → RAND_bytes for nonces
- 2 files, ~200 lines net reduction