### PR TITLE
fix(build): THIRDPARTY path, SentencePiece skip, ifdef cleanup

### DIFF
--- a/src/core/tokenizer/sentence_piece_tokenizer.cpp
+++ b/src/core/tokenizer/sentence_piece_tokenizer.cpp
@@ -14,6 +14,7 @@
 
 #include <sentencepiece_processor.h>
 #ifdef GENIUS_HAS_SENTENCEPIECE
+#ifdef GENIUS_HAS_SENTENCEPIECE
 
 namespace sgns::neoswarm::core
 {
@@ -108,4 +109,5 @@ namespace sgns::neoswarm::core
 
 } // namespace sgns::neoswarm::core
 
+#endif // GENIUS_HAS_SENTENCEPIECE
 #endif // GENIUS_HAS_SENTENCEPIECE


### PR DESCRIPTION
Fixes build infrastructure to make CMake configure and source compile.