### PR TITLE
fix: SuperGeniusClient GRPC guards + test CMakeLists restore

### DIFF
--- a/src/api/api_server.cpp
+++ b/src/api/api_server.cpp
@@ -186,7 +186,7 @@ namespace sgns::neoswarm::api
 #endif // GENIUS_HAS_GRPC
 
         // 7. Knowledge
-        if ( m_cfg.enable_m_knowledge )
+        if ( m_cfg.m_enableKnowledge )
         {
             knowledge::KnowledgeRetrieval::Config k_cfg;
             k_cfg.m_factsPath = m_cfg.m_knowledgefacts_;

--- a/src/api/api_server.cpp
+++ b/src/api/api_server.cpp
@@ -74,7 +74,7 @@ namespace sgns::neoswarm::api
         core::MNNInferenceEngine::Config engine_cfg;
         engine_cfg.engine_m_mode = m_cfg.m_enableSgProcessing ? "sgprocessing" : "interpreter";
         engine_cfg.backend_ = "vulkan"; // cross-platform; MoltenVK on Apple
-        engine_cfg.sg_network_m_mode = m_cfg.sg_processing_network_m_mode;
+        engine_cfg.sg_m_networkMode = m_cfg.sg_processing_m_networkMode;
         auto engine = std::make_shared<core::MNNInferenceEngine>( engine_cfg );
 
 #ifdef GENIUS_HAS_SENTENCEPIECE
@@ -479,8 +479,10 @@ namespace sgns::neoswarm::api
         m_running.store( false );
         if ( m_p2pNode )
             m_p2pNode->Stop();
+#ifdef GENIUS_HAS_GRPC
         if ( m_sgClient )
             m_sgClient->Disconnect();
+#endif
         if ( m_repStorage )
             m_repStorage->Close();
         ServerLogger()->info( "ApiServer stopped" );

--- a/src/api/api_server.hpp
+++ b/src/api/api_server.hpp
@@ -54,7 +54,7 @@ namespace sgns::neoswarm::api
             std::string m_reputationDbPath = "./reputation.db";
             std::string m_knowledgefacts_ = "";
             bool m_enableNetwork = false;
-            bool enable_m_knowledge = true;
+            bool m_enableKnowledge = true;
             int m_grpcPort = 50051;
             std::string m_nodeKeyFile = "./node.key";
             bool m_enableSgProcessing = false;

--- a/src/api/api_server.hpp
+++ b/src/api/api_server.hpp
@@ -58,7 +58,7 @@ namespace sgns::neoswarm::api
             int m_grpcPort = 50051;
             std::string m_nodeKeyFile = "./node.key";
             bool m_enableSgProcessing = false;
-            bool sg_processing_network_m_mode = false;
+            bool sg_processing_m_networkMode = false;
             std::string sg_m_endpoint = "localhost:50051";
             std::string m_sgTlsCa;
             std::string m_sgTlsCert;
@@ -116,7 +116,9 @@ namespace sgns::neoswarm::api
         std::shared_ptr<knowledge::KnowledgeRetrieval> m_knowledge;
         std::unique_ptr<knowledge::ContextInjection> m_contextInj;
         std::unique_ptr<knowledge::FactValidation> m_factVal;
+#ifdef GENIUS_HAS_GRPC
         std::unique_ptr<network::SuperGeniusClient> m_sgClient;
+#endif
 
         outcome::result<InferenceResponse> RunSingleNode( const Task& task, const RouteDecision& route );
         outcome::result<InferenceResponse> RunSpecialist( const Task& task, const RouteDecision& route );

--- a/src/core/engine/mnn_inference_engine.cpp
+++ b/src/core/engine/mnn_inference_engine.cpp
@@ -80,7 +80,7 @@ namespace sgns::neoswarm::core
     {
         if ( m_cfg.engine_m_mode == "sgprocessing" )
         {
-            return m_cfg.sg_network_m_mode ? "SGProcessing/Network" : "SGProcessing/Local";
+            return m_cfg.sg_m_networkMode ? "SGProcessing/Network" : "SGProcessing/Local";
         }
         return ( m_cfg.backend_ == "vulkan" ) ? "MNN/Vulkan" : "MNN/CPU";
 
@@ -99,7 +99,7 @@ namespace sgns::neoswarm::core
             m_modelPath = model_path;
 
             SGProcessingBridge::Config bridge_cfg;
-            bridge_cfg.network_m_mode = m_cfg.sg_network_m_mode;
+            bridge_cfg.m_networkMode = m_cfg.sg_m_networkMode;
             m_bridge = std::make_unique<SGProcessingBridge>( bridge_cfg );
 
             m_tensorInterpreter = std::make_unique<TensorInterpreter>();

--- a/src/core/engine/mnn_inference_engine.hpp
+++ b/src/core/engine/mnn_inference_engine.hpp
@@ -99,7 +99,7 @@ namespace sgns::neoswarm::core
             float repetition_penalty_ = kDefaultRepetitionPenalty;
 
             /// SGProcessing network mode (Phase 2: dispatch via gRPC to SuperGenius)
-            bool sg_network_m_mode = false;
+            bool sg_m_networkMode = false;
         };
 
         MNNInferenceEngine();

--- a/src/core/sgprocessing/sg_processing_bridge.cpp
+++ b/src/core/sgprocessing/sg_processing_bridge.cpp
@@ -9,7 +9,7 @@
 
 #include "sg_processing_bridge.hpp"
 #include "common/logging.hpp"
-#include "network/sg_client/super_genius_client.hpp"
+// SuperGeniusClient requires GENIUS_HAS_GRPC
 
 #include <boost/asio/io_context.hpp>
 #include <nlohmann/json.hpp>
@@ -252,7 +252,7 @@ namespace sgns::neoswarm::core
                                                                          std::shared_ptr<boost::asio::io_context> ioc )
     {
         BridgeLogger()->debug( "SubmitJob model={} format={} networkMode={}", model_uri,
-                               InputFormatToFormatString( input_format ), static_cast<int>( m_cfg.network_m_mode ) );
+                               InputFormatToFormatString( input_format ), static_cast<int>( m_cfg.m_networkMode ) );
 
         auto json_res = BuildSchemaJson( model_uri, input_uri, input_format, shape );
         if ( !json_res.has_value() )
@@ -260,7 +260,7 @@ namespace sgns::neoswarm::core
             return outcome::failure( json_res.error() );
         }
 
-        if ( m_cfg.network_m_mode )
+        if ( m_cfg.m_networkMode )
         {
             auto result = SubmitNetwork( json_res.value() );
             if ( !result.has_value() )
@@ -347,8 +347,8 @@ namespace sgns::neoswarm::core
     // -----------------------------------------------------------------------
     void SGProcessingBridge::SetClient( network::SuperGeniusClient* client ) noexcept
     {
-        client_ = client;
-        BridgeLogger()->info( "SuperGeniusClient set (network_m_mode={})", client ? "true" : "false" );
+        m_client = client;
+        BridgeLogger()->info( "SuperGeniusClient set (m_networkMode={})", client ? "true" : "false" );
     }
 
     // -----------------------------------------------------------------------
@@ -356,14 +356,15 @@ namespace sgns::neoswarm::core
     // -----------------------------------------------------------------------
     outcome::result<std::vector<uint8_t>> SGProcessingBridge::SubmitNetwork( const std::string& jsondata ) const
     {
-        if ( !client_ )
+        if ( !m_client )
         {
             BridgeLogger()->error( "SubmitNetwork: SuperGeniusClient not configured" );
             return outcome::failure( Error::NetworkError );
         }
 
         BridgeLogger()->debug( "Submitting job via SuperGeniusClient ({} bytes)", jsondata.size() );
-        return client_->SubmitJob( jsondata );
+        (void)jsondata;
+        return outcome::failure( Error::NetworkError );
     }
 
 } // namespace sgns::neoswarm::core

--- a/src/core/sgprocessing/sg_processing_bridge.hpp
+++ b/src/core/sgprocessing/sg_processing_bridge.hpp
@@ -40,7 +40,7 @@ namespace sgns::neoswarm::core
         public:
         struct Config
         {
-            bool network_m_mode = false; ///< Phase 2: dispatch via gRPCForSuperGenius
+            bool m_networkMode = false; ///< Phase 2: dispatch via gRPCForSuperGenius
         };
 
         SGProcessingBridge();
@@ -69,8 +69,8 @@ namespace sgns::neoswarm::core
         /**
          * @brief Submit a job and return raw tensor output bytes.
          *
-         * Phase 1 (network_m_mode=false): calls ProcessingManager::Create + Process.
-         * Phase 2 (network_m_mode=true):  dispatches via gRPCForSuperGenius (stub).
+         * Phase 1 (m_networkMode=false): calls ProcessingManager::Create + Process.
+         * Phase 2 (m_networkMode=true):  dispatches via gRPCForSuperGenius (stub).
          *
          * @param model_uri    IPFS URI or path to the MNN model.
          * @param input_uri    IPFS URI or path to the input data.
@@ -87,7 +87,7 @@ namespace sgns::neoswarm::core
 
         private:
         Config m_cfg;
-        network::SuperGeniusClient* client_ = nullptr;
+        network::SuperGeniusClient* m_client = nullptr;
 
         outcome::result<std::vector<uint8_t>> SubmitDirect( const std::string& jsondata,
                                                             std::shared_ptr<boost::asio::io_context> ioc ) const;

--- a/src/genius_elm_chat_completions.cpp
+++ b/src/genius_elm_chat_completions.cpp
@@ -36,7 +36,9 @@ namespace
   "model_loaded": false,
   "mode": "stub",
   "backend": "cpu",
-  "node_id": "stub-node"
+  "node_id": "stub-node",
+  "supergenius_connected": false,
+  "fallback_active": true
 })";
 
     char* AllocCopy( const std::string& src )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -288,7 +288,7 @@ int main( int argc, char** argv )
     cfg.m_reputationDbPath = args.db_path_;
     cfg.m_knowledgefacts_ = args.m_knowledgepath_;
     cfg.m_enableNetwork = args.network_;
-    cfg.enable_m_knowledge = true;
+    cfg.m_enableKnowledge = true;
     (void) args.port_;
     cfg.m_nodeKeyFile = args.key_file_;
     cfg.sg_m_endpoint = args.sg_m_endpoint;

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(neoswarm_network STATIC
     p2p_node.cpp
     result_aggregation.cpp
-    #sg_client/super_genius_client.cpp
+    ##sg_client/super_genius_client.cpp
     
     
     sg_client/sg_result_collector.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,1 +1,68 @@
+find_package(GTest QUIET)
 
+if(NOT GTest_FOUND)
+    find_path(GTEST_INCLUDE_DIR gtest/gtest.h
+        PATHS ${THIRDPARTY_BUILD_DIR}/GTest/include
+              ${CMAKE_SOURCE_DIR}/../thirdparty/GTest/googletest/include
+    )
+    find_library(GTEST_LIB gtest
+        PATHS ${THIRDPARTY_BUILD_DIR}/GTest/lib
+    )
+    find_library(GTEST_MAIN_LIB gtest_main
+        PATHS ${THIRDPARTY_BUILD_DIR}/GTest/lib
+    )
+    if(GTEST_INCLUDE_DIR AND GTEST_LIB)
+        add_library(GTest::GTest UNKNOWN IMPORTED)
+        set_target_properties(GTest::GTest PROPERTIES
+            IMPORTED_LOCATION ${GTEST_LIB}
+            INTERFACE_INCLUDE_DIRECTORIES ${GTEST_INCLUDE_DIR}
+        )
+        add_library(GTest::Main UNKNOWN IMPORTED)
+        set_target_properties(GTest::Main PROPERTIES
+            IMPORTED_LOCATION ${GTEST_MAIN_LIB}
+        )
+        set(GTest_FOUND TRUE)
+    endif()
+endif()
+
+if(NOT GTest_FOUND)
+    message(WARNING "GTest not found — skipping tests")
+    return()
+endif()
+
+enable_testing()
+
+# Path to SuperGenius processing_datatypes test data
+# Used by test_sgprocessing_pipeline for Phase 1 integration tests
+set(SUPERGENIUS_TEST_DATA_DIR
+    "${CMAKE_SOURCE_DIR}/../SuperGenius/test/src"
+    CACHE PATH "Path to SuperGenius test/src directory containing processing_datatypes/")
+
+# Helper macro
+macro(genius_test name sources libs)
+    add_executable(${name} ${sources})
+    target_link_libraries(${name} PRIVATE
+        ${libs}
+        GTest::GTest
+        GTest::Main
+    )
+    target_compile_definitions(${name} PRIVATE
+        SUPERGENIUS_TEST_DATA_DIR="${SUPERGENIUS_TEST_DATA_DIR}"
+    )
+    add_test(NAME ${name} COMMAND ${name})
+endmacro()
+
+genius_test(test_fp4_codec             core/test_fp4_codec.cpp                          "neoswarm_core")
+genius_test(test_router                router/test_router.cpp                           "neoswarm_router;neoswarm_common")
+genius_test(test_reputation            reputation/test_reputation.cpp                   "neoswarm_reputation;neoswarm_common")
+genius_test(test_pipeline              integration/test_pipeline.cpp                    "neoswarm_api")
+genius_test(test_sgprocessing_pipeline integration/test_sgprocessing_pipeline.cpp       "neoswarm_api")
+genius_test(test_node_identity     security/test_node_identity.cpp        "neoswarm_security;neoswarm_common")
+genius_test(test_message_signing   security/test_message_signing.cpp      "neoswarm_security;neoswarm_common")
+genius_test(test_genius_slm_ffi    ffi/test_genius_elm_ffi.cpp             "neoswarm_api")
+target_sources(test_genius_slm_ffi PRIVATE "${PROJECT_ROOT}/src/genius_elm_chat_completions.cpp")
+genius_test(test_fact_validation   knowledge/test_fact_validation.cpp      "neoswarm_knowledge;neoswarm_common")
+genius_test(test_network           network/test_network.cpp                "neoswarm_network;neoswarm_security;neoswarm_common")
+
+# Benchmarks (not part of CTest — run manually)
+add_subdirectory(benchmark)

--- a/test/integration/test_pipeline.cpp
+++ b/test/integration/test_pipeline.cpp
@@ -17,11 +17,11 @@ class PipelineTest : public ::testing::Test
     void SetUp() override
     {
         ApiServer::Config cfg;
-        cfg.model_path_ = ""; // stub mode
-        cfg.enable_network_ = false;
-        cfg.enable_knowledge_ = true;
-        cfg.reputation_db_path_ = ":memory:";
-        cfg.node_key_file_ = "/tmp/test_genius_node.key";
+        cfg.m_modelPath = ""; // stub mode
+        cfg.m_enableNetwork = false;
+        cfg.m_enableKnowledge = true;
+        cfg.m_reputationDbPath = ":memory:";
+        cfg.m_nodeKeyFile = "/tmp/test_genius_node.key";
 
         server_ = std::make_unique<ApiServer>( cfg );
         ASSERT_TRUE( server_->Initialize().has_value() );
@@ -33,83 +33,83 @@ class PipelineTest : public ::testing::Test
 TEST_F( PipelineTest, SingleNodeMode )
 {
     Task task;
-    task.prompt_ = "Tell me about the history of Rome.";
-    task.mode_ = ExecutionMode::SingleNode;
-    task.max_tokens_ = 32;
-    task.temperature_ = 0.7f;
+    task.m_prompt = "Tell me about the history of Rome.";
+    task.m_mode = ExecutionMode::SingleNode;
+    task.m_maxTokens = 32;
+    task.m_temperature = 0.7f;
 
     auto res = server_->Process( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_EQ( res.value().mode_used_, ExecutionMode::SingleNode );
-    EXPECT_FALSE( res.value().task_id_.empty() );
+    EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::SingleNode );
+    EXPECT_FALSE( res.value().m_taskId.empty() );
 }
 
 TEST_F( PipelineTest, MathRoutingAutoDetect )
 {
     Task task;
-    task.prompt_ = "Calculate 847 × 963";
-    task.mode_ = ExecutionMode::SingleNode;
-    task.max_tokens_ = 32;
+    task.m_prompt = "Calculate 847 × 963";
+    task.m_mode = ExecutionMode::SingleNode;
+    task.m_maxTokens = 32;
 
     auto res = server_->Process( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_NE( res.value().route_used_, RouteTarget::CoreOnly );
+    EXPECT_NE( res.value().m_routeUsed, RouteTarget::CoreOnly );
 }
 
 TEST_F( PipelineTest, GrammarRoutingAutoDetect )
 {
     Task task;
-    task.prompt_ = "Please fix my grammar: I goes to store yesterday.";
-    task.mode_ = ExecutionMode::SingleNode;
-    task.max_tokens_ = 64;
+    task.m_prompt = "Please fix my grammar: I goes to store yesterday.";
+    task.m_mode = ExecutionMode::SingleNode;
+    task.m_maxTokens = 64;
 
     auto res = server_->Process( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_EQ( res.value().route_used_, RouteTarget::CorePlusGrammar );
+    EXPECT_EQ( res.value().m_routeUsed, RouteTarget::CorePlusGrammar );
 }
 
 TEST_F( PipelineTest, ExplicitSpecialistMode )
 {
     Task task;
-    task.prompt_ = "What is the square root of 144?";
-    task.mode_ = ExecutionMode::Specialist;
-    task.max_tokens_ = 32;
+    task.m_prompt = "What is the square root of 144?";
+    task.m_mode = ExecutionMode::Specialist;
+    task.m_maxTokens = 32;
 
     auto res = server_->Process( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_EQ( res.value().mode_used_, ExecutionMode::Specialist );
+    EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::Specialist );
 }
 
 TEST_F( PipelineTest, SwarmFallsBackToSingleWithoutNetwork )
 {
     Task task;
-    task.prompt_ = "Complex question requiring swarm";
-    task.mode_ = ExecutionMode::Swarm;
-    task.max_tokens_ = 32;
+    task.m_prompt = "Complex question requiring swarm";
+    task.m_mode = ExecutionMode::Swarm;
+    task.m_maxTokens = 32;
 
     auto res = server_->Process( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_TRUE( res.value().success_ );
+    EXPECT_TRUE( res.value().m_success );
 }
 
 TEST_F( PipelineTest, ResponseHasTaskId )
 {
     Task task;
-    task.prompt_ = "Hello";
-    task.max_tokens_ = 16;
+    task.m_prompt = "Hello";
+    task.m_maxTokens = 16;
 
     auto res = server_->Process( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_FALSE( res.value().task_id_.empty() );
+    EXPECT_FALSE( res.value().m_taskId.empty() );
 }
 
 TEST_F( PipelineTest, LatencyIsPositive )
 {
     Task task;
-    task.prompt_ = "What is 2 + 2?";
-    task.max_tokens_ = 16;
+    task.m_prompt = "What is 2 + 2?";
+    task.m_maxTokens = 16;
 
     auto res = server_->Process( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_GT( res.value().total_latency_ms_, 0.0 );
+    EXPECT_GT( res.value().m_totalLatencyMs, 0.0 );
 }

--- a/test/integration/test_sgprocessing_pipeline.cpp
+++ b/test/integration/test_sgprocessing_pipeline.cpp
@@ -140,7 +140,7 @@ TEST( SGProcessingBridge, SubmitJob_StubMode_ReturnsOk )
 TEST( SGProcessingBridge, NetworkMode_ReturnsNotImplemented )
 {
     SGProcessingBridge::Config cfg;
-    cfg.network_mode_ = true;
+    cfg.m_networkMode = true;
     SGProcessingBridge bridge( cfg );
 
     auto ioc = std::make_shared<boost::asio::io_context>();

--- a/test/knowledge/test_fact_validation.cpp
+++ b/test/knowledge/test_fact_validation.cpp
@@ -20,15 +20,15 @@ namespace
     KnowledgeFact MakeFact( const std::string& source, const std::string& content )
     {
         KnowledgeFact f;
-        f.source_ = source;
-        f.content_ = content;
+        f.m_source = source;
+        f.m_content = content;
         return f;
     }
 
     std::shared_ptr<KnowledgeRetrieval> MakeRetrieval()
     {
         KnowledgeRetrieval::Config cfg;
-        cfg.facts_path_ = "";
+        cfg.m_factsPath = "";
         auto ret = std::make_shared<KnowledgeRetrieval>( cfg );
         ret->Load();
         return ret;
@@ -83,7 +83,7 @@ TEST( FactValidation, IsAvailable )
 TEST( KnowledgeRetrieval, LoadEmptyPathDoesNotCrash )
 {
     KnowledgeRetrieval::Config cfg;
-    cfg.facts_path_ = "";
+    cfg.m_factsPath = "";
     KnowledgeRetrieval retriever( cfg );
     retriever.Load();
 
@@ -95,7 +95,7 @@ TEST( KnowledgeRetrieval, LoadEmptyPathDoesNotCrash )
 TEST( KnowledgeRetrieval, NotLoadedReturnsEmpty )
 {
     KnowledgeRetrieval::Config cfg;
-    cfg.facts_path_ = "/nonexistent/path/facts.csv";
+    cfg.m_factsPath = "/nonexistent/path/facts.csv";
     KnowledgeRetrieval retriever( cfg );
     retriever.Load();
 

--- a/test/network/test_network.cpp
+++ b/test/network/test_network.cpp
@@ -49,7 +49,7 @@ TEST( P2PNode, StopBeforeStartDoesNotCrash )
 TEST( ResultAggregation, CollectEmptyWithTimeout )
 {
     ResultAggregation::Config cfg;
-    cfg.timeout_ = std::chrono::milliseconds( 50 );
+    cfg.m_timeout = std::chrono::milliseconds( 50 );
     cfg.min_responses_ = 1;
 
     ResultAggregation agg( cfg );
@@ -63,35 +63,35 @@ TEST( ResultAggregation, CollectEmptyWithTimeout )
 TEST( ResultAggregation, SubmitAndCollectSingle )
 {
     ResultAggregation::Config cfg;
-    cfg.timeout_ = std::chrono::milliseconds( 200 );
+    cfg.m_timeout = std::chrono::milliseconds( 200 );
     cfg.min_responses_ = 1;
 
     ResultAggregation agg( cfg );
 
     NodeOutput output;
-    output.node_id_ = "test-node-1";
-    output.output_ = "test output";
-    output.latency_ms_ = 100.0;
+    output.m_nodeId = "test-node-1";
+    output.m_output = "test output";
+    output.m_latencyMs = 100.0;
 
     agg.Submit( output );
 
     auto result = agg.Collect();
     EXPECT_TRUE( result.has_value() );
     EXPECT_FALSE( result.value().empty() );
-    EXPECT_EQ( result.value()[0].node_id_, "test-node-1" );
+    EXPECT_EQ( result.value()[0].m_nodeId, "test-node-1" );
     EXPECT_EQ( agg.ResponseCount(), 1U );
 }
 
 TEST( ResultAggregation, ResetClearsState )
 {
     ResultAggregation::Config cfg;
-    cfg.timeout_ = std::chrono::milliseconds( 50 );
+    cfg.m_timeout = std::chrono::milliseconds( 50 );
     cfg.min_responses_ = 1;
 
     ResultAggregation agg( cfg );
 
     NodeOutput output;
-    output.node_id_ = "test-node";
+    output.m_nodeId = "test-node";
     agg.Submit( output );
 
     agg.Reset();

--- a/test/reputation/test_reputation.cpp
+++ b/test/reputation/test_reputation.cpp
@@ -44,35 +44,35 @@ TEST( ReputationScoring, ScoreClampedToRange )
 {
     ReputationScoring scoring;
     NodeReputation rep;
-    rep.identity_key_ = "test-node";
-    rep.global_score_ = 0.99;
+    rep.m_identityKey = "test-node";
+    rep.m_globalScore = 0.99;
 
     InferenceResponse resp;
-    resp.output_ = "correct";
-    resp.perplexity_ = 1.0f;
-    resp.latency_ms_ = 100.0;
-    resp.node_id_ = "test-node";
+    resp.m_output = "correct";
+    resp.m_perplexity = 1.0f;
+    resp.m_latencyMs = 100.0;
+    resp.m_nodeId = "test-node";
 
     auto updated = scoring.Update( rep, resp, 100.0, std::string( "correct" ), "correct" );
-    EXPECT_LE( updated.global_score_, 1.0 );
-    EXPECT_GE( updated.global_score_, 0.0 );
+    EXPECT_LE( updated.m_globalScore, 1.0 );
+    EXPECT_GE( updated.m_globalScore, 0.0 );
 }
 
 TEST( ReputationScoring, TaskCountIncremented )
 {
     ReputationScoring scoring;
     NodeReputation rep;
-    rep.identity_key_ = "test-node";
-    rep.task_count_ = 5;
+    rep.m_identityKey = "test-node";
+    rep.m_taskCount = 5;
 
     InferenceResponse resp;
-    resp.output_ = "answer";
-    resp.perplexity_ = 2.0f;
-    resp.latency_ms_ = 200.0;
-    resp.node_id_ = "test-node";
+    resp.m_output = "answer";
+    resp.m_perplexity = 2.0f;
+    resp.m_latencyMs = 200.0;
+    resp.m_nodeId = "test-node";
 
     auto updated = scoring.Update( rep, resp, 200.0, std::nullopt, "answer" );
-    EXPECT_EQ( updated.task_count_, 6u );
+    EXPECT_EQ( updated.m_taskCount, 6u );
 }
 
 // ---------------------------------------------------------------------------
@@ -85,21 +85,21 @@ TEST( WeightedConsensus, SelectsHighReputationNode )
                                         { "node-B", "815961", 1.2f, 120.0, 0.7 },
                                         { "node-C", "814000", 2.0f, 150.0, 0.2 } };
     auto winner = consensus.SelectWinner( outputs );
-    EXPECT_EQ( winner.output_, "815961" );
+    EXPECT_EQ( winner.m_output, "815961" );
 }
 
 TEST( WeightedConsensus, SingleNode )
 {
     WeightedConsensus consensus;
     std::vector<NodeOutput> outputs = { { "node-A", "answer", 1.0f, 100.0, 0.8 } };
-    EXPECT_EQ( consensus.SelectWinner( outputs ).output_, "answer" );
+    EXPECT_EQ( consensus.SelectWinner( outputs ).m_output, "answer" );
 }
 
 TEST( WeightedConsensus, EmptyInputReturnsDefault )
 {
     WeightedConsensus consensus;
     std::vector<NodeOutput> outputs;
-    EXPECT_TRUE( consensus.SelectWinner( outputs ).output_.empty() );
+    EXPECT_TRUE( consensus.SelectWinner( outputs ).m_output.empty() );
 }
 
 TEST( WeightedConsensus, BestWeightedScoreStrategy )
@@ -110,7 +110,7 @@ TEST( WeightedConsensus, BestWeightedScoreStrategy )
 
     std::vector<NodeOutput> outputs = { { "node-A", "wrong", 5.0f, 100.0, 0.9 },
                                         { "node-B", "correct", 1.0f, 100.0, 0.8 } };
-    EXPECT_EQ( consensus.SelectWinner( outputs ).output_, "correct" );
+    EXPECT_EQ( consensus.SelectWinner( outputs ).m_output, "correct" );
 }
 
 // ---------------------------------------------------------------------------
@@ -120,60 +120,60 @@ TEST( ReputationCRDT, MergeNewEntry )
 {
     ReputationCRDT crdt;
     NodeReputation r;
-    r.identity_key_ = "node-1";
-    r.global_score_ = 0.8;
-    r.last_updated_ms_ = 1000;
+    r.m_identityKey = "node-1";
+    r.m_globalScore = 0.8;
+    r.m_lastUpdatedMs = 1000;
     crdt.Merge( r );
 
     auto got = crdt.Get( "node-1" );
     ASSERT_TRUE( got.has_value() );
-    EXPECT_DOUBLE_EQ( got->global_score_, 0.8 );
+    EXPECT_DOUBLE_EQ( got->m_globalScore, 0.8 );
 }
 
 TEST( ReputationCRDT, LWWKeepsLatest )
 {
     ReputationCRDT crdt;
     NodeReputation old_r;
-    old_r.identity_key_ = "node-1";
-    old_r.global_score_ = 0.5;
-    old_r.last_updated_ms_ = 1000;
+    old_r.m_identityKey = "node-1";
+    old_r.m_globalScore = 0.5;
+    old_r.m_lastUpdatedMs = 1000;
     crdt.Merge( old_r );
 
     NodeReputation newer;
-    newer.identity_key_ = "node-1";
-    newer.global_score_ = 0.9;
-    newer.last_updated_ms_ = 2000;
+    newer.m_identityKey = "node-1";
+    newer.m_globalScore = 0.9;
+    newer.m_lastUpdatedMs = 2000;
     crdt.Merge( newer );
 
-    EXPECT_DOUBLE_EQ( crdt.Get( "node-1" )->global_score_, 0.9 );
+    EXPECT_DOUBLE_EQ( crdt.Get( "node-1" )->m_globalScore, 0.9 );
 }
 
 TEST( ReputationCRDT, LWWIgnoresOlder )
 {
     ReputationCRDT crdt;
     NodeReputation newer;
-    newer.identity_key_ = "node-1";
-    newer.global_score_ = 0.9;
-    newer.last_updated_ms_ = 2000;
+    newer.m_identityKey = "node-1";
+    newer.m_globalScore = 0.9;
+    newer.m_lastUpdatedMs = 2000;
     crdt.Merge( newer );
 
     NodeReputation old_r;
-    old_r.identity_key_ = "node-1";
-    old_r.global_score_ = 0.3;
-    old_r.last_updated_ms_ = 500;
+    old_r.m_identityKey = "node-1";
+    old_r.m_globalScore = 0.3;
+    old_r.m_lastUpdatedMs = 500;
     crdt.Merge( old_r );
 
-    EXPECT_DOUBLE_EQ( crdt.Get( "node-1" )->global_score_, 0.9 );
+    EXPECT_DOUBLE_EQ( crdt.Get( "node-1" )->m_globalScore, 0.9 );
 }
 
 TEST( ReputationCRDT, SerializeDeserializeRoundtrip )
 {
     ReputationCRDT crdt1;
     NodeReputation r;
-    r.identity_key_ = "node-X";
-    r.global_score_ = 0.75;
-    r.task_count_ = 42;
-    r.last_updated_ms_ = 99999;
+    r.m_identityKey = "node-X";
+    r.m_globalScore = 0.75;
+    r.m_taskCount = 42;
+    r.m_lastUpdatedMs = 99999;
     crdt1.Merge( r );
 
     ReputationCRDT crdt2;
@@ -181,8 +181,8 @@ TEST( ReputationCRDT, SerializeDeserializeRoundtrip )
 
     auto got = crdt2.Get( "node-X" );
     ASSERT_TRUE( got.has_value() );
-    EXPECT_DOUBLE_EQ( got->global_score_, 0.75 );
-    EXPECT_EQ( got->task_count_, 42u );
+    EXPECT_DOUBLE_EQ( got->m_globalScore, 0.75 );
+    EXPECT_EQ( got->m_taskCount, 42u );
 }
 
 // ---------------------------------------------------------------------------
@@ -200,15 +200,15 @@ TEST( ReputationStorage, PutAndGet )
     ASSERT_TRUE( storage.Open().has_value() );
 
     NodeReputation r;
-    r.identity_key_ = "test-node";
-    r.global_score_ = 0.65;
-    r.task_count_ = 10;
+    r.m_identityKey = "test-node";
+    r.m_globalScore = 0.65;
+    r.m_taskCount = 10;
     ASSERT_TRUE( storage.Put( r ).has_value() );
 
     auto got = storage.Get( "test-node" );
     ASSERT_TRUE( got.has_value() );
-    EXPECT_DOUBLE_EQ( got.value().global_score_, 0.65 );
-    EXPECT_EQ( got.value().task_count_, 10u );
+    EXPECT_DOUBLE_EQ( got.value().m_globalScore, 0.65 );
+    EXPECT_EQ( got.value().m_taskCount, 10u );
 }
 
 TEST( ReputationStorage, GetNotFound )
@@ -226,8 +226,8 @@ TEST( ReputationStorage, GetAll )
     for ( int i = 0; i < 5; ++i )
     {
         NodeReputation r;
-        r.identity_key_ = "node-" + std::to_string( i );
-        r.global_score_ = 0.5 + i * 0.1;
+        r.m_identityKey = "node-" + std::to_string( i );
+        r.m_globalScore = 0.5 + i * 0.1;
         ASSERT_TRUE( storage.Put( r ).has_value() );
     }
 

--- a/test/router/test_router.cpp
+++ b/test/router/test_router.cpp
@@ -51,68 +51,68 @@ TEST( RuleBasedRouter, RouteMathByDensity )
 {
     RuleBasedRouter router;
     Task task;
-    task.prompt_ = "Calculate 847 × 963 + 12 / 4 - 100";
-    task.mode_ = ExecutionMode::SingleNode;
+    task.m_prompt = "Calculate 847 × 963 + 12 / 4 - 100";
+    task.m_mode = ExecutionMode::SingleNode;
 
     auto res = router.Route( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_EQ( res.value().target_, RouteTarget::CorePlusMath );
+    EXPECT_EQ( res.value().m_target, RouteTarget::CorePlusMath );
 }
 
 TEST( RuleBasedRouter, RouteMathByKeyword )
 {
     RuleBasedRouter router;
     Task task;
-    task.prompt_ = "Solve the integral of x^2 from 0 to 1";
-    task.mode_ = ExecutionMode::SingleNode;
+    task.m_prompt = "Solve the integral of x^2 from 0 to 1";
+    task.m_mode = ExecutionMode::SingleNode;
 
     auto res = router.Route( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_EQ( res.value().target_, RouteTarget::CorePlusMath );
+    EXPECT_EQ( res.value().m_target, RouteTarget::CorePlusMath );
 }
 
 TEST( RuleBasedRouter, RouteGrammar )
 {
     RuleBasedRouter router;
     Task task;
-    task.prompt_ = "Please fix my grammar: I goes to the store yesterday.";
-    task.mode_ = ExecutionMode::SingleNode;
+    task.m_prompt = "Please fix my grammar: I goes to the store yesterday.";
+    task.m_mode = ExecutionMode::SingleNode;
 
     auto res = router.Route( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_EQ( res.value().target_, RouteTarget::CorePlusGrammar );
+    EXPECT_EQ( res.value().m_target, RouteTarget::CorePlusGrammar );
 }
 
 TEST( RuleBasedRouter, RouteCoreOnly )
 {
     RuleBasedRouter router;
     Task task;
-    task.prompt_ = "Tell me about the history of ancient Rome.";
-    task.mode_ = ExecutionMode::SingleNode;
+    task.m_prompt = "Tell me about the history of ancient Rome.";
+    task.m_mode = ExecutionMode::SingleNode;
 
     auto res = router.Route( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_EQ( res.value().target_, RouteTarget::CoreOnly );
+    EXPECT_EQ( res.value().m_target, RouteTarget::CoreOnly );
 }
 
 TEST( RuleBasedRouter, HonourExplicitSwarmMode )
 {
     RuleBasedRouter router;
     Task task;
-    task.prompt_ = "Simple question";
-    task.mode_ = ExecutionMode::Swarm;
+    task.m_prompt = "Simple question";
+    task.m_mode = ExecutionMode::Swarm;
 
     auto res = router.Route( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_EQ( res.value().mode_, ExecutionMode::Swarm );
+    EXPECT_EQ( res.value().m_mode, ExecutionMode::Swarm );
 }
 
 TEST( RuleBasedRouter, ConfidenceInRange )
 {
     RuleBasedRouter router;
     Task task;
-    task.prompt_ = "What is 2 + 2?";
-    task.mode_ = ExecutionMode::SingleNode;
+    task.m_prompt = "What is 2 + 2?";
+    task.m_mode = ExecutionMode::SingleNode;
 
     auto res = router.Route( task );
     ASSERT_TRUE( res.has_value() );


### PR DESCRIPTION
## Summary
Guard SuperGeniusClient/sg_client code with GENIUS_HAS_GRPC ifdefs. Restore test CMakeLists.txt.

## Changes
- api_server.cpp: guard Initialize/Stop/IsSuperGeniusConnected with GENIUS_HAS_GRPC
- api_server.hpp: guard SuperGeniusClient member and forward decl
- sg_processing_bridge: stub SubmitNetwork/SetClient
- test/CMakeLists.txt: restored and updated for neoswarm_* libs
- All test member references updated
- 10/10 tests pass

~12 files