### PR TITLE
refactor: remove #ifdef gates from core, tokenizer, sgprocessing

### DIFF
--- a/src/core/engine/mnn_inference_engine.cpp
+++ b/src/core/engine/mnn_inference_engine.cpp
@@ -19,33 +19,14 @@
 #include <random>
 #include <stdexcept>
 
-#ifdef GENIUS_HAS_SGPROCESSING
 #include <InputFormat.hpp>
-#else
-namespace sgns
-{
-    enum class InputFormat : int
-    {
-        FLOAT16 = 0,
-        FLOAT32 = 1,
-        FP4_ULTRA = 2,
-        INT16 = 3,
-        INT32 = 4,
-        INT8 = 5,
-        RGB8 = 6,
-        RGBA8 = 7
-    };
-} // namespace sgns
-#endif
 
-#ifdef GENIUS_HAS_MNN
 #include <MNN/Interpreter.hpp>
 #include <MNN/MNNDefine.h>
 #include <MNN/MNNForwardType.h>
 #include <MNN/Tensor.hpp>
 #include <MNN/expr/Executor.hpp>
 #include <MNN/llm/llm.hpp>
-#endif
 
 namespace sgns::neoswarm::core
 {
@@ -72,7 +53,6 @@ namespace sgns::neoswarm::core
 
     MNNInferenceEngine::~MNNInferenceEngine()
     {
-#ifdef GENIUS_HAS_MNN
         if ( mnn_llm_ )
         {
             MNN::Transformer::Llm::destroy( mnn_llm_ );
@@ -82,7 +62,6 @@ namespace sgns::neoswarm::core
         {
             interpreter_->releaseSession( session_ );
         }
-#endif
     }
 
     // -----------------------------------------------------------------------
@@ -90,12 +69,9 @@ namespace sgns::neoswarm::core
     // -----------------------------------------------------------------------
     int MNNInferenceEngine::SelectBackend() const
     {
-#ifdef GENIUS_HAS_MNN
         // MNN_FORWARD_VULKAN = 7, MNN_FORWARD_CPU = 0
         return ( cfg_.backend_ == "vulkan" ) ? 7 : 0;
-#else
-        return 0;
-#endif
+
     }
 
     std::string MNNInferenceEngine::BackendName() const
@@ -104,11 +80,8 @@ namespace sgns::neoswarm::core
         {
             return cfg_.sg_network_mode_ ? "SGProcessing/Network" : "SGProcessing/Local";
         }
-#ifdef GENIUS_HAS_MNN
         return ( cfg_.backend_ == "vulkan" ) ? "MNN/Vulkan" : "MNN/CPU";
-#else
-        return "Stub/NoMNN";
-#endif
+
     }
 
     // -----------------------------------------------------------------------
@@ -144,7 +117,6 @@ namespace sgns::neoswarm::core
         }
 
         // ---- MNN Interpreter path (fallback) ----
-#ifdef GENIUS_HAS_MNN
         if ( cfg_.engine_mode_ == "interpreter" )
         {
             // Check if this is an MNN LLM model directory (has llm_config.json or llm.mnn.json)
@@ -223,7 +195,6 @@ namespace sgns::neoswarm::core
             EngineLogger()->info( "Model loaded (Interpreter, backend={})", BackendName() );
             return outcome::success();
         }
-#endif
 
         // ---- Stub mode (no engine configured or MNN not compiled) ----
         EngineLogger()->warn( "Engine mode '{}' — running in stub mode", cfg_.engine_mode_ );
@@ -288,7 +259,6 @@ namespace sgns::neoswarm::core
         }
 
         // ---- MNN Interpreter path (fallback) ----
-#ifdef GENIUS_HAS_MNN
         if ( cfg_.engine_mode_ == "interpreter" )
         {
             // --- MNN native LLM path (autoregressive) ---
@@ -383,7 +353,6 @@ namespace sgns::neoswarm::core
                                    latency_ms, perplexity );
             return outcome::success( std::move( resp ) );
         }
-#endif
 
         // ---- Stub path ----
         InferenceResponse resp;
@@ -408,7 +377,6 @@ namespace sgns::neoswarm::core
         // SGProcessing does not support streaming yet — fall through to batch.
         // Interpreter path supports token-by-token streaming.
 
-#ifdef GENIUS_HAS_MNN
         if ( cfg_.engine_mode_ == "interpreter" )
         {
             // --- MNN native LLM streaming ---
@@ -493,7 +461,6 @@ namespace sgns::neoswarm::core
             }
             return outcome::success();
         }
-#endif
 
         // Fallback: run batch inference and emit the full result as one token.
         auto result = Infer( task );
@@ -513,7 +480,6 @@ namespace sgns::neoswarm::core
     // -----------------------------------------------------------------------
     outcome::result<std::vector<float>> MNNInferenceEngine::RunForward( const std::vector<int>& input_ids )
     {
-#ifdef GENIUS_HAS_MNN
         if ( !session_ )
         {
             // Stub: return random logits using dynamic vocab size
@@ -555,16 +521,7 @@ namespace sgns::neoswarm::core
         std::vector<float> logits( host_logits->host<float>(), host_logits->host<float>() + vocab_size );
         delete host_logits;
         return outcome::success( std::move( logits ) );
-#else
-        (void) input_ids;
-        const size_t kVocabSize = tokenizer_ ? tokenizer_->VocabSize() : 32000;
-        std::vector<float> logits( kVocabSize, 0.0f );
-        static std::mt19937 rng( 42 );
-        std::normal_distribution<float> dist( 0.0f, 1.0f );
-        for ( auto& v : logits )
-            v = dist( rng );
-        return outcome::success( std::move( logits ) );
-#endif
+
     }
 
     // -----------------------------------------------------------------------

--- a/src/core/sgprocessing/sg_processing_bridge.cpp
+++ b/src/core/sgprocessing/sg_processing_bridge.cpp
@@ -14,34 +14,11 @@
 #include <boost/asio/io_context.hpp>
 #include <nlohmann/json.hpp>
 
-#ifdef __unix__
-#include <unistd.h> // getcwd
-#elif defined( _WIN32 )
-#include <direct.h>
-#define getcwd _getcwd
-#endif
-
-#ifdef GENIUS_HAS_SGPROCESSING
+#include <filesystem>
 #include <Generators.hpp>
 #include <InputFormat.hpp>
 #include <SGNSProcMain.hpp>
 #include <processingbase/ProcessingManager.hpp>
-#else
-namespace sgns
-{
-    enum class InputFormat : int
-    {
-        FLOAT16 = 0,
-        FLOAT32 = 1,
-        FP4_ULTRA = 2,
-        INT16 = 3,
-        INT32 = 4,
-        INT8 = 5,
-        RGB8 = 6,
-        RGBA8 = 7
-    };
-} // namespace sgns
-#endif
 
 namespace sgns::neoswarm::core
 {
@@ -133,8 +110,8 @@ namespace sgns::neoswarm::core
                     return uri;
                 }
                 // Prepend current working directory
-                char cwd[4096] = {};
-                if ( getcwd( cwd, sizeof( cwd ) ) != nullptr )
+                std::string cwd = std::filesystem::current_path().string();
+                if ( !cwd.empty() )
                 {
                     return std::string( "file://" ) + cwd + "/" + rel;
                 }
@@ -314,7 +291,6 @@ namespace sgns::neoswarm::core
         const std::string& jsondata,
         std::shared_ptr<boost::asio::io_context> ioc ) const
     {
-#ifdef GENIUS_HAS_SGPROCESSING
         // Step 1: Create ProcessingManager from JSON
         auto pm_result = sgns::sgprocessing::ProcessingManager::Create( jsondata );
         if ( !pm_result )
@@ -357,12 +333,7 @@ namespace sgns::neoswarm::core
         BridgeLogger()->debug( "Process() succeeded: {} bytes, {} chunk hashes", process_result.value().size(),
                                chunkhashes.size() );
         return outcome::success( process_result.value() );
-#else
-        (void) jsondata;
-        (void) ioc;
-        BridgeLogger()->warn( "SGProcessingBridge: SGProcessingManager not compiled in — stub mode" );
-        return outcome::success( std::vector<uint8_t>{} );
-#endif
+
     }
 
     // -----------------------------------------------------------------------

--- a/src/core/sgprocessing/tensor_interpreter.cpp
+++ b/src/core/sgprocessing/tensor_interpreter.cpp
@@ -12,24 +12,7 @@
 #include <cstring>
 #include <sstream>
 
-#ifdef GENIUS_HAS_SGPROCESSING
 #include <InputFormat.hpp>
-#else
-namespace sgns
-{
-    enum class InputFormat : int
-    {
-        FLOAT16 = 0,
-        FLOAT32 = 1,
-        FP4_ULTRA = 2,
-        INT16 = 3,
-        INT32 = 4,
-        INT8 = 5,
-        RGB8 = 6,
-        RGBA8 = 7
-    };
-} // namespace sgns
-#endif
 
 namespace sgns::neoswarm::core
 {

--- a/src/core/tokenizer/sentence_piece_tokenizer.cpp
+++ b/src/core/tokenizer/sentence_piece_tokenizer.cpp
@@ -12,9 +12,7 @@
 #include <cctype>
 #include <sstream>
 
-#ifdef GENIUS_HAS_SENTENCEPIECE
 #include <sentencepiece_processor.h>
-#endif
 
 namespace sgns::neoswarm::core
 {
@@ -28,9 +26,7 @@ namespace sgns::neoswarm::core
 
     struct SentencePieceTokenizer::Impl
     {
-#ifdef GENIUS_HAS_SENTENCEPIECE
         sentencepiece::SentencePieceProcessor processor_;
-#endif
         bool loaded_ = false;
     };
 
@@ -48,7 +44,6 @@ namespace sgns::neoswarm::core
     // -----------------------------------------------------------------------
     outcome::result<void> SentencePieceTokenizer::Load( const std::string& model_path )
     {
-#ifdef GENIUS_HAS_SENTENCEPIECE
         auto status = impl_->processor_.Load( model_path );
         if ( !status.ok() )
         {
@@ -57,12 +52,7 @@ namespace sgns::neoswarm::core
         impl_->loaded_ = true;
         TokenizerLogger()->info( "Tokenizer loaded: {} (vocab={})", model_path, VocabSize() );
         return outcome::success();
-#else
-        (void) model_path;
-        TokenizerLogger()->warn( "SentencePiece not compiled in — using whitespace tokenizer stub" );
-        impl_->loaded_ = true;
-        return outcome::success();
-#endif
+
     }
 
     // -----------------------------------------------------------------------
@@ -70,7 +60,6 @@ namespace sgns::neoswarm::core
     // -----------------------------------------------------------------------
     outcome::result<std::vector<int>> SentencePieceTokenizer::Encode( const std::string& text ) const
     {
-#ifdef GENIUS_HAS_SENTENCEPIECE
         if ( !impl_->loaded_ )
         {
             return outcome::failure( Error::TokenizerFailed );
@@ -82,18 +71,7 @@ namespace sgns::neoswarm::core
             return outcome::failure( Error::TokenizerFailed );
         }
         return outcome::success( std::move( ids ) );
-#else
-        std::vector<int> ids;
-        ids.push_back( bos_id_ );
-        std::istringstream iss( text );
-        std::string word;
-        while ( iss >> word )
-        {
-            int id = 3 + static_cast<int>( std::hash<std::string>{}( word ) % 31997 );
-            ids.push_back( id );
-        }
-        return outcome::success( std::move( ids ) );
-#endif
+
     }
 
     // -----------------------------------------------------------------------
@@ -101,7 +79,6 @@ namespace sgns::neoswarm::core
     // -----------------------------------------------------------------------
     outcome::result<std::string> SentencePieceTokenizer::Decode( const std::vector<int>& ids ) const
     {
-#ifdef GENIUS_HAS_SENTENCEPIECE
         if ( !impl_->loaded_ )
         {
             return outcome::failure( Error::TokenizerFailed );
@@ -113,16 +90,7 @@ namespace sgns::neoswarm::core
             return outcome::failure( Error::TokenizerFailed );
         }
         return outcome::success( std::move( text ) );
-#else
-        std::string out;
-        for ( int id : ids )
-        {
-            if ( !out.empty() )
-                out += ' ';
-            out += std::to_string( id );
-        }
-        return outcome::success( out );
-#endif
+
     }
 
     // -----------------------------------------------------------------------
@@ -130,12 +98,10 @@ namespace sgns::neoswarm::core
     // -----------------------------------------------------------------------
     size_t SentencePieceTokenizer::VocabSize() const
     {
-#ifdef GENIUS_HAS_SENTENCEPIECE
         if ( impl_->loaded_ )
         {
             return static_cast<size_t>( impl_->processor_.GetPieceSize() );
         }
-#endif
         return 0; // unknown until model is loaded
     }
 


### PR DESCRIPTION
## Summary
Removes 18 #ifdef GENIUS_HAS_* feature gates from core engine, tokenizer, and sgprocessing modules.

## Changes
- **mnn_inference_engine.cpp**: Remove 9 GENIUS_HAS_MNN/SGPROCESSING gates (665 → 622 lines)
- **sentence_piece_tokenizer.cpp**: Remove 6 GENIUS_HAS_SENTENCEPIECE gates
- **sg_processing_bridge.cpp**: Remove 2 GENIUS_HAS_SGPROCESSING gates + platform ifdef
- **tensor_interpreter.cpp**: Remove 1 GENIUS_HAS_SGPROCESSING gate

4 files, ~130 lines net reduction