### PR TITLE
refactor: remove #ifdef gates from network and reputation

### DIFF
--- a/src/network/p2p_node.cpp
+++ b/src/network/p2p_node.cpp
@@ -11,12 +11,10 @@
 #include <atomic>
 #include <nlohmann/json.hpp>
 
-#ifdef GENIUS_HAS_LIBP2P
 #include <libp2p/host/basic_host/basic_host.hpp>
 #include <libp2p/injector/host_injector.hpp>
 #include <libp2p/multi/multiaddress.hpp>
 #include <libp2p/protocol/gossip/gossip.hpp>
-#endif
 
 namespace sgns::neoswarm::network
 {
@@ -38,7 +36,6 @@ namespace sgns::neoswarm::network
         std::vector<std::string> peers_;
         std::atomic<bool> m_running{ false };
 
-#ifdef GENIUS_HAS_LIBP2P
         std::shared_ptr<libp2p::Host> host_;
         std::shared_ptr<libp2p::protocol::gossip::Gossip> gossip_;
         std::shared_ptr<libp2p::peer::IdentityManager> id_mgr_;
@@ -51,7 +48,6 @@ namespace sgns::neoswarm::network
             libp2p::protocol::Subscription crdt_sub;
         };
         std::unique_ptr<GossipSubs> subs_;
-#endif
     };
 
     P2PNode::P2PNode( std::shared_ptr<security::NodeIdentity> identity )
@@ -78,7 +74,6 @@ namespace sgns::neoswarm::network
     // -----------------------------------------------------------------------
     outcome::result<void> P2PNode::Start()
     {
-#ifdef GENIUS_HAS_LIBP2P
         NetworkLogger()->info( "P2PNode starting (libp2p)..." );
 
         try
@@ -158,17 +153,7 @@ namespace sgns::neoswarm::network
         }
 
         return outcome::success();
-#else
-        NetworkLogger()->warn( "libp2p not compiled in — P2PNode running in stub mode" );
 
-        m_impl->peer_id_ = m_identity ? m_identity->PeerId() : "stub-peer";
-        m_impl->listen_addr_ = m_cfg.listen_addr_;
-        m_impl->m_running.store( true );
-        m_running = true;
-
-        NetworkLogger()->info( "P2PNode started: peerId={} addr={}", m_impl->peer_id_, m_impl->listen_addr_ );
-        return outcome::success();
-#endif
     }
 
     // -----------------------------------------------------------------------
@@ -180,7 +165,6 @@ namespace sgns::neoswarm::network
         {
             return;
         }
-#ifdef GENIUS_HAS_LIBP2P
         if ( m_impl->gossip_ )
             m_impl->gossip_->stop();
         if ( m_impl->host_ )
@@ -188,7 +172,6 @@ namespace sgns::neoswarm::network
         m_impl->host_.reset();
         m_impl->gossip_.reset();
         m_impl->id_mgr_.reset();
-#endif
         m_impl->m_running.store( false );
         m_running = false;
         NetworkLogger()->info( "P2PNode stopped" );
@@ -229,21 +212,13 @@ namespace sgns::neoswarm::network
 
         NetworkLogger()->debug( "Broadcasting task {} to {} peers", task.id_, m_impl->peers_.size() );
 
-#ifdef GENIUS_HAS_LIBP2P
         // Publish via GossipSub to all peers
         if ( m_impl->gossip_ )
         {
             std::vector<uint8_t> data( payload.begin(), payload.end() );
             m_impl->gossip_->publish( kTaskTopic, std::move( data ) );
         }
-#else
-        // Stub: call local handler directly for single-process testing
-        if ( task_handler_ )
-        {
-            Task t = task;
-            task_handler_( t, m_impl->peer_id_ );
-        }
-#endif
+
         return outcome::success();
     }
 
@@ -257,18 +232,12 @@ namespace sgns::neoswarm::network
             return outcome::failure( Error::NetworkError );
         }
         NetworkLogger()->debug( "Broadcasting CRDT update ({} bytes)", crdt_data.size() );
-#ifdef GENIUS_HAS_LIBP2P
         if ( m_impl->gossip_ )
         {
             std::vector<uint8_t> data( crdt_data.begin(), crdt_data.end() );
             m_impl->gossip_->publish( kCRDTTopic, std::move( data ) );
         }
-#else
-        if ( crdt_handler_ )
-        {
-            crdt_handler_( crdt_data );
-        }
-#endif
+
         return outcome::success();
     }
 

--- a/src/network/sg_client/sg_channel_manager.cpp
+++ b/src/network/sg_client/sg_channel_manager.cpp
@@ -36,7 +36,6 @@ namespace sgns::neoswarm::network
             return outcome::success();
         }
 
-#ifdef GENIUS_HAS_GRPC
         bool isLocalhost = m_cfg.endpoint_.find( "localhost" ) != std::string::npos ||
                            m_cfg.endpoint_.find( "127.0.0.1" ) != std::string::npos;
 
@@ -75,10 +74,7 @@ namespace sgns::neoswarm::network
 
         ChannelLogger()->info( "Channel created to {}", m_cfg.endpoint_ );
         return outcome::success();
-#else
-        ChannelLogger()->warn( "SGChannelManager: gRPC not compiled in — stub mode" );
-        return outcome::failure( Error::NotImplemented );
-#endif
+
     }
 
     outcome::result<bool> SGChannelManager::HealthCheck() const
@@ -88,7 +84,6 @@ namespace sgns::neoswarm::network
             return false;
         }
 
-#ifdef GENIUS_HAS_GRPC
         auto state = channel_->GetState( false );
         if ( state == GRPC_CHANNEL_READY )
         {
@@ -96,9 +91,7 @@ namespace sgns::neoswarm::network
         }
         ChannelLogger()->debug( "Channel health check: state={}", static_cast<int>( state ) );
         return false;
-#else
-        return false;
-#endif
+
     }
 
     outcome::result<void> SGChannelManager::Reconnect()

--- a/src/network/sg_client/sg_job_submitter.cpp
+++ b/src/network/sg_client/sg_job_submitter.cpp
@@ -60,7 +60,6 @@ namespace sgns::neoswarm::network
     {
         std::string taskId = GenerateTaskId();
 
-#ifdef GENIUS_HAS_GRPC
         // Sign the payload with nonce + timestamp + secp256k1 signature
         auto signedPayload = m_impl->authenticator_.SignPayload( gnusSchemaJson );
         if ( !signedPayload.has_value() )
@@ -91,10 +90,7 @@ namespace sgns::neoswarm::network
         SubmitLogger()->warn( "gRPC PubSub publish not yet wired — task {} prepared for dispatch", taskId );
 
         return taskId;
-#else
-        SubmitLogger()->warn( "SGJobSubmitter: gRPC not compiled in — returning taskId as stub" );
-        return taskId;
-#endif
+
     }
 
     SGJobSubmitter::~SGJobSubmitter() = default;

--- a/src/reputation/reputation_storage.cpp
+++ b/src/reputation/reputation_storage.cpp
@@ -13,11 +13,9 @@
 #include <stdexcept>
 #include <unordered_map>
 
-#ifdef GENIUS_HAS_ROCKSDB
 #include <rocksdb/db.h>
 #include <rocksdb/options.h>
 #include <rocksdb/slice.h>
-#endif
 
 namespace sgns::neoswarm::reputation
 {
@@ -74,12 +72,9 @@ namespace sgns::neoswarm::reputation
     // -----------------------------------------------------------------------
     struct ReputationStorage::Impl
     {
-#ifdef GENIUS_HAS_ROCKSDB
         rocksdb::DB* db_ = nullptr;
         rocksdb::Options options_;
-#else
-        std::unordered_map<std::string, std::string> store_;
-#endif
+
     };
 
     ReputationStorage::ReputationStorage( const std::string& db_path )
@@ -98,7 +93,6 @@ namespace sgns::neoswarm::reputation
     // -----------------------------------------------------------------------
     outcome::result<void> ReputationStorage::Open()
     {
-#ifdef GENIUS_HAS_ROCKSDB
         m_impl->options_.create_if_missing = true;
         rocksdb::Status status = rocksdb::DB::Open( m_impl->options_, db_path_, &m_impl->db_ );
         if ( !status.ok() )
@@ -106,9 +100,7 @@ namespace sgns::neoswarm::reputation
             return outcome::failure( Error::StorageError );
         }
         StorageLogger()->info( "ReputationStorage opened: {}", db_path_ );
-#else
-        StorageLogger()->warn( "RocksDB not compiled in — using in-memory reputation store" );
-#endif
+
         open_ = true;
         return outcome::success();
     }
@@ -118,13 +110,11 @@ namespace sgns::neoswarm::reputation
     // -----------------------------------------------------------------------
     void ReputationStorage::Close()
     {
-#ifdef GENIUS_HAS_ROCKSDB
         if ( m_impl && m_impl->db_ )
         {
             delete m_impl->db_;
             m_impl->db_ = nullptr;
         }
-#endif
         open_ = false;
     }
 
@@ -138,15 +128,12 @@ namespace sgns::neoswarm::reputation
             return outcome::failure( Error::StorageError );
         }
         std::string val = Serialize( rep );
-#ifdef GENIUS_HAS_ROCKSDB
         auto status = m_impl->db_->Put( rocksdb::WriteOptions(), rep.identity_key_, val );
         if ( !status.ok() )
         {
             return outcome::failure( Error::StorageError );
         }
-#else
-        m_impl->store_[rep.identity_key_] = val;
-#endif
+
         return outcome::success();
     }
 
@@ -159,7 +146,6 @@ namespace sgns::neoswarm::reputation
         {
             return outcome::failure( Error::StorageError );
         }
-#ifdef GENIUS_HAS_ROCKSDB
         std::string val;
         rocksdb::Status status = m_impl->db_->Get( rocksdb::ReadOptions(), identity_key, &val );
         if ( status.IsNotFound() )
@@ -171,14 +157,7 @@ namespace sgns::neoswarm::reputation
             return outcome::failure( Error::StorageError );
         }
         return outcome::success( Deserialize( val ) );
-#else
-        auto it = m_impl->store_.find( identity_key );
-        if ( it == m_impl->store_.end() )
-        {
-            return outcome::failure( Error::ReputationNotFound );
-        }
-        return outcome::success( Deserialize( it->second ) );
-#endif
+
     }
 
     // -----------------------------------------------------------------------
@@ -190,15 +169,12 @@ namespace sgns::neoswarm::reputation
         {
             return outcome::failure( Error::StorageError );
         }
-#ifdef GENIUS_HAS_ROCKSDB
         auto status = m_impl->db_->Delete( rocksdb::WriteOptions(), identity_key );
         if ( !status.ok() )
         {
             return outcome::failure( Error::StorageError );
         }
-#else
-        m_impl->store_.erase( identity_key );
-#endif
+
         return outcome::success();
     }
 
@@ -212,19 +188,13 @@ namespace sgns::neoswarm::reputation
             return outcome::failure( Error::StorageError );
         }
         std::vector<NodeReputation> result;
-#ifdef GENIUS_HAS_ROCKSDB
         auto* it = m_impl->db_->NewIterator( rocksdb::ReadOptions() );
         for ( it->SeekToFirst(); it->Valid(); it->Next() )
         {
             result.push_back( Deserialize( it->value().ToString() ) );
         }
         delete it;
-#else
-        for ( const auto& [k, v] : m_impl->store_ )
-        {
-            result.push_back( Deserialize( v ) );
-        }
-#endif
+
         return outcome::success( std::move( result ) );
     }
 


### PR DESCRIPTION
## Summary
Removes 17 #ifdef GENIUS_HAS_* feature gates from network and reputation modules.

## Changes
- **p2p_node.cpp**: Remove 6 GENIUS_HAS_LIBP2P gates (275 → 244 lines)
- **reputation_storage.cpp**: Remove 8 GENIUS_HAS_ROCKSDB gates (231 → 201 lines)
- **sg_channel_manager.cpp**: Remove 2 GENIUS_HAS_GRPC gates
- **sg_job_submitter.cpp**: Remove 1 GENIUS_HAS_GRPC gate

4 files, ~140 lines net reduction