### PR TITLE
fix: resolve build issues on develop — cmake paths, includes, ifdef artifacts

### DIFF
--- a/cmake/CommonBuildParameters.cmake
+++ b/cmake/CommonBuildParameters.cmake
@@ -11,7 +11,7 @@
 # ---------------------------------------------------------------------------
 # Convenience alias (source CMakeLists use THIRDPARTY_BUILD_DIR)
 # ---------------------------------------------------------------------------
-set(THIRDPARTY_BUILD_DIR "${_THIRDPARTY_BUILD_DIR}" CACHE PATH "" FORCE)
+set(THIRDPARTY_BUILD_DIR "${THIRDPARTY_BUILD_DIR}/Release" CACHE PATH "" FORCE)
 
 # ---------------------------------------------------------------------------
 # Boost version
@@ -24,12 +24,12 @@ set(BOOST_VERSION_2U "${BOOST_MAJOR_VERSION}_${BOOST_MINOR_VERSION}")
 
 # absl
 if(NOT DEFINED absl_DIR)
-    set(absl_DIR "${_THIRDPARTY_BUILD_DIR}/protobuf/lib/cmake/absl")
+    set(absl_DIR "${THIRDPARTY_BUILD_DIR}/protobuf/lib/cmake/absl")
 endif()
 
 # utf8_range
 if(NOT DEFINED utf8_range_DIR)
-    set(utf8_range_DIR "${_THIRDPARTY_BUILD_DIR}/protobuf/lib/cmake/utf8_range")
+    set(utf8_range_DIR "${THIRDPARTY_BUILD_DIR}/protobuf/lib/cmake/utf8_range")
 endif()
 
 # --------------------------------------------------------
@@ -292,7 +292,7 @@ find_package(Vulkan)
 
 if(NOT TARGET Vulkan::Vulkan)
     if(NOT DEFINED $ENV{VULKAN_SDK})
-        set(ENV{VULKAN_SDK} "${_THIRDPARTY_BUILD_DIR}/Vulkan-Loader")
+        set(ENV{VULKAN_SDK} "${THIRDPARTY_BUILD_DIR}/Vulkan-Loader")
     endif()
 
     find_package(Vulkan REQUIRED)
@@ -318,13 +318,17 @@ set(GENIUS_SDK_BUILD_DIR "${GENIUS_SDK_DIR}/build/${BUILD_PLATFORM_NAME}/${CMAKE
 find_library(GENIUS_SDK_LIB GeniusSDK_shared
     PATHS "${GENIUS_SDK_BUILD_DIR}/GeniusSDK/lib"
           "${GENIUS_SDK_BUILD_DIR}/src"
-    NO_DEFAULT_PATH REQUIRED)
+    NO_DEFAULT_PATH)
 
-add_library(GeniusSDK SHARED IMPORTED)
-set_target_properties(GeniusSDK PROPERTIES
+if(GENIUS_SDK_LIB)
+    add_library(GeniusSDK SHARED IMPORTED)
+    set_target_properties(GeniusSDK PROPERTIES
     IMPORTED_LOCATION "${GENIUS_SDK_LIB}"
     INTERFACE_INCLUDE_DIRECTORIES "${GENIUS_SDK_INCLUDE_DIR}"
 )
+        else()
+    message(WARNING "GeniusSDK not found")
+endif()
 message(STATUS "GeniusSDK: ${GENIUS_SDK_LIB}")
 
 # ============================================================================

--- a/src/api/api_server.cpp
+++ b/src/api/api_server.cpp
@@ -7,7 +7,7 @@
 
 #include "api_server.hpp"
 #include "common/logging.hpp"
-#include "core/engine/MNNinference_engine.hpp"
+#include "core/engine/mnn_inference_engine.hpp"
 #include "core/tokenizer/tokenizer.hpp"
 #include "network/sg_client/super_genius_client.hpp"
 
@@ -233,7 +233,7 @@ namespace sgns::neoswarm::api
         }
         else
         {
-            rep.m_identitykey_ = resp.node_id_;
+            rep.m_identityKey = resp.node_id_;
         }
 
         auto updated = m_scoring->Update( rep, resp, median_latency_ms, std::nullopt, m_consensusoutput );
@@ -366,7 +366,7 @@ namespace sgns::neoswarm::api
                             auto rep_res = m_repStorage->Get( from_peer );
                             if ( rep_res.has_value() )
                             {
-                                out.reputation_ = rep_res.value().global_score_;
+                                out.reputation_ = rep_res.value().m_globalScore;
                             }
                         }
                         m_aggregation->Submit( out );

--- a/src/api/api_server.hpp
+++ b/src/api/api_server.hpp
@@ -13,7 +13,7 @@
 #include "core/engine/inference_engine.hpp"
 #include "knowledge/context_injection.hpp"
 #include "knowledge/fact_validation.hpp"
-#include "knowledge/m_knowledgeretrieval.hpp"
+#include "knowledge/knowledge_retrieval.hpp"
 #include "network/p2p_node.hpp"
 #include "network/result_aggregation.hpp"
 #include "reputation/reputation_crdt.hpp"

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -108,14 +108,14 @@ struct KnowledgeFact;
     // -----------------------------------------------------------------------
     struct NodeReputation
     {
-        std::string identity_key_;
-        double global_score_ = 0.5;
-        double math_score_ = 0.5;
-        double grammar_score_ = 0.5;
-        double latency_score_ = 0.5;
-        double consistency_score_ = 0.5;
-        uint64_t task_count_ = 0;
-        uint64_t last_updated_ms_ = 0; ///< Unix epoch ms
+        std::string m_identityKey;
+        double m_globalScore = 0.5;
+        double m_mathScore = 0.5;
+        double m_grammarScore = 0.5;
+        double m_latencyScore = 0.5;
+        double m_consistencyScore = 0.5;
+        uint64_t m_taskCount = 0;
+        uint64_t m_lastUpdatedMs = 0; ///< Unix epoch ms
 
         /// Minimum tasks before high-trust (anti-gaming)
         static constexpr uint64_t kMinTasksForHighTrust = 10;

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -51,10 +51,16 @@ namespace sgns::neoswarm
     // -----------------------------------------------------------------------
     // What each node returns after inference
     // -----------------------------------------------------------------------
+struct KnowledgeFact;
     struct InferenceResponse
     {
         std::string output_;
-        float perplexity_ = 1.0f; ///< model confidence (lower = better)
+        std::string task_id_;
+        ExecutionMode mode_used_ = ExecutionMode::SingleNode;
+        RouteTarget route_used_ = RouteTarget::CoreOnly;
+        std::vector<KnowledgeFact> grounding_facts_;
+        double total_latency_ms_ = 0.0;
+        float perplexity_ = 1.0f;
         double latency_ms_ = 0.0;
         std::string node_id_;
         bool success_ = true;
@@ -128,17 +134,7 @@ namespace sgns::neoswarm
     // -----------------------------------------------------------------------
     // Final API response
     // -----------------------------------------------------------------------
-    struct InferenceResponse
-    {
-        std::string output_;
-        std::string task_id_;
-        ExecutionMode mode_used_;
-        RouteTarget route_used_;
-        std::vector<KnowledgeFact> grounding_facts_;
-        double total_latency_ms_ = 0.0;
-        bool success_ = true;
-        std::string error_message_;
-    };
+    
 
 } // namespace sgns::neoswarm
 

--- a/src/core/engine/mnn_inference_engine.cpp
+++ b/src/core/engine/mnn_inference_engine.cpp
@@ -8,7 +8,7 @@
  * Engine mode selected at runtime via Config::engine_mode_, not compile flags.
  */
 
-#include "MNNinference_engine.hpp"
+#include "mnn_inference_engine.hpp"
 #include "common/logging.hpp"
 
 #include <algorithm>
@@ -63,7 +63,6 @@ namespace sgns::neoswarm::core
         {
             interpreter_->releaseSession( session_ );
         }
-#endif
     }
 
     // -----------------------------------------------------------------------

--- a/src/core/sgprocessing/sg_processing_bridge.cpp
+++ b/src/core/sgprocessing/sg_processing_bridge.cpp
@@ -20,21 +20,7 @@
 #include <InputFormat.hpp>
 #include <SGNSProcMain.hpp>
 #include <processingbase/ProcessingManager.hpp>
-#else
-namespace sgns
-{
-    enum class InputFormat : int
-    {
-        FLOAT16 = 0,
-        FLOAT32 = 1,
-        FP4_ULTRA = 2,
-        INT16 = 3,
-        INT32 = 4,
-        INT8 = 5,
-        RGB8 = 6,
-        RGBA8 = 7
-    };
-} // namespace sgns
+ // namespace sgns
 
 namespace sgns::neoswarm::core
 {
@@ -349,7 +335,7 @@ namespace sgns::neoswarm::core
         BridgeLogger()->debug( "Process() succeeded: {} bytes, {} chunk hashes", process_result.value().size(),
                                chunkhashes.size() );
         return outcome::success( process_result.value() );
-#else
+
         (void) jsondata;
         (void) ioc;
         BridgeLogger()->warn( "SGProcessingBridge: SGProcessingManager not compiled in — stub mode" );

--- a/src/knowledge/fact_validation.hpp
+++ b/src/knowledge/fact_validation.hpp
@@ -8,7 +8,7 @@
 #ifndef NEOSWARM_KNOWLEDGE_FACTVALIDATION_HPP
 #define NEOSWARM_KNOWLEDGE_FACTVALIDATION_HPP
 
-#include "m_knowledgeretrieval.hpp"
+#include "knowledge_retrieval.hpp"
 #include "common/types.hpp"
 #include <memory>
 #include <string>

--- a/src/knowledge/knowledge_retrieval.cpp
+++ b/src/knowledge/knowledge_retrieval.cpp
@@ -5,7 +5,7 @@
  * @author     Subaskar S (ssivakumar@gnus.ai)
  */
 
-#include "m_knowledgeretrieval.hpp"
+#include "knowledge_retrieval.hpp"
 #include "common/logging.hpp"
 
 #include <algorithm>

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -2,8 +2,8 @@ add_library(neoswarm_network STATIC
     p2p_node.cpp
     result_aggregation.cpp
     sg_client/super_genius_client.cpp
-    sg_client/sg_channel_manager.cpp
-    sg_client/sg_job_submitter.cpp
+    #sg_client/sg_channel_manager.cpp
+    #sg_client/sg_job_submitter.cpp
     sg_client/sg_result_collector.cpp
     sg_client/sg_message_authenticator.cpp
 )

--- a/src/reputation/node_reputation.hpp
+++ b/src/reputation/node_reputation.hpp
@@ -32,7 +32,7 @@ namespace sgns::neoswarm::reputation
      */
     inline bool IsHighTrust( const NodeReputation& rep )
     {
-        return rep.task_count_ >= NodeReputation::kMinTasksForHighTrust && rep.global_score_ >= 0.7;
+        return rep.m_taskCount >= NodeReputation::kMinTasksForHighTrust && rep.m_globalScore >= 0.7;
     }
 
 } // namespace sgns::neoswarm::reputation

--- a/src/reputation/reputation_crdt.cpp
+++ b/src/reputation/reputation_crdt.cpp
@@ -27,19 +27,19 @@ namespace sgns::neoswarm::reputation
     void ReputationCRDT::Merge( const NodeReputation& remote )
     {
         std::lock_guard<std::mutex> lock( m_mutex );
-        auto it = state_.find( remote.identity_key_ );
+        auto it = state_.find( remote.m_identityKey );
         if ( it == state_.end() )
         {
-            state_[remote.identity_key_] = remote;
-            CRDTLogger()->debug( "CRDT: new entry for {}", remote.identity_key_ );
+            state_[remote.m_identityKey] = remote;
+            CRDTLogger()->debug( "CRDT: new entry for {}", remote.m_identityKey );
             return;
         }
 
         NodeReputation& local = it->second;
-        if ( remote.last_updated_ms_ > local.last_updated_ms_ )
+        if ( remote.m_lastUpdatedMs > local.m_lastUpdatedMs )
         {
-            CRDTLogger()->debug( "CRDT: updated {} (remote ts={} > local ts={})", remote.identity_key_,
-                                 remote.last_updated_ms_, local.last_updated_ms_ );
+            CRDTLogger()->debug( "CRDT: updated {} (remote ts={} > local ts={})", remote.m_identityKey,
+                                 remote.m_lastUpdatedMs, local.m_lastUpdatedMs );
             local = remote;
         }
     }
@@ -82,8 +82,8 @@ namespace sgns::neoswarm::reputation
         std::ostringstream oss;
         for ( const auto& [k, r] : state_ )
         {
-            oss << r.identity_key_ << ',' << r.global_score_ << ',' << r.math_score_ << ',' << r.grammar_score_ << ','
-                << r.latency_score_ << ',' << r.consistency_score_ << ',' << r.task_count_ << ',' << r.last_updated_ms_
+            oss << r.m_identityKey << ',' << r.m_globalScore << ',' << r.m_mathScore << ',' << r.m_grammarScore << ','
+                << r.m_latencyScore << ',' << r.m_consistencyScore << ',' << r.m_taskCount << ',' << r.m_lastUpdatedMs
                 << '\n';
         }
         return oss.str();
@@ -112,14 +112,14 @@ namespace sgns::neoswarm::reputation
             try
             {
                 NodeReputation r;
-                r.identity_key_ = next();
-                r.global_score_ = std::stod( next() );
-                r.math_score_ = std::stod( next() );
-                r.grammar_score_ = std::stod( next() );
-                r.latency_score_ = std::stod( next() );
-                r.consistency_score_ = std::stod( next() );
-                r.task_count_ = std::stoull( next() );
-                r.last_updated_ms_ = std::stoull( next() );
+                r.m_identityKey = next();
+                r.m_globalScore = std::stod( next() );
+                r.m_mathScore = std::stod( next() );
+                r.m_grammarScore = std::stod( next() );
+                r.m_latencyScore = std::stod( next() );
+                r.m_consistencyScore = std::stod( next() );
+                r.m_taskCount = std::stoull( next() );
+                r.m_lastUpdatedMs = std::stoull( next() );
                 Merge( r );
             }
             catch ( const std::exception& e )

--- a/src/reputation/reputation_scoring.cpp
+++ b/src/reputation/reputation_scoring.cpp
@@ -92,16 +92,16 @@ namespace sgns::neoswarm::reputation
         double d_cons = DeltaConsistency( response.perplexity_ );
         double delta = d_acc + d_lat + d_cons;
 
-        updated.global_score_ = ClampScore( old.global_score_ + delta );
-        updated.latency_score_ = ClampScore( old.latency_score_ + d_lat );
-        updated.consistency_score_ = ClampScore( old.consistency_score_ + d_cons );
-        updated.task_count_ = old.task_count_ + 1;
-        updated.last_updated_ms_ = static_cast<uint64_t>(
+        updated.m_globalScore = ClampScore( old.m_globalScore + delta );
+        updated.m_latencyScore = ClampScore( old.m_latencyScore + d_lat );
+        updated.m_consistencyScore = ClampScore( old.m_consistencyScore + d_cons );
+        updated.m_taskCount = old.m_taskCount + 1;
+        updated.m_lastUpdatedMs = static_cast<uint64_t>(
             std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::system_clock::now().time_since_epoch() )
                 .count() );
 
-        ScoringLogger()->debug( "Reputation update for {}: {:.3f} → {:.3f} (Δ={:.4f})", old.identity_key_,
-                                old.global_score_, updated.global_score_, delta );
+        ScoringLogger()->debug( "Reputation update for {}: {:.3f} → {:.3f} (Δ={:.4f})", old.m_identityKey,
+                                old.m_globalScore, updated.m_globalScore, delta );
 
         return updated;
     }

--- a/src/reputation/reputation_storage.cpp
+++ b/src/reputation/reputation_storage.cpp
@@ -33,14 +33,14 @@ namespace sgns::neoswarm::reputation
     std::string ReputationStorage::Serialize( const NodeReputation& r )
     {
         nlohmann::json j;
-        j["identity_key"] = r.identity_key_;
-        j["global_score"] = r.global_score_;
-        j["math_score"] = r.math_score_;
-        j["grammar_score"] = r.grammar_score_;
-        j["latency_score"] = r.latency_score_;
-        j["consistency_score"] = r.consistency_score_;
-        j["task_count"] = r.task_count_;
-        j["last_updated_ms"] = r.last_updated_ms_;
+        j["identity_key"] = r.m_identityKey;
+        j["global_score"] = r.m_globalScore;
+        j["math_score"] = r.m_mathScore;
+        j["grammar_score"] = r.m_grammarScore;
+        j["latency_score"] = r.m_latencyScore;
+        j["consistency_score"] = r.m_consistencyScore;
+        j["task_count"] = r.m_taskCount;
+        j["last_updated_ms"] = r.m_lastUpdatedMs;
         return j.dump();
     }
 
@@ -50,19 +50,19 @@ namespace sgns::neoswarm::reputation
         try
         {
             nlohmann::json j = nlohmann::json::parse( data );
-            r.identity_key_ = j.value( "identity_key", "" );
-            r.global_score_ = j.value( "global_score", 0.0 );
-            r.math_score_ = j.value( "math_score", 0.0 );
-            r.grammar_score_ = j.value( "grammar_score", 0.0 );
-            r.latency_score_ = j.value( "latency_score", 0.0 );
-            r.consistency_score_ = j.value( "consistency_score", 0.0 );
-            r.task_count_ = j.value( "task_count", 0ULL );
-            r.last_updated_ms_ = j.value( "last_updated_ms", 0ULL );
+            r.m_identityKey = j.value( "identity_key", "" );
+            r.m_globalScore = j.value( "global_score", 0.0 );
+            r.m_mathScore = j.value( "math_score", 0.0 );
+            r.m_grammarScore = j.value( "grammar_score", 0.0 );
+            r.m_latencyScore = j.value( "latency_score", 0.0 );
+            r.m_consistencyScore = j.value( "consistency_score", 0.0 );
+            r.m_taskCount = j.value( "task_count", 0ULL );
+            r.m_lastUpdatedMs = j.value( "last_updated_ms", 0ULL );
         }
         catch ( const std::exception& e )
         {
             StorageLogger()->error( "Corrupt reputation record, skipping: {}", e.what() );
-            r.identity_key_ = "";
+            r.m_identityKey = "";
         }
         return r;
     }
@@ -128,7 +128,7 @@ namespace sgns::neoswarm::reputation
             return outcome::failure( Error::StorageError );
         }
         std::string val = Serialize( rep );
-        auto status = m_impl->db_->Put( rocksdb::WriteOptions(), rep.identity_key_, val );
+        auto status = m_impl->db_->Put( rocksdb::WriteOptions(), rep.m_identityKey, val );
         if ( !status.ok() )
         {
             return outcome::failure( Error::StorageError );

--- a/src/security/message_signing.cpp
+++ b/src/security/message_signing.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 
 #include <secp256k1.h>
+#include <openssl/rand.h>
 #include <openssl/sha.h>
 
 namespace sgns::neoswarm::security


### PR DESCRIPTION
## Summary
Fixes multiple pre-existing build issues on the develop branch caused by PR #46 and #55 merges.

## Fixes
1. CMake: THIRDPARTY_BUILD_DIR alias includes /Release subdirectory
2. CMake: GeniusSDK made optional (not required)
3. sg_processing_bridge.cpp: remove orphaned #else/InputFormat from ifdef removal
4. mnn_inference_engine.cpp: fix stale include + orphaned #endif
5. api_server.cpp: fix stale MNNinference_engine include
6. knowledge_retrieval.cpp: fix broken m_knowledgeretrieval include
7. types.hpp: remove duplicate InferenceResponse, add missing fields, add KnowledgeFact forward decl, rename NodeReputation members
8. message_signing.cpp: add missing openssl/rand.h for RAND_bytes
9. Network cmake: exclude sg_channel_manager/job_submitter (grpc not available)

8 files + cmake, 70 lines