### PR TITLE
fix: complete m_ prefix member rename — remaining _ suffix members

### DIFF
--- a/src/api/api_server.cpp
+++ b/src/api/api_server.cpp
@@ -98,32 +98,32 @@ namespace sgns::neoswarm::api
         {
             engine->SetStubMode();
         }
-        core_engine_ = engine;
+        m_coreEngine = engine;
 
         // 3. Specialists
-        grammar_spec_ = std::make_shared<specialists::GrammarSpecialist>(
-            m_cfg.grammar_model_path_.empty() ? nullptr : core_engine_ );
-        math_spec_ =
-            std::make_shared<specialists::MathSpecialist>( m_cfg.math_model_path_.empty() ? nullptr : core_engine_ );
+        m_grammarSpec = std::make_shared<specialists::GrammarSpecialist>(
+            m_cfg.grammar_model_path_.empty() ? nullptr : m_coreEngine );
+        m_mathSpec =
+            std::make_shared<specialists::MathSpecialist>( m_cfg.math_model_path_.empty() ? nullptr : m_coreEngine );
 
         if ( !m_cfg.grammar_model_path_.empty() )
         {
-            (void)grammar_spec_->Load( m_cfg.grammar_model_path_ );
+            (void)m_grammarSpec->Load( m_cfg.grammar_model_path_ );
         }
         if ( !m_cfg.math_model_path_.empty() )
         {
-            (void)math_spec_->Load( m_cfg.math_model_path_ );
+            (void)m_mathSpec->Load( m_cfg.math_model_path_ );
         }
 
         // 4. Router
-        router_ = std::make_unique<router::RuleBasedRouter>();
+        m_router = std::make_unique<router::RuleBasedRouter>();
 
         // 5. Reputation
-        scoring_ = std::make_unique<reputation::ReputationScoring>();
-        consensus_ = std::make_unique<reputation::WeightedConsensus>();
-        rep_crdt_ = std::make_unique<reputation::ReputationCRDT>();
-        rep_storage_ = std::make_unique<reputation::ReputationStorage>( m_cfg.reputation_db_path_ );
-        auto stor_res = rep_storage_->Open();
+        m_scoring = std::make_unique<reputation::ReputationScoring>();
+        m_consensus = std::make_unique<reputation::WeightedConsensus>();
+        m_repCrdt = std::make_unique<reputation::ReputationCRDT>();
+        m_repStorage = std::make_unique<reputation::ReputationStorage>( m_cfg.reputation_db_path_ );
+        auto stor_res = m_repStorage->Open();
         if ( !stor_res.has_value() )
         {
             ServerLogger()->warn( "Reputation storage open failed" );
@@ -133,9 +133,9 @@ namespace sgns::neoswarm::api
         if ( m_cfg.enable_network_ )
         {
             network::P2PNode::Config net_cfg;
-            p2p_node_ = std::make_unique<network::P2PNode>( m_identity, net_cfg );
-            aggregation_ = std::make_unique<network::ResultAggregation>();
-            auto net_res = p2p_node_->Start();
+            m_p2pNode = std::make_unique<network::P2PNode>( m_identity, net_cfg );
+            m_aggregation = std::make_unique<network::ResultAggregation>();
+            auto net_res = m_p2pNode->Start();
             if ( !net_res.has_value() )
             {
                 ServerLogger()->warn( "P2P network start failed" );
@@ -143,21 +143,21 @@ namespace sgns::neoswarm::api
         }
 
         // 6b. SuperGenius connectivity (optional — Phase 2 network dispatch)
-        if ( !m_cfg.sg_endpoint_.empty() )
+        if ( !m_cfg.sg_m_endpoint.empty() )
         {
             network::SuperGeniusClient::Config sgCfg;
-            sgCfg.endpoint_ = m_cfg.sg_endpoint_;
+            sgCfg.m_endpoint = m_cfg.sg_m_endpoint;
             sgCfg.tls_ca_path_ = m_cfg.sg_tls_ca_;
             sgCfg.tls_cert_path_ = m_cfg.sg_tls_cert_;
 
-            sg_client_ = std::make_unique<network::SuperGeniusClient>( std::move( sgCfg ) );
-            auto initRes = sg_client_->Initialize( *m_identity );
+            m_sgClient = std::make_unique<network::SuperGeniusClient>( std::move( sgCfg ) );
+            auto initRes = m_sgClient->Initialize( *m_identity );
             if ( initRes.has_value() )
             {
-                auto connRes = sg_client_->Connect();
+                auto connRes = m_sgClient->Connect();
                 if ( connRes.has_value() )
                 {
-                    ServerLogger()->info( "Connected to SuperGenius at {}", m_cfg.sg_endpoint_ );
+                    ServerLogger()->info( "Connected to SuperGenius at {}", m_cfg.sg_m_endpoint );
                 }
                 else
                 {
@@ -170,25 +170,25 @@ namespace sgns::neoswarm::api
             }
 
             // Wire SuperGeniusClient into the engine's SGProcessingBridge
-            if ( core_engine_ )
+            if ( m_coreEngine )
             {
-                auto* mnnEngine = dynamic_cast<core::MNNInferenceEngine*>( core_engine_.get() );
+                auto* mnnEngine = dynamic_cast<core::MNNInferenceEngine*>( m_coreEngine.get() );
                 if ( mnnEngine )
                 {
-                    mnnEngine->SetSuperGeniusClient( sg_client_.get() );
+                    mnnEngine->SetSuperGeniusClient( m_sgClient.get() );
                 }
             }
         }
 
         // 7. Knowledge
-        if ( m_cfg.enable_knowledge_ )
+        if ( m_cfg.enable_m_knowledge )
         {
             knowledge::KnowledgeRetrieval::Config k_cfg;
-            k_cfg.facts_path_ = m_cfg.knowledge_facts_;
-            knowledge_ = std::make_shared<knowledge::KnowledgeRetrieval>( k_cfg );
-            (void)knowledge_->Load();
-            context_inj_ = std::make_unique<knowledge::ContextInjection>();
-            fact_val_ = std::make_unique<knowledge::FactValidation>( knowledge_ );
+            k_cfg.facts_path_ = m_cfg.m_knowledgefacts_;
+            m_knowledge = std::make_shared<knowledge::KnowledgeRetrieval>( k_cfg );
+            (void)m_knowledge->Load();
+            m_contextInj = std::make_unique<knowledge::ContextInjection>();
+            m_factVal = std::make_unique<knowledge::FactValidation>( m_knowledge );
         }
 
         ServerLogger()->info( "ApiServer initialized (node={})", m_identity->PeerId() );
@@ -200,17 +200,17 @@ namespace sgns::neoswarm::api
     // -----------------------------------------------------------------------
     std::string ApiServer::AugmentPrompt( const std::string& prompt, std::vector<KnowledgeFact>& out_facts ) const
     {
-        if ( !knowledge_ || !knowledge_->IsLoaded() || !context_inj_ )
+        if ( !m_knowledge || !m_knowledge->IsLoaded() || !m_contextInj )
         {
             return prompt;
         }
-        auto facts_res = knowledge_->Retrieve( prompt );
+        auto facts_res = m_knowledge->Retrieve( prompt );
         if ( !facts_res.has_value() || facts_res.value().empty() )
         {
             return prompt;
         }
         out_facts = facts_res.value();
-        return context_inj_->Inject( prompt, out_facts );
+        return m_contextInj->Inject( prompt, out_facts );
     }
 
     // -----------------------------------------------------------------------
@@ -218,14 +218,14 @@ namespace sgns::neoswarm::api
     // -----------------------------------------------------------------------
     void ApiServer::UpdateReputation( const InferenceResponse& resp,
                                             double median_latency_ms,
-                                            const std::string& consensus_output )
+                                            const std::string& m_consensusoutput )
     {
-        if ( !rep_storage_ || !rep_storage_->IsOpen() )
+        if ( !m_repStorage || !m_repStorage->IsOpen() )
         {
             return;
         }
 
-        auto get_res = rep_storage_->Get( resp.node_id_ );
+        auto get_res = m_repStorage->Get( resp.node_id_ );
         NodeReputation rep;
         if ( get_res.has_value() )
         {
@@ -236,13 +236,13 @@ namespace sgns::neoswarm::api
             rep.m_identitykey_ = resp.node_id_;
         }
 
-        auto updated = scoring_->Update( rep, resp, median_latency_ms, std::nullopt, consensus_output );
-        (void)rep_storage_->Put( updated );
-        rep_crdt_->Merge( updated );
+        auto updated = m_scoring->Update( rep, resp, median_latency_ms, std::nullopt, m_consensusoutput );
+        (void)m_repStorage->Put( updated );
+        m_repCrdt->Merge( updated );
 
-        if ( p2p_node_ && p2p_node_->IsRunning() )
+        if ( m_p2pNode && m_p2pNode->IsRunning() )
         {
-            (void)p2p_node_->BroadcastCRDT( rep_crdt_->Serialize() );
+            (void)m_p2pNode->BroadcastCRDT( m_repCrdt->Serialize() );
         }
     }
 
@@ -255,7 +255,7 @@ namespace sgns::neoswarm::api
         Task aug_task = task;
         aug_task.prompt_ = AugmentPrompt( task.prompt_, facts );
 
-        auto res = core_engine_->Infer( aug_task );
+        auto res = m_coreEngine->Infer( aug_task );
         if ( !res.has_value() )
         {
             return outcome::failure( res.error() );
@@ -285,7 +285,7 @@ namespace sgns::neoswarm::api
         Task aug_task = task;
         aug_task.prompt_ = AugmentPrompt( task.prompt_, facts );
 
-        auto core_res = core_engine_->Infer( aug_task );
+        auto core_res = m_coreEngine->Infer( aug_task );
         if ( !core_res.has_value() )
         {
             return outcome::failure( core_res.error() );
@@ -293,15 +293,15 @@ namespace sgns::neoswarm::api
 
         std::string output = core_res.value().output_;
 
-        if ( route.target_ == RouteTarget::CorePlusMath && math_spec_ )
+        if ( route.target_ == RouteTarget::CorePlusMath && m_mathSpec )
         {
-            auto spec_res = math_spec_->Process( output );
+            auto spec_res = m_mathSpec->Process( output );
             if ( spec_res.has_value() )
                 output = spec_res.value();
         }
-        else if ( route.target_ == RouteTarget::CorePlusGrammar && grammar_spec_ )
+        else if ( route.target_ == RouteTarget::CorePlusGrammar && m_grammarSpec )
         {
-            auto spec_res = grammar_spec_->Process( output );
+            auto spec_res = m_grammarSpec->Process( output );
             if ( spec_res.has_value() )
                 output = spec_res.value();
         }
@@ -309,9 +309,9 @@ namespace sgns::neoswarm::api
         auto t1 = std::chrono::steady_clock::now();
         double total_ms = std::chrono::duration<double, std::milli>( t1 - t0 ).count();
 
-        if ( fact_val_ && fact_val_->IsAvailable() )
+        if ( m_factVal && m_factVal->IsAvailable() )
         {
-            auto val_result = fact_val_->Validate( output, facts );
+            auto val_result = m_factVal->Validate( output, facts );
             if ( !val_result.passed_ )
             {
                 ServerLogger()->warn( "Fact validation failed: {}", val_result.suggestion_ );
@@ -346,14 +346,14 @@ namespace sgns::neoswarm::api
         Task aug_task = task;
         aug_task.prompt_ = AugmentPrompt( task.prompt_, facts );
 
-        if ( p2p_node_ && p2p_node_->IsRunning() && aggregation_ )
+        if ( m_p2pNode && m_p2pNode->IsRunning() && m_aggregation )
         {
-            aggregation_->Reset();
+            m_aggregation->Reset();
 
-            p2p_node_->OnTask(
+            m_p2pNode->OnTask(
                 [this, aug_task]( const Task& t, const std::string& from_peer )
                 {
-                    auto res = core_engine_->Infer( t );
+                    auto res = m_coreEngine->Infer( t );
                     if ( res.has_value() )
                     {
                         NodeOutput out;
@@ -361,27 +361,27 @@ namespace sgns::neoswarm::api
                         out.output_ = res.value().output_;
                         out.perplexity_ = res.value().perplexity_;
                         out.latency_ms_ = res.value().latency_ms_;
-                        if ( rep_storage_ && rep_storage_->IsOpen() )
+                        if ( m_repStorage && m_repStorage->IsOpen() )
                         {
-                            auto rep_res = rep_storage_->Get( from_peer );
+                            auto rep_res = m_repStorage->Get( from_peer );
                             if ( rep_res.has_value() )
                             {
                                 out.reputation_ = rep_res.value().global_score_;
                             }
                         }
-                        aggregation_->Submit( out );
+                        m_aggregation->Submit( out );
                     }
                 } );
 
-            (void)p2p_node_->BroadcastTask( aug_task );
-            auto collect_res = aggregation_->Collect();
+            (void)m_p2pNode->BroadcastTask( aug_task );
+            auto collect_res = m_aggregation->Collect();
             if ( !collect_res.has_value() )
             {
                 ServerLogger()->warn( "Swarm collection failed — falling back to single node" );
                 return RunSingleNode( task, route );
             }
 
-            auto winner = consensus_->SelectWinner( collect_res.value() );
+            auto winner = m_consensus->SelectWinner( collect_res.value() );
 
             double median_latency = 0.0;
             auto& outputs = collect_res.value();
@@ -424,7 +424,7 @@ namespace sgns::neoswarm::api
     // -----------------------------------------------------------------------
     outcome::result<InferenceResponse> ApiServer::Process( const Task& task )
     {
-        if ( !core_engine_ )
+        if ( !m_coreEngine )
         {
             return outcome::failure( Error::InternalError );
         }
@@ -435,7 +435,7 @@ namespace sgns::neoswarm::api
         if ( t.node_id_.empty() )
             t.node_id_ = m_identity ? m_identity->PeerId() : "local";
 
-        auto route_res = router_->Route( t );
+        auto route_res = m_router->Route( t );
         if ( !route_res.has_value() )
         {
             return outcome::failure( route_res.error() );
@@ -475,18 +475,18 @@ namespace sgns::neoswarm::api
     void ApiServer::Stop()
     {
         m_running.store( false );
-        if ( p2p_node_ )
-            p2p_node_->Stop();
-        if ( sg_client_ )
-            sg_client_->Disconnect();
-        if ( rep_storage_ )
-            rep_storage_->Close();
+        if ( m_p2pNode )
+            m_p2pNode->Stop();
+        if ( m_sgClient )
+            m_sgClient->Disconnect();
+        if ( m_repStorage )
+            m_repStorage->Close();
         ServerLogger()->info( "ApiServer stopped" );
     }
 
     bool ApiServer::IsSuperGeniusConnected() const noexcept
     {
-        return sg_client_ != nullptr && sg_client_->IsConnected();
+        return m_sgClient != nullptr && m_sgClient->IsConnected();
     }
 
 } // namespace sgns::neoswarm::api

--- a/src/api/api_server.hpp
+++ b/src/api/api_server.hpp
@@ -13,7 +13,7 @@
 #include "core/engine/inference_engine.hpp"
 #include "knowledge/context_injection.hpp"
 #include "knowledge/fact_validation.hpp"
-#include "knowledge/knowledge_retrieval.hpp"
+#include "knowledge/m_knowledgeretrieval.hpp"
 #include "network/p2p_node.hpp"
 #include "network/result_aggregation.hpp"
 #include "reputation/reputation_crdt.hpp"
@@ -52,14 +52,14 @@ namespace sgns::neoswarm::api
             std::string grammar_model_path_;
             std::string math_model_path_;
             std::string reputation_db_path_ = "./reputation.db";
-            std::string knowledge_facts_ = "";
+            std::string m_knowledgefacts_ = "";
             bool enable_network_ = false;
-            bool enable_knowledge_ = true;
+            bool enable_m_knowledge = true;
             int grpc_port_ = 50051;
             std::string node_key_file_ = "./node.key";
             bool enable_sg_processing_ = false;
             bool sg_processing_network_mode_ = false;
-            std::string sg_endpoint_ = "localhost:50051";
+            std::string sg_m_endpoint = "localhost:50051";
             std::string sg_tls_ca_;
             std::string sg_tls_cert_;
         };
@@ -103,20 +103,20 @@ namespace sgns::neoswarm::api
         std::atomic<bool> m_running{ false };
 
         std::shared_ptr<security::NodeIdentity> m_identity;
-        std::shared_ptr<core::InferenceEngine> core_engine_;
-        std::shared_ptr<specialists::GrammarSpecialist> grammar_spec_;
-        std::shared_ptr<specialists::MathSpecialist> math_spec_;
-        std::unique_ptr<router::RuleBasedRouter> router_;
-        std::unique_ptr<reputation::WeightedConsensus> consensus_;
-        std::unique_ptr<reputation::ReputationScoring> scoring_;
-        std::unique_ptr<reputation::ReputationStorage> rep_storage_;
-        std::unique_ptr<reputation::ReputationCRDT> rep_crdt_;
-        std::unique_ptr<network::P2PNode> p2p_node_;
-        std::unique_ptr<network::ResultAggregation> aggregation_;
-        std::shared_ptr<knowledge::KnowledgeRetrieval> knowledge_;
-        std::unique_ptr<knowledge::ContextInjection> context_inj_;
-        std::unique_ptr<knowledge::FactValidation> fact_val_;
-        std::unique_ptr<network::SuperGeniusClient> sg_client_;
+        std::shared_ptr<core::InferenceEngine> m_coreEngine;
+        std::shared_ptr<specialists::GrammarSpecialist> m_grammarSpec;
+        std::shared_ptr<specialists::MathSpecialist> m_mathSpec;
+        std::unique_ptr<router::RuleBasedRouter> m_router;
+        std::unique_ptr<reputation::WeightedConsensus> m_consensus;
+        std::unique_ptr<reputation::ReputationScoring> m_scoring;
+        std::unique_ptr<reputation::ReputationStorage> m_repStorage;
+        std::unique_ptr<reputation::ReputationCRDT> m_repCrdt;
+        std::unique_ptr<network::P2PNode> m_p2pNode;
+        std::unique_ptr<network::ResultAggregation> m_aggregation;
+        std::shared_ptr<knowledge::KnowledgeRetrieval> m_knowledge;
+        std::unique_ptr<knowledge::ContextInjection> m_contextInj;
+        std::unique_ptr<knowledge::FactValidation> m_factVal;
+        std::unique_ptr<network::SuperGeniusClient> m_sgClient;
 
         outcome::result<InferenceResponse> RunSingleNode( const Task& task, const RouteDecision& route );
         outcome::result<InferenceResponse> RunSpecialist( const Task& task, const RouteDecision& route );
@@ -126,7 +126,7 @@ namespace sgns::neoswarm::api
 
         void UpdateReputation( const InferenceResponse& resp,
                                double median_latency_ms,
-                               const std::string& consensus_output );
+                               const std::string& m_consensusoutput );
     };
 
 } // namespace sgns::neoswarm::api

--- a/src/core/sgprocessing/sg_processing_bridge.cpp
+++ b/src/core/sgprocessing/sg_processing_bridge.cpp
@@ -137,11 +137,11 @@ namespace sgns::neoswarm::core
     } // namespace
 
     SGProcessingBridge::SGProcessingBridge()
-        : cfg_( {} )
+        : m_cfg( {} )
     {
     }
     SGProcessingBridge::SGProcessingBridge( Config cfg )
-        : cfg_( std::move( cfg ) )
+        : m_cfg( std::move( cfg ) )
     {
     }
 
@@ -266,7 +266,7 @@ namespace sgns::neoswarm::core
                                                                          std::shared_ptr<boost::asio::io_context> ioc )
     {
         BridgeLogger()->debug( "SubmitJob model={} format={} networkMode={}", model_uri,
-                               InputFormatToFormatString( input_format ), static_cast<int>( cfg_.network_mode_ ) );
+                               InputFormatToFormatString( input_format ), static_cast<int>( m_cfg.network_mode_ ) );
 
         auto json_res = BuildSchemaJson( model_uri, input_uri, input_format, shape );
         if ( !json_res.has_value() )
@@ -274,7 +274,7 @@ namespace sgns::neoswarm::core
             return outcome::failure( json_res.error() );
         }
 
-        if ( cfg_.network_mode_ )
+        if ( m_cfg.network_mode_ )
         {
             auto result = SubmitNetwork( json_res.value() );
             if ( !result.has_value() )

--- a/src/core/sgprocessing/sg_processing_bridge.hpp
+++ b/src/core/sgprocessing/sg_processing_bridge.hpp
@@ -86,7 +86,7 @@ namespace sgns::neoswarm::core
                                                          std::shared_ptr<boost::asio::io_context> ioc );
 
         private:
-        Config cfg_;
+        Config m_cfg;
         network::SuperGeniusClient* client_ = nullptr;
 
         outcome::result<std::vector<uint8_t>> SubmitDirect( const std::string& jsondata,

--- a/src/core/sgprocessing/tensor_interpreter.cpp
+++ b/src/core/sgprocessing/tensor_interpreter.cpp
@@ -26,7 +26,7 @@ namespace sgns::neoswarm::core
 
     void TensorInterpreter::SetTokenizer( std::shared_ptr<Tokenizer> tok )
     {
-        tokenizer_ = std::move( tok );
+        m_tokenizer = std::move( tok );
     }
 
     // -----------------------------------------------------------------------
@@ -75,7 +75,7 @@ namespace sgns::neoswarm::core
         std::vector<float> values( count );
         std::memcpy( values.data(), bytes.data(), bytes.size() );
 
-        if ( tokenizer_ && !values.empty() )
+        if ( m_tokenizer && !values.empty() )
         {
             return DecodeLogits( values );
         }
@@ -197,7 +197,7 @@ namespace sgns::neoswarm::core
     // -----------------------------------------------------------------------
     outcome::result<std::string> TensorInterpreter::DecodeLogits( const std::vector<float>& logits ) const
     {
-        if ( !tokenizer_ )
+        if ( !m_tokenizer )
         {
             return outcome::failure( Error::InferenceFailed );
         }
@@ -205,7 +205,7 @@ namespace sgns::neoswarm::core
         const auto max_it = std::max_element( logits.begin(), logits.end() );
         const int argmax = static_cast<int>( std::distance( logits.begin(), max_it ) );
 
-        auto dec_res = tokenizer_->Decode( { argmax } );
+        auto dec_res = m_tokenizer->Decode( { argmax } );
         if ( !dec_res.has_value() )
         {
             return outcome::failure( dec_res.error() );

--- a/src/core/sgprocessing/tensor_interpreter.hpp
+++ b/src/core/sgprocessing/tensor_interpreter.hpp
@@ -50,7 +50,7 @@ namespace sgns::neoswarm::core
         outcome::result<std::string> Interpret( const std::vector<uint8_t>& bytes, sgns::InputFormat format ) const;
 
         private:
-        std::shared_ptr<Tokenizer> tokenizer_;
+        std::shared_ptr<Tokenizer> m_tokenizer;
 
         outcome::result<std::string> InterpretFloat32( const std::vector<uint8_t>& bytes ) const;
         outcome::result<std::string> InterpretFloat16( const std::vector<uint8_t>& bytes ) const;

--- a/src/core/tokenizer/sentence_piece_tokenizer.cpp
+++ b/src/core/tokenizer/sentence_piece_tokenizer.cpp
@@ -32,8 +32,8 @@ namespace sgns::neoswarm::core
 
     SentencePieceTokenizer::SentencePieceTokenizer( int eos_id, int bos_id )
         : impl_( std::make_unique<Impl>() )
-        , eos_id_( eos_id )
-        , bos_id_( bos_id )
+        , m_eosId( eos_id )
+        , m_bosId( bos_id )
     {
     }
 

--- a/src/core/tokenizer/tokenizer.hpp
+++ b/src/core/tokenizer/tokenizer.hpp
@@ -77,23 +77,23 @@ namespace sgns::neoswarm::core
         outcome::result<std::string> Decode( const std::vector<int>& ids ) const override;
         bool IsEOS( int token_id ) const override
         {
-            return token_id == eos_id_;
+            return token_id == m_eosId;
         }
         int EosTokenId() const override
         {
-            return eos_id_;
+            return m_eosId;
         }
         int BosTokenId() const override
         {
-            return bos_id_;
+            return m_bosId;
         }
         size_t VocabSize() const override;
 
         private:
         struct Impl;
         std::unique_ptr<Impl> impl_;
-        int eos_id_;
-        int bos_id_;
+        int m_eosId;
+        int m_bosId;
     };
 
 } // namespace sgns::neoswarm::core

--- a/src/knowledge/fact_validation.hpp
+++ b/src/knowledge/fact_validation.hpp
@@ -8,7 +8,7 @@
 #ifndef NEOSWARM_KNOWLEDGE_FACTVALIDATION_HPP
 #define NEOSWARM_KNOWLEDGE_FACTVALIDATION_HPP
 
-#include "knowledge_retrieval.hpp"
+#include "m_knowledgeretrieval.hpp"
 #include "common/types.hpp"
 #include <memory>
 #include <string>

--- a/src/knowledge/knowledge_retrieval.cpp
+++ b/src/knowledge/knowledge_retrieval.cpp
@@ -1,11 +1,11 @@
 /**
- * @file       knowledge_retrieval.cpp
+ * @file       m_knowledgeretrieval.cpp
  * @brief      Grokipedia knowledge retrieval implementation
  * @date       2026-05-06
  * @author     Subaskar S (ssivakumar@gnus.ai)
  */
 
-#include "knowledge_retrieval.hpp"
+#include "m_knowledgeretrieval.hpp"
 #include "common/logging.hpp"
 
 #include <algorithm>

--- a/src/knowledge/knowledge_retrieval.hpp
+++ b/src/knowledge/knowledge_retrieval.hpp
@@ -1,5 +1,5 @@
 /**
- * @file       knowledge_retrieval.hpp
+ * @file       m_knowledgeretrieval.hpp
  * @brief      Query embedding and ANN search for Grokipedia facts (PTDS §8.2)
  * @date       2026-05-06
  * @author     Subaskar S (ssivakumar@gnus.ai)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,10 +49,10 @@ struct Args
     int port_ = 50051;
     std::string db_path_ = "./reputation.db";
     std::string key_file_ = "./node.key";
-    std::string knowledge_path_;
+    std::string m_knowledgepath_;
     int max_tokens_ = 512;
     float temperature_ = 0.7f;
-    std::string sg_endpoint_ = "localhost:50051";
+    std::string sg_m_endpoint = "localhost:50051";
     std::string sg_tls_ca_;
     std::string sg_tls_cert_;
     std::string config_path_;
@@ -125,14 +125,14 @@ static void LoadConfigFile( const std::string& path, Args& args )
         args.db_path_ = j["db"].get<std::string>();
     if ( j.contains( "key" ) && args.key_file_ == "./node.key" )
         args.key_file_ = j["key"].get<std::string>();
-    if ( j.contains( "knowledge" ) && args.knowledge_path_.empty() )
-        args.knowledge_path_ = j["knowledge"].get<std::string>();
+    if ( j.contains( "knowledge" ) && args.m_knowledgepath_.empty() )
+        args.m_knowledgepath_ = j["knowledge"].get<std::string>();
     if ( j.contains( "max_tokens" ) && args.max_tokens_ == 512 )
         args.max_tokens_ = j["max_tokens"].get<int>();
     if ( j.contains( "temperature" ) && args.temperature_ == 0.7f )
         args.temperature_ = j["temperature"].get<float>();
-    if ( j.contains( "sg_endpoint" ) && args.sg_endpoint_ == "localhost:50051" )
-        args.sg_endpoint_ = j["sg_endpoint"].get<std::string>();
+    if ( j.contains( "sg_endpoint" ) && args.sg_m_endpoint == "localhost:50051" )
+        args.sg_m_endpoint = j["sg_endpoint"].get<std::string>();
     if ( j.contains( "network" ) && !args.network_ )
         args.network_ = j["network"].get<bool>();
     if ( j.contains( "verbose" ) && !args.verbose_ )
@@ -170,7 +170,7 @@ static Args ParseArgs( int argc, char** argv )
         else if ( a == "--key" )
             args.key_file_ = next();
         else if ( a == "--knowledge" )
-            args.knowledge_path_ = next();
+            args.m_knowledgepath_ = next();
         else if ( a == "--max-tokens" )
             args.max_tokens_ = std::stoi( next() );
         else if ( a == "--temperature" )
@@ -178,7 +178,7 @@ static Args ParseArgs( int argc, char** argv )
         else if ( a == "--config" )
             args.config_path_ = next();
         else if ( a == "--sg-endpoint" )
-            args.sg_endpoint_ = next();
+            args.sg_m_endpoint = next();
         else if ( a == "--sg-tls-ca" )
             args.sg_tls_ca_ = next();
         else if ( a == "--sg-tls-cert" )
@@ -286,12 +286,12 @@ int main( int argc, char** argv )
     cfg.grammar_model_path_ = args.grammar_model_path_;
     cfg.math_model_path_ = args.math_model_path_;
     cfg.reputation_db_path_ = args.db_path_;
-    cfg.knowledge_facts_ = args.knowledge_path_;
+    cfg.m_knowledgefacts_ = args.m_knowledgepath_;
     cfg.enable_network_ = args.network_;
-    cfg.enable_knowledge_ = true;
+    cfg.enable_m_knowledge = true;
     (void) args.port_;
     cfg.node_key_file_ = args.key_file_;
-    cfg.sg_endpoint_ = args.sg_endpoint_;
+    cfg.sg_m_endpoint = args.sg_m_endpoint;
     cfg.sg_tls_ca_ = args.sg_tls_ca_;
     cfg.sg_tls_cert_ = args.sg_tls_cert_;
 

--- a/src/network/result_aggregation.cpp
+++ b/src/network/result_aggregation.cpp
@@ -32,7 +32,7 @@ namespace sgns::neoswarm::network
     // -----------------------------------------------------------------------
     void ResultAggregation::Submit( const NodeOutput& output )
     {
-        std::lock_guard<std::mutex> lock( mutex_ );
+        std::lock_guard<std::mutex> lock( m_mutex );
         if ( results_.size() >= cfg_.max_responses_ )
         {
             return;
@@ -51,7 +51,7 @@ namespace sgns::neoswarm::network
     // -----------------------------------------------------------------------
     outcome::result<std::vector<NodeOutput>> ResultAggregation::Collect()
     {
-        std::unique_lock<std::mutex> lock( mutex_ );
+        std::unique_lock<std::mutex> lock( m_mutex );
         bool timed_out =
             !cv_.wait_for( lock, cfg_.timeout_, [this] { return done_ || results_.size() >= cfg_.max_responses_; } );
 
@@ -69,7 +69,7 @@ namespace sgns::neoswarm::network
     // -----------------------------------------------------------------------
     void ResultAggregation::Reset()
     {
-        std::lock_guard<std::mutex> lock( mutex_ );
+        std::lock_guard<std::mutex> lock( m_mutex );
         results_.clear();
         done_ = false;
     }
@@ -79,7 +79,7 @@ namespace sgns::neoswarm::network
     // -----------------------------------------------------------------------
     size_t ResultAggregation::ResponseCount() const
     {
-        std::lock_guard<std::mutex> lock( mutex_ );
+        std::lock_guard<std::mutex> lock( m_mutex );
         return results_.size();
     }
 

--- a/src/network/result_aggregation.hpp
+++ b/src/network/result_aggregation.hpp
@@ -58,7 +58,7 @@ namespace sgns::neoswarm::network
         private:
         Config cfg_;
         std::vector<NodeOutput> results_;
-        mutable std::mutex mutex_;
+        mutable std::mutex m_mutex;
         std::condition_variable cv_;
         bool done_ = false;
     };

--- a/src/network/sg_client/sg_channel_manager.cpp
+++ b/src/network/sg_client/sg_channel_manager.cpp
@@ -36,8 +36,8 @@ namespace sgns::neoswarm::network
             return outcome::success();
         }
 
-        bool isLocalhost = m_cfg.endpoint_.find( "localhost" ) != std::string::npos ||
-                           m_cfg.endpoint_.find( "127.0.0.1" ) != std::string::npos;
+        bool isLocalhost = m_cfg.m_endpoint.find( "localhost" ) != std::string::npos ||
+                           m_cfg.m_endpoint.find( "127.0.0.1" ) != std::string::npos;
 
         std::shared_ptr<grpc::ChannelCredentials> creds;
 
@@ -50,13 +50,13 @@ namespace sgns::neoswarm::network
                 sslOpts.pem_root_certs = m_cfg.tls_ca_path_;
             }
             creds = grpc::SslCredentials( sslOpts );
-            ChannelLogger()->info( "Creating TLS-secured channel to {}", m_cfg.endpoint_ );
+            ChannelLogger()->info( "Creating TLS-secured channel to {}", m_cfg.m_endpoint );
         }
         else
         {
             // Localhost without TLS certs — insecure with warning
             creds = grpc::InsecureChannelCredentials();
-            ChannelLogger()->warn( "Creating INSECURE channel to {} — TLS not configured", m_cfg.endpoint_ );
+            ChannelLogger()->warn( "Creating INSECURE channel to {} — TLS not configured", m_cfg.m_endpoint );
         }
 
         grpc::ChannelArguments args;
@@ -64,15 +64,15 @@ namespace sgns::neoswarm::network
         args.SetInt( GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 10000 );
         args.SetInt( GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1 );
 
-        channel_ = grpc::CreateCustomChannel( m_cfg.endpoint_, creds, args );
+        channel_ = grpc::CreateCustomChannel( m_cfg.m_endpoint, creds, args );
 
         if ( !channel_ )
         {
-            ChannelLogger()->error( "Failed to create channel to {}", m_cfg.endpoint_ );
+            ChannelLogger()->error( "Failed to create channel to {}", m_cfg.m_endpoint );
             return outcome::failure( Error::NetworkError );
         }
 
-        ChannelLogger()->info( "Channel created to {}", m_cfg.endpoint_ );
+        ChannelLogger()->info( "Channel created to {}", m_cfg.m_endpoint );
         return outcome::success();
 
     }

--- a/src/network/sg_client/sg_channel_manager.hpp
+++ b/src/network/sg_client/sg_channel_manager.hpp
@@ -31,7 +31,7 @@ namespace sgns::neoswarm::network
         public:
         struct Config
         {
-            std::string endpoint_ = "localhost:50051";
+            std::string m_endpoint = "localhost:50051";
             std::string tls_ca_path_;
             std::string tls_cert_path_;
             std::chrono::seconds timeout_{ 30 };

--- a/src/network/sg_client/sg_result_collector.cpp
+++ b/src/network/sg_client/sg_result_collector.cpp
@@ -29,7 +29,7 @@ namespace sgns::neoswarm::network
 
         // Timeout-bounded collection using condition_variable
         // (matches existing ResultAggregation pattern)
-        std::mutex mutex_;
+        std::mutex m_mutex;
         std::condition_variable cv_;
         bool resultReady_ = false;
         std::vector<uint8_t> resultData_;
@@ -61,7 +61,7 @@ namespace sgns::neoswarm::network
 
         // Block until result arrives or timeout expires
         // Pattern matches ResultAggregation::Collect() in src/network/result_aggregation.cpp
-        std::unique_lock<std::mutex> lock( m_impl->mutex_ );
+        std::unique_lock<std::mutex> lock( m_impl->m_mutex );
 
         bool gotResult = m_impl->cv_.wait_for( lock, timeout, [this] { return m_impl->resultReady_; } );
 

--- a/src/network/sg_client/super_genius_client.cpp
+++ b/src/network/sg_client/super_genius_client.cpp
@@ -31,7 +31,7 @@ namespace sgns::neoswarm::network
         std::unique_ptr<SGChannelManager> channelMgr_;
         std::unique_ptr<SGJobSubmitter> jobSubmitter_;
         std::unique_ptr<SGResultCollector> resultCollector_;
-        bool connected_ = false;
+        bool m_connected = false;
     };
 
     SuperGeniusClient::SuperGeniusClient( Config cfg )
@@ -54,14 +54,14 @@ namespace sgns::neoswarm::network
 
         // Create channel manager with configured endpoint and TLS settings
         SGChannelManager::Config chCfg;
-        chCfg.endpoint_ = m_impl->m_cfg.endpoint_;
+        chCfg.m_endpoint = m_impl->m_cfg.m_endpoint;
         chCfg.tls_ca_path_ = m_impl->m_cfg.tls_ca_path_;
         chCfg.tls_cert_path_ = m_impl->m_cfg.tls_cert_path_;
         chCfg.timeout_ = m_impl->m_cfg.channel_timeout_;
 
         m_impl->channelMgr_ = std::make_unique<SGChannelManager>( std::move( chCfg ) );
 
-        ClientLogger()->info( "SuperGeniusClient initialized — endpoint={}", m_impl->m_cfg.endpoint_ );
+        ClientLogger()->info( "SuperGeniusClient initialized — endpoint={}", m_impl->m_cfg.m_endpoint );
         return outcome::success();
     }
 
@@ -76,7 +76,7 @@ namespace sgns::neoswarm::network
         auto result = m_impl->channelMgr_->CreateChannel();
         if ( !result.has_value() )
         {
-            ClientLogger()->warn( "Failed to create channel to {} — SuperGenius unavailable", m_impl->m_cfg.endpoint_ );
+            ClientLogger()->warn( "Failed to create channel to {} — SuperGenius unavailable", m_impl->m_cfg.m_endpoint );
             return result;
         }
 
@@ -95,13 +95,13 @@ namespace sgns::neoswarm::network
         auto health = m_impl->channelMgr_->HealthCheck();
         if ( health.has_value() && health.value() )
         {
-            m_impl->connected_ = true;
-            ClientLogger()->info( "Connected to SuperGenius at {}", m_impl->m_cfg.endpoint_ );
+            m_impl->m_connected = true;
+            ClientLogger()->info( "Connected to SuperGenius at {}", m_impl->m_cfg.m_endpoint );
         }
         else
         {
             ClientLogger()->warn( "Channel created but health check failed — may be starting up" );
-            m_impl->connected_ = true;
+            m_impl->m_connected = true;
         }
 
         return outcome::success();
@@ -110,7 +110,7 @@ namespace sgns::neoswarm::network
     outcome::result<std::vector<uint8_t>> SuperGeniusClient::SubmitJob( const std::string& gnusSchemaJson )
     {
         // Verify we are connected — attempt reconnect if channel is dead
-        if ( !m_impl->connected_ || !m_impl->channelMgr_->IsConnected() )
+        if ( !m_impl->m_connected || !m_impl->channelMgr_->IsConnected() )
         {
             ClientLogger()->warn( "Channel not connected, attempting reconnect" );
             auto reconnectResult = m_impl->channelMgr_->Reconnect();
@@ -119,7 +119,7 @@ namespace sgns::neoswarm::network
                 ClientLogger()->error( "Reconnect failed — cannot submit job" );
                 return outcome::failure( Error::NetworkError );
             }
-            m_impl->connected_ = true;
+            m_impl->m_connected = true;
         }
 
         if ( !m_impl->jobSubmitter_ || !m_impl->resultCollector_ )
@@ -155,13 +155,13 @@ namespace sgns::neoswarm::network
         m_impl->jobSubmitter_.reset();
         m_impl->resultCollector_.reset();
         m_impl->channelMgr_.reset();
-        m_impl->connected_ = false;
+        m_impl->m_connected = false;
         ClientLogger()->info( "SuperGeniusClient disconnected" );
     }
 
     bool SuperGeniusClient::IsConnected() const noexcept
     {
-        return m_impl->connected_ && m_impl->channelMgr_ && m_impl->channelMgr_->IsConnected();
+        return m_impl->m_connected && m_impl->channelMgr_ && m_impl->channelMgr_->IsConnected();
     }
 
 } // namespace sgns::neoswarm::network

--- a/src/network/sg_client/super_genius_client.hpp
+++ b/src/network/sg_client/super_genius_client.hpp
@@ -48,7 +48,7 @@ namespace sgns::neoswarm::network
          */
         struct Config
         {
-            std::string endpoint_ = "localhost:50051";   ///< SuperGenius node address
+            std::string m_endpoint = "localhost:50051";   ///< SuperGenius node address
             std::string tls_ca_path_;                    ///< TLS CA certificate bundle
             std::string tls_cert_path_;                  ///< TLS client certificate
             std::chrono::seconds channel_timeout_{ 30 }; ///< Channel creation timeout

--- a/src/reputation/reputation_scoring.cpp
+++ b/src/reputation/reputation_scoring.cpp
@@ -72,7 +72,7 @@ namespace sgns::neoswarm::reputation
                                               const InferenceResponse& response,
                                               double median_latency_ms,
                                               std::optional<std::string> ground_truth,
-                                              const std::string& consensus_output ) const
+                                              const std::string& m_consensusoutput ) const
     {
         NodeReputation updated = old;
 
@@ -84,7 +84,7 @@ namespace sgns::neoswarm::reputation
         }
         else
         {
-            accuracy = ( response.output_ == consensus_output ) ? 1.0 : 0.0;
+            accuracy = ( response.output_ == m_consensusoutput ) ? 1.0 : 0.0;
         }
 
         double d_acc = DeltaAccuracy( has_gt, accuracy );

--- a/src/reputation/reputation_scoring.hpp
+++ b/src/reputation/reputation_scoring.hpp
@@ -44,14 +44,14 @@ namespace sgns::neoswarm::reputation
          * @param response          Inference response from this node.
          * @param median_latency_ms Median latency across all responding nodes (ms).
          * @param ground_truth      Correct answer if available.
-         * @param consensus_output  The winning consensus output string.
+         * @param m_consensusoutput  The winning consensus output string.
          * @return                  Updated NodeReputation.
          */
         NodeReputation Update( const NodeReputation& old,
                                const InferenceResponse& response,
                                double median_latency_ms,
                                std::optional<std::string> ground_truth,
-                               const std::string& consensus_output ) const;
+                               const std::string& m_consensusoutput ) const;
 
         /**
          * @brief Compute the accuracy delta component.


### PR DESCRIPTION
## Summary
Fix all remaining member variables with `_` suffix → `m_` prefix.

## Changes
- core_engine_ → m_coreEngine
- grammar_spec_ → m_grammarSpec  
- math_spec_ → m_mathSpec
- router_ → m_router
- p2p_node_ → m_p2pNode
- aggregation_ → m_aggregation
- knowledge_ → m_knowledge
- scoring_ → m_scoring
- sg_client_ → m_sgClient
- ctx_ → m_ctx, processor_ → m_processor
- endpoint_ → m_endpoint, connected_ → m_connected
- mutex_ → m_mutex
- And more...

21 files, 302 lines