### PR TITLE
Phase 2 Wave 2: wire GeniusSDKProcess() into SGJobSubmitter

### DIFF
--- a/src/network/sg_client/sg_job_submitter.cpp
+++ b/src/network/sg_client/sg_job_submitter.cpp
@@ -7,7 +7,9 @@
 #include "sg_job_submitter.hpp"
 #include "sg_message_authenticator.hpp"
 #include "common/logging.hpp"
+#include "GeniusSDK.h"
 #include <chrono>
+#include <cstring>
 #include <iomanip>
 #include <random>
 #include <sstream>
@@ -74,9 +76,24 @@ namespace sgns::neoswarm::network
 
         SubmitLogger()->info( "Publishing task {} to {} ({} bytes, signed)", taskId, m_impl->m_endpoint, taskMessage.size() );
 
-        // TODO(Phase 2 Wave 2): dispatch via GeniusSDKProcess(taskMessage)
-        SubmitLogger()->warn( "GeniusSDK dispatch not yet wired — task {} prepared for submission", taskId );
+        if ( taskMessage.size() >= 2048 )
+        {
+            SubmitLogger()->error( "Task payload too large for GeniusSDK ({} bytes, max 2047)", taskMessage.size() );
+            return outcome::failure( Error::InvalidArgument );
+        }
 
+        JsonData_t sdkPayload;
+        std::strncpy( sdkPayload, taskMessage.c_str(), sizeof( sdkPayload ) - 1 );
+        sdkPayload[ sizeof( sdkPayload ) - 1 ] = '\0';
+
+        auto sdkResult = GeniusSDKProcess( sdkPayload );
+        if ( sdkResult != GENIUS_NODE_RET_OK )
+        {
+            SubmitLogger()->error( "GeniusSDKProcess failed: error code {}", static_cast<int>( sdkResult ) );
+            return outcome::failure( Error::NetworkError );
+        }
+
+        SubmitLogger()->info( "Task {} dispatched via GeniusSDK", taskId );
         return taskId;
 
     }


### PR DESCRIPTION
## What
Waves to wire the actual GeniusSDK dispatch call into the job submitter. Replaces the TODO stub with a real `GeniusSDKProcess()` call.

## Changes
- Added `GeniusSDK.h` and `<cstring>` includes
- `PublishJob()` now calls `GeniusSDKProcess()` with the signed task JSON
- Added 2KB payload size check — `JsonData_t` is `char[2048]`
- Maps `GeniusNodeReturnValue_t` to `Error::NetworkError` on failure
- Logs dispatch at info level (success) or error level (failure)

## Depends on
- PR #79 (Wave 1 — strip gRPC, add GeniusSDK include paths)