### PR TITLE
Phase 2 Wave 2: wire GeniusSDKProcess() into SGJobSubmitter

### DIFF
--- a/.planning/workstreams/neoswarm/phases/02-supergenius-connectivity/02-CONTEXT.md
+++ b/.planning/workstreams/neoswarm/phases/02-supergenius-connectivity/02-CONTEXT.md
@@ -1,118 +1,122 @@
-# Phase 2: SuperGenius Connectivity - Context
+# Phase 2: SuperGenius Connectivity — Context
 
-**Gathered:** 2026-05-28
+**Gathered:** 2026-06-24 (updated from 2026-05-28)
 **Status:** Ready for planning
 
 <domain>
 ## Phase Boundary
 
-The engine dispatches inference jobs to the SuperGenius blockchain compute network via TLS-protected, authenticated PubSub-based gRPC. A new `SuperGeniusClient` component in `src/network/sg_client/` bridges the local engine to the external SuperGenius process. Requires Phase 1 (real secp256k1 identity and message signing) to be complete.
+The engine dispatches inference jobs to the SuperGenius blockchain compute network via **GeniusSDK** — a C shared library that internally handles gRPC transport through SuperGenius's `gRPCForSuperGenius`. GNUS-NEO-SWARM does NOT use raw gRPC — all transport goes through GeniusSDK.
 
-This phase covers the network dispatch path only — local inference via `SubmitDirect` already works. The Flutter UI, streaming output, and swarm P2P are separate phases.
+The existing `SGClient` component in `src/network/sg_client/` bridges the local engine to GeniusSDK. Phase 1 (real secp256k1 identity and message signing) is complete. This phase covers wiring GeniusSDK dispatch — local inference via `SubmitDirect` already works.
 </domain>
 
 <decisions>
 ## Implementation Decisions
 
-### SuperGeniusClient API Surface
-- **D-01:** Separate component in `src/network/sg_client/` with 6 files: `SuperGeniusClient.hpp/.cpp`, `SGChannelManager.hpp/.cpp`, `SGJobSubmitter.hpp/.cpp`, `SGResultCollector.hpp/.cpp`, `SGMessageAuthenticator.hpp/.cpp`
-- **D-02:** Sync execution model — `SubmitJob(json) → outcome::result<vector<uint8_t>>`, blocking with condition_variable timeout (matches existing `ResultAggregation` pattern)
-- **D-03:** `SGProcessingBridge` becomes a thin dispatch router: `network_mode_ ? client_->SubmitJob(json) : SubmitDirect(json)`
+### Transport Architecture
+- **D-14:** GeniusSDK is the transport. `SGClient` calls `GeniusSDKProcess(jsondata)` → the SDK internally handles gRPC to SuperGenius. Zero raw gRPC calls in GNUS-NEO-SWARM.
+- **D-15:** `GeniusSDKProcess()` takes `JsonData_t` (char[2048], max 2KB). Payloads exceeding 2KB are a known constraint — decision needed on chunking or protocol change.
+- **D-16:** GeniusSDK is already linked as `GeniusSDK_shared` in cmake (`CommonBuildParameters.cmake:294-310`). No new linking needed.
 
-### gRPC Channel & Connection Management
-- **D-04:** Single persistent gRPC channel per node with HTTP/2 multiplexing, reused across all jobs (not per-job connections)
-- **D-05:** Exponential backoff reconnect: 1s → 2s → 4s → 8s → max 30s between attempts
-- **D-06:** Eager connect at `GeniusAPIServer::Initialize()` — fail-fast if SuperGenius is unreachable at startup (fail-close philosophy from Phase 1)
-- **D-07:** Health exposed via `GeniusSlmGetStatus()` with `supergenius_connected: bool` and `fallback_active: bool` fields; detailed logs for diagnostics
+### SGClient API Surface (existing, partially implemented)
+- **D-01:** Separate component in `src/network/sg_client/` with 5 files: `SGClient` (`super_genius_client.cpp/.hpp`), `SGChannelManager`, `SGJobSubmitter`, `SGResultCollector`, `SGMessageAuthenticator`
+- **D-02:** Sync execution model — `SubmitJob(json) → outcome::result<vector<uint8_t>>`, blocking with condition_variable timeout
+- **D-03:** `SGProcessingBridge` is a thin dispatch router: `m_networkMode ? SubmitNetwork(json) : SubmitDirect(json)`
 
-### Error Handling & Fallback Behavior
-- **D-08:** Auto-fallback to local MNN inference (`SubmitDirect`) when SuperGenius is unreachable
-- **D-09:** 3 retries with exponential backoff for gRPC transient errors (UNAVAILABLE, DEADLINE_EXCEEDED). Auth failures (PERMISSION_DENIED, UNAUTHENTICATED) fail immediately — no retry
-- **D-10:** Operator visibility via `GeniusSlmGetStatus()` — Flutter UI can show "Connected to GNUS Network" badge or "Local Mode" fallback indicator
+### Current State of SGClient (post-refactor)
+- `SGChannelManager` — IMPLEMENTED. gRPC channel, TLS, keepalive, health check, reconnect
+- `SGMessageAuthenticator` — IMPLEMENTED. secp256k1 signing + nonce/timestamp replay
+- `SGJobSubmitter` — STUB. Signs payload, `TODO(Phase 2): implement actual gRPC PubSub publish` → REPLACE with `GeniusSDKProcess()`
+- `SGResultCollector` — STUB. `TODO(Phase 2): implement actual gRPC PubSub subscribe` → REPLACE with SDK callback or polling
+- `SGClient` — PARTIAL. Orchestrates sub-components. `Connect()` creates channel, `SubmitJob()` signs + calls submitter, `Disconnect()` tears down.
 
-### TLS & Endpoint Configuration
-- **D-11:** `--sg-endpoint <host:port>` CLI flag, default `localhost:50051`
-- **D-12:** TLS required for non-localhost endpoints. Localhost allowed insecure with `warn`-level log message. Production: `--sg-tls-ca /etc/gnus/ca.pem`
-- **D-13:** `--sg-tls-ca <path>` and `--sg-tls-cert <path>` CLI flags for TLS configuration. gRPC uses `grpc::SslCredentials()` from CA bundle
+### Error Handling & Fallback
+- **D-08:** Auto-fallback to local MNN inference when SuperGenius unreachable
+- **D-09:** GeniusSDK errors (returned as `GeniusNodeReturnValue_t`) → map to outcome Error codes. Transient errors retry; terminal errors fail immediately.
+- **D-10:** `GeniusElmGetStatus()` reports `supergenius_connected` and `fallback_active`
 
-### OpenCode's Discretion
-- Exact PubSub message format (derived from SuperGenius proto definitions)
-- gRPC keepalive interval and timeout values
-- Channel reconnect state machine implementation details
-- `TaskResult` struct fields beyond raw bytes
-- Integration test approach against local SuperGenius node
+### TLS & Endpoint Configuration (already implemented)
+- **D-11:** `--sg-endpoint <host:port>` CLI flag — already parsed in `main.cpp`
+- **D-12:** TLS config via `SGClient::Config` with CA/cert paths
+- **D-13:** TLS fields in `ApiServer::Config` — `m_sgTlsCa`, `m_sgTlsCert`
+
+### Open Discretion
+- Exact `GeniusSDKProcess()` call pattern — how the JSON payload maps to `JsonData_t`
+- Result collection through GeniusSDK — callback, polling, or condition_variable
+- Timeout enforcement: SDK-level timeout vs engine-level timeout
+- `GeniusSDKProcess()` error code mapping to `Error` enum
 </decisions>
 
 <canonical_refs>
 ## Canonical References
 
-Downstream agents MUST read these before planning or implementing.
-
 ### Requirements
-- `.planning/REQUIREMENTS.md` § SuperGenius Connectivity — SG-01 through SG-05
+- `.planning/workstreams/neoswarm/REQUIREMENTS.md` § SuperGenius Connectivity — SG-01 through SG-05
+- SG-01 (SGClient component): ✅ done
+- SG-02 (SubmitNetwork): ❌ stubbed — needs GeniusSDK wiring
+- SG-03 (--sg-endpoint): ✅ done
+- SG-04 (TLS): ✅ done
+- SG-05 (deadline): ❌ not started
 
-### Architecture
-- `.planning/research/ARCHITECTURE.md` — Full production architecture, SuperGeniusClient design, 25-step data flow diagram, component boundaries
-- `.planning/research/SUMMARY.md` § Architecture Approach — Design decisions: PubSub, persistent channel, timeout-bounded collection
-
-### SuperGenius Interface
-- `../SuperGenius/gRPCForSuperGenius/openapi_yaml/SuperGenius-OpenAPI.yaml` — SuperGenius gRPC service definitions
-- `../SuperGenius/gRPCForSuperGenius/` — Compiled gRPC stubs for C++ client
+### GeniusSDK Interface
+- `../GeniusSDK/src/GeniusSDK.h` — C API (345 lines). Key functions:
+  - `GeniusSDKProcess(JsonData_t jsondata)` → `GeniusNodeReturnValue_t` — submits JSON for processing
+  - `GeniusSDKGetProcessingStatus()` → `GeniusProcessingStatusInfo` — polling-based status
+  - `GeniusSDKInit(base_path, ...)` — node initialization (called by SuperGenius, not us)
+  - `GeniusSDKGetNodeState()` → `GeniusNodeState_t` — node health
 
 ### Existing Code
-- `src/core/sgprocessing/SGProcessingBridge.hpp` — Current bridge interface, `SubmitNetwork()` stub at line 340
-- `src/core/sgprocessing/SGProcessingBridge.cpp` — `SubmitDirect` implementation, `BuildSchemaJson()`, `SubmitNetwork` stub
-- `src/security/NodeIdentity.hpp` — Key generation, sign/verify (hardened in Phase 1)
-- `src/security/MessageSigning.hpp` — Payload signing, nonce+timestamp replay protection (hardened in Phase 1)
-- `src/api/GeniusAPIServer.hpp` — Orchestration façade, `Config` struct where channel config must integrate
-- `src/genius_node.cpp` — CLI args parser where `--sg-endpoint`, `--sg-tls-ca`, `--sg-tls-cert` must be added
+- `src/network/sg_client/SGClient` (`super_genius_client.cpp/.hpp`) — orchestrator, already wired into ApiServer
+- `src/network/sg_client/SGJobSubmitter` — signs + builds task JSON, needs `GeniusSDKProcess()` call
+- `src/network/sg_client/SGResultCollector` — condition_variable wait, needs SDK result polling
+- `src/core/sgprocessing/SGProcessingBridge::SubmitNetwork()` — stub at line 355, returns NetworkError
+- `src/api/ApiServer::Initialize()` — creates SGClient, calls Connect(). Already wired.
+- `src/main.cpp` — parses `--sg-endpoint`, `--sg-tls-ca`, `--sg-tls-cert`
+- `src/genius_elm_chat_completions.cpp` `GeniusElmGetStatus()` — reports connectivity status
+
+### Architecture Decisions
+- ROADMAP.md: "Connectivity uses GeniusSDK + libp2p GossipSub pubsub, NOT raw gRPC"
+- ROADMAP.md: "Transport-layer gRPC lives in SuperGenius's `gRPCForSuperGenius/`"
+- STATE.md: "GeniusSDK integration pattern needs research during planning"
 
 ### Pitfalls
-- `.planning/research/PITFALLS.md` § gRPC — Default-insecure channels, TLS enforcement, replay protection requirements
+- `JsonData_t` is fixed 2KB — payload compression or chunking may be needed
+- `GeniusSDKProcess()` return values need cross-referencing with error handling
+- GeniusSDK initialization (`GeniusSDKInit`) already called by SuperGenius process — we may NOT need to call it
+- Result collection pattern unclear — GeniusSDK has no async callback API visible in header
 </canonical_refs>
 
 <code_context>
 ## Existing Code Insights
 
 ### Reusable Assets
-- `SGProcessingBridge::BuildSchemaJson()` — Already produces GNUS-compliant JSON schema; SuperGeniusClient receives this directly
-- `SGProcessingBridge::SubmitDirect()` — Local path implementation pattern for `SubmitNetwork()` to mirror
-- `ResultAggregation` (`src/network/ResultAggregation.cpp`) — Sync timeout-bounded collection via condition_variable; same pattern for collecting PubSub results
-- `NodeIdentity::Sign()` + `MessageSigning::Sign()` — Already hardened with RFC6979 nonces; SuperGeniusClient authenticates every Job via these
+- `SGClient` already wraps channel + authenticator + job submitter + result collector
+- `SGProcessingBridge::BuildSchemaJson()` already produces GNUS-compliant JSON
+- `ApiServer::Initialize()` already initializes SGClient (lines 188-213)
+- `ApiServer::RunSingleNode()` already falls back to local mode when network unavailable
+- `ResultAggregation` — condition_variable + timeout pattern for collection
 
-### Established Patterns
-- All subsystem initialization flows through `GeniusAPIServer::Initialize()` — connect SuperGeniusClient there
-- CLI args parsed in `src/genius_node.cpp` via manual `ParseArgs()` — add new flags there
-- Config structs with sensible defaults (`Config{...}`) — match this for `SuperGeniusClient::Config`
-- `outcome::result<T>` + `BOOST_OUTCOME_TRY` for all error propagation
-- C++17, Allman bracing, 4-space indent, noexcept, unique_ptr ownership
+### Integration Points (what to change)
+- `SGJobSubmitter::PublishJob()` — replace `TODO(Phase 2)` with `GeniusSDKProcess(jsondata)`
+- `SGResultCollector::WaitForResult()` — replace `TODO(Phase 2)` with SDK polling
+- `SGProcessingBridge::SubmitNetwork()` — replace `return NetworkError` with real dispatch through SGClient
+- Decision: does `SGChannelManager` become unnecessary? The SDK handles gRPC internally.
 
-### Integration Points
-- `SGProcessingBridge::SubmitNetwork()` at `src/core/sgprocessing/SGProcessingBridge.cpp:340` — the stub to replace
-- `SGProcessingBridge::Config::network_mode_` at `src/core/sgprocessing/SGProcessingBridge.hpp:38` — already exists, controls dispatch path
-- `GeniusAPIServer::Config` — add `sg_endpoint_`, `sg_tls_ca_`, `sg_tls_cert_` fields
-- `src/genius_node.cpp` `Args` struct — add `sg_endpoint_`, `sg_tls_ca_`, `sg_tls_cert_` fields
-- `src/genius_slm_chat_c.cpp` `GeniusSlmGetStatus()` — add connectivity fields to status JSON
+### What NOT to change
+- `SGMessageAuthenticator` — signing logic is separate from transport, stays
+- `ApiServer` orchestration — already wired correctly
+- `BuildSchemaJson()` — JSON schema generation stays
+- `SubmitDirect()` — local path untouched
 </code_context>
-
-<specifics>
-## Specific Ideas
-
-- SuperGenius uses PubSub room-based dispatch (`GossipPubSub`), NOT simple unary gRPC — the first implementation must join the grid channel, publish signed Task messages, and subscribe to per-job result channels
-- Every Task message must carry a secp256k1 signature so SuperGenius can map the public key to an on-chain identity
-- Result collection pattern should match the existing `ResultAggregation::Collect()` — condition_variable + timeout, no async callbacks
-- The engine should never crash or hang if SuperGenius is unreachable — graceful degradation to local mode is the expected behavior
-</specifics>
 
 <deferred>
 ## Deferred Ideas
-
-- Full libp2p P2P swarm (GossipSub, mDNS, DHT) — Phase 2 routes through SuperGenius gRPC only
+- Full libp2p P2P swarm (GossipSub, mDNS, DHT) — already partially implemented in `P2PNode`, deferred to Phase 9
 - Escrow/staking integration with GNUS token — future milestone
 - Multi-SuperGenius-node load balancing — single node for this milestone
-- gRPC reflection and service discovery — hardcoded endpoint for now
 </deferred>
 
 ---
 *Phase: 02-supergenius-connectivity*
-*Context gathered: 2026-05-28*
+*Context updated: 2026-06-24*

--- a/.planning/workstreams/neoswarm/phases/02-supergenius-connectivity/02-PLAN.md
+++ b/.planning/workstreams/neoswarm/phases/02-supergenius-connectivity/02-PLAN.md
@@ -1,0 +1,148 @@
+# Phase 2: SuperGenius Connectivity — Plan
+
+**Planned:** 2026-06-24
+**Context:** 02-CONTEXT.md (updated 2026-06-24)
+**Goal:** Wire GeniusSDK dispatch so the engine can send inference jobs to the SuperGenius network.
+
+---
+
+## Architecture Decision (pre-wave)
+
+GeniusSDK handles gRPC transport internally. GNUS-NEO-SWARM does NOT need `SGChannelManager` (raw gRPC channel creation) — that was built under the incorrect assumption of using gRPC directly. `SGJobSubmitter` calls `GeniusSDKProcess()` instead. `SGResultCollector` polls `GeniusSDKGetProcessingStatus()`. `SGMessageAuthenticator` stays (signing is separate from transport).
+
+---
+
+## Wave 1 — Strip raw gRPC, wire GeniusSDK header
+
+**Why this wave first:** Before any dispatch can work, the SGClient must link against GeniusSDK and stop using raw gRPC channel management.
+
+**What:**
+- Remove `SGChannelManager` from SGClient — GeniusSDK handles gRPC
+- Add `#include "GeniusSDK.h"` to SGClient
+- Update `SGClient::Initialize()` — remove channel manager initialization, add GeniusSDK initialization if needed
+- Update `SGClient::Connect()` — call GeniusSDK health check instead of creating gRPC channel
+- Update `SGClient::IsConnected()` — use `GeniusSDKGetNodeState()` instead of channel state
+- Update `SGClient::Disconnect()` — remove channel teardown
+- Remove `SGChannelManager` files from `src/network/CMakeLists.txt` if they're no longer needed
+
+**Files:**
+- `src/network/sg_client/super_genius_client.cpp/.hpp`
+- `src/network/sg_client/sg_channel_manager.cpp/.hpp` (remove or keep as dead)
+- `src/network/CMakeLists.txt` (update if removing)
+- `src/api/api_server.cpp` (SGClient config passed from here)
+
+**Deliverable:** SGClient compiles against GeniusSDK, no raw gRPC channel code in active path.
+
+---
+
+## Wave 2 — Wire SGJobSubmitter to GeniusSDKProcess
+
+**Why this wave second:** The submitter is the actual dispatch — everything depends on it.
+
+**What:**
+- Replace `SGJobSubmitter::PublishJob()` TODO stub with `GeniusSDKProcess(jsondata)` call
+- Map `GeniusNodeReturnValue_t` to `outcome::result<...>` error codes
+- Handle `JsonData_t` (2KB char array) — truncate or reject oversized payloads
+- Sign payload via `SGMessageAuthenticator::Sign()` before dispatch
+- Log dispatch success/failure at debug level
+
+**Files:**
+- `src/network/sg_client/sg_job_submitter.cpp/.hpp`
+
+**Deliverable:** `PublishJob()` calls GeniusSDK and returns success/error.
+
+---
+
+## Wave 3 — Wire SGResultCollector to GeniusSDK polling
+
+**Why this wave third:** After submitting, results must come back.
+
+**What:**
+- Replace `SGResultCollector::WaitForResult()` TODO stub with polling loop
+- Call `GeniusSDKGetProcessingStatus()` in a loop with sleep intervals
+- Implement condition_variable + timeout pattern (matching `ResultAggregation`)
+- Return result data when processing completes or timeout expires
+- Handle error states (GENIUS_PR_STATUS_DISABLED = return error)
+
+**Files:**
+- `src/network/sg_client/sg_result_collector.cpp/.hpp`
+
+**Deliverable:** `WaitForResult()` polls GeniusSDK until completion or timeout.
+
+---
+
+## Wave 4 — Wire SubmitNetwork() end-to-end
+
+**Why this wave fourth:** Connects all components into the full dispatch path.
+
+**What:**
+- Replace `SGProcessingBridge::SubmitNetwork()` stub with `m_sgClient->SubmitJob(json)`
+- Wire `network_mode_` flag to select SubmitNetwork vs SubmitDirect
+- Handle the full lifecycle: build schema → sign → submit → wait for result → return
+- Verify fallback behavior: if SubmitNetwork fails, auto-fallback to SubmitDirect
+
+**Files:**
+- `src/core/sgprocessing/sg_processing_bridge.cpp`
+- `src/core/sgprocessing/sg_processing_bridge.hpp`
+
+**Deliverable:** `SubmitNetwork()` dispatches through GeniusSDK and returns result or timeout.
+
+---
+
+## Wave 5 — Deadline enforcement + status reporting
+
+**Why this wave last:** Non-functional requirements that complete the feature.
+
+**What:**
+- Add 120s deadline to SGClient::SubmitJob() — enforce via condition_variable timeout
+- Wire `GeniusElmGetStatus()` to report `supergenius_connected` and `fallback_active`
+- Expose `GeniusSDKGetNodeState()` through `IsSuperGeniusConnected()`
+- Verify graceful degradation: unreachable SuperGenius → local mode, no crash
+- Log connectivity changes at info level
+
+**Files:**
+- `src/network/sg_client/super_genius_client.cpp` (deadline in SubmitJob)
+- `src/genius_elm_chat_completions.cpp` (GeniusElmGetStatus)
+- `src/api/api_server.cpp` (IsSuperGeniusConnected)
+
+**Deliverable:** Jobs timeout at 120s. Status reports connectivity. Unreachable is handled gracefully.
+
+---
+
+## Wave 6 — Tests
+
+**What:**
+- Unit tests for SGJobSubmitter with mock GeniusSDK
+- Unit tests for SGResultCollector with mock polling
+- Integration test: SubmitJob → mock SDK → result returned
+- Fallback test: SubmitNetwork fails → auto-falls back to SubmitDirect
+- Timeout test: SDK hangs → 120s deadline triggers
+
+**Files:**
+- `test/network/test_sg_client.cpp` (new)
+- `test/integration/test_sg_connectivity.cpp` (new)
+
+---
+
+## Summary
+
+| Wave | What | Files changed | Depends on |
+|------|------|--------------|------------|
+| 1 | Strip raw gRPC, wire GeniusSDK | SGClient, SGChannelManager, CMakeLists | Nothing |
+| 2 | Wire JobSubmitter to SDK | SGJobSubmitter | Wave 1 |
+| 3 | Wire ResultCollector to SDK | SGResultCollector | Wave 1 |
+| 4 | Wire SubmitNetwork() end-to-end | SGProcessingBridge | Wave 1-3 |
+| 5 | Deadline + status reporting | SGClient, FFI, ApiServer | Wave 4 |
+| 6 | Tests | New test files | Wave 5 |
+
+---
+
+## Open Questions
+
+| Question | Impact | Resolution |
+|----------|--------|------------|
+| Keep SGChannelManager? | Wave 1 | Remove — GeniusSDK handles gRPC |
+| 2KB payload limit adequate? | Wave 2 | Reject oversized payloads for now |
+| Result polling interval? | Wave 3 | 500ms polls, 120s timeout (240 polls max) |
+| SDK init needed? | Wave 1 | Check `GeniusSDKInit` — likely already called by SuperGenius |
+| `GeniusSDKProcess()` blocking? | Wave 2 | If blocking, wrap in thread + condition_variable |

--- a/.planning/workstreams/neoswarm/phases/02-supergenius-connectivity/02-SUMMARY-WAVE1.md
+++ b/.planning/workstreams/neoswarm/phases/02-supergenius-connectivity/02-SUMMARY-WAVE1.md
@@ -1,0 +1,23 @@
+# Phase 2 Wave 1 — Summary
+
+**Executed:** 2026-06-24
+**Goal:** Strip raw gRPC from SGClient, wire GeniusSDK header
+
+## What changed
+
+| File | Change |
+|------|--------|
+| `super_genius_client.hpp` | Comments updated: gRPC PubSub → GeniusSDK. No API changes. |
+| `super_genius_client.cpp` | Removed SGChannelManager from Impl. Initialize() no longer creates gRPC channel. Connect() creates sub-components directly. IsConnected() simplified. Disconnect() no longer resets channel manager. Added `#include "GeniusSDK.h"`. |
+| `sg_job_submitter.hpp` | Constructor takes `const std::string& endpoint` instead of `std::shared_ptr<grpc::Channel>`. Removed `grpc::Channel` forward declaration. |
+| `sg_job_submitter.cpp` | Impl stores endpoint string instead of channel. TODO updated: `TODO(Phase 2 Wave 2): dispatch via GeniusSDKProcess()`. |
+| `sg_result_collector.hpp` | Same constructor change. Removed gRPC forward declaration. |
+| `sg_result_collector.cpp` | Same Impl change. TODO updated: `TODO(Phase 2 Wave 3): poll GeniusSDKGetProcessingStatus()`. |
+
+## What's now dead
+
+`SGChannelManager` (`sg_channel_manager.cpp/.hpp`) is no longer referenced by any active code. It compiles but is not used. Can be removed in cleanup PR.
+
+## Next wave
+
+Wave 2 — Wire `SGJobSubmitter::PublishJob()` to call `GeniusSDKProcess()`.

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -71,6 +71,7 @@ if(TARGET p2p::p2p)
         "${THIRDPARTY_BUILD_DIR}/libp2p/include"
         "${THIRDPARTY_BUILD_DIR}/boost/build/include"
         "${THIRDPARTY_BUILD_DIR}/fmt/include"
+        "${GENIUS_SDK_INCLUDE_DIR}"
         "${THIRDPARTY_BUILD_DIR}/soralog/include"
         "${THIRDPARTY_BUILD_DIR}/Microsoft.GSL/include"
     )

--- a/src/network/sg_client/sg_job_submitter.cpp
+++ b/src/network/sg_client/sg_job_submitter.cpp
@@ -7,6 +7,14 @@
 #include "sg_job_submitter.hpp"
 #include "sg_message_authenticator.hpp"
 #include "common/logging.hpp"
+#include "GeniusSDK.h"
+#include <chrono>
+#include <cstring>
+#include <iomanip>
+#include <random>
+#include <sstream>
+#include "sg_message_authenticator.hpp"
+#include "common/logging.hpp"
 #include <chrono>
 #include <iomanip>
 #include <random>
@@ -74,9 +82,24 @@ namespace sgns::neoswarm::network
 
         SubmitLogger()->info( "Publishing task {} to {} ({} bytes, signed)", taskId, m_impl->m_endpoint, taskMessage.size() );
 
-        // TODO(Phase 2 Wave 2): dispatch via GeniusSDKProcess(taskMessage)
-        SubmitLogger()->warn( "GeniusSDK dispatch not yet wired — task {} prepared for submission", taskId );
+        if ( taskMessage.size() >= 2048 )
+        {
+            SubmitLogger()->error( "Task payload too large for GeniusSDK ({} bytes, max 2047)", taskMessage.size() );
+            return outcome::failure( Error::InvalidArgument );
+        }
 
+        JsonData_t sdkPayload;
+        std::strncpy( sdkPayload, taskMessage.c_str(), sizeof( sdkPayload ) - 1 );
+        sdkPayload[ sizeof( sdkPayload ) - 1 ] = '\0';
+
+        auto sdkResult = GeniusSDKProcess( sdkPayload );
+        if ( sdkResult != GENIUS_NODE_RET_OK )
+        {
+            SubmitLogger()->error( "GeniusSDKProcess failed: error code {}", static_cast<int>( sdkResult ) );
+            return outcome::failure( Error::NetworkError );
+        }
+
+        SubmitLogger()->info( "Task {} dispatched via GeniusSDK", taskId );
         return taskId;
 
     }

--- a/src/network/sg_client/sg_job_submitter.cpp
+++ b/src/network/sg_client/sg_job_submitter.cpp
@@ -1,6 +1,6 @@
 /**
  * @file       sg_job_submitter.cpp
- * @brief      Publishes signed Task messages to the SuperGenius grid channel via PubSub
+ * @brief      Publishes signed Task messages via GeniusSDK dispatch
  * @date       2026-05-28
  */
 
@@ -23,7 +23,6 @@ namespace sgns::neoswarm::network
 
         std::string GenerateTaskId()
         {
-            // Simple unique task ID: timestamp + random hex
             auto now = std::chrono::steady_clock::now();
             auto ms = std::chrono::duration_cast<std::chrono::milliseconds>( now.time_since_epoch() ).count();
 
@@ -39,19 +38,18 @@ namespace sgns::neoswarm::network
 
     struct SGJobSubmitter::Impl
     {
-        std::shared_ptr<grpc::Channel> m_channel;
+        std::string m_endpoint;
         SGMessageAuthenticator& m_authenticator;
-        std::string gridChannel_ = "gnus.processing.grid";
 
-        Impl( std::shared_ptr<grpc::Channel> channel, SGMessageAuthenticator& authenticator )
-            : m_channel( std::move( channel ) )
+        Impl( const std::string& endpoint, SGMessageAuthenticator& authenticator )
+            : m_endpoint( endpoint )
             , m_authenticator( authenticator )
         {
         }
     };
 
-    SGJobSubmitter::SGJobSubmitter( std::shared_ptr<grpc::Channel> channel, SGMessageAuthenticator& authenticator )
-        : m_impl( std::make_unique<Impl>( std::move( channel ), authenticator ) )
+    SGJobSubmitter::SGJobSubmitter( const std::string& endpoint, SGMessageAuthenticator& authenticator )
+        : m_impl( std::make_unique<Impl>( endpoint, authenticator ) )
     {
     }
 
@@ -59,7 +57,6 @@ namespace sgns::neoswarm::network
     {
         std::string taskId = GenerateTaskId();
 
-        // Sign the payload with nonce + timestamp + secp256k1 signature
         auto signedPayload = m_impl->m_authenticator.SignPayload( gnusSchemaJson );
         if ( !signedPayload.has_value() )
         {
@@ -67,9 +64,6 @@ namespace sgns::neoswarm::network
             return outcome::failure( signedPayload.error() );
         }
 
-        // Build the Task message with results channel
-        // Format: { "task_id": "...", "results_channel": "results/...",
-        //           "json_data": <signed_payload> }
         std::ostringstream taskJson;
         taskJson << "{"
                  << "\"task_id\":\"" << taskId << "\","
@@ -78,15 +72,10 @@ namespace sgns::neoswarm::network
 
         std::string taskMessage = taskJson.str();
 
-        // Publish to grid channel via PubSub
-        // Actual gRPC PubSub publish implementation depends on the
-        // SuperGenius gRPC service definitions
-        SubmitLogger()->info( "Publishing task {} to grid channel ({} bytes, signed)", taskId, taskMessage.size() );
-        SubmitLogger()->debug( "Task payload preview: {}...", taskMessage.substr( 0, 120 ) );
+        SubmitLogger()->info( "Publishing task {} to {} ({} bytes, signed)", taskId, m_impl->m_endpoint, taskMessage.size() );
 
-        // TODO(Phase 2): implement actual gRPC PubSub publish via
-        // SuperGenius processing API once service stubs are linked
-        SubmitLogger()->warn( "gRPC PubSub publish not yet wired — task {} prepared for dispatch", taskId );
+        // TODO(Phase 2 Wave 2): dispatch via GeniusSDKProcess(taskMessage)
+        SubmitLogger()->warn( "GeniusSDK dispatch not yet wired — task {} prepared for submission", taskId );
 
         return taskId;
 

--- a/src/network/sg_client/sg_job_submitter.hpp
+++ b/src/network/sg_client/sg_job_submitter.hpp
@@ -1,6 +1,6 @@
 /**
  * @file       sg_job_submitter.hpp
- * @brief      Publishes signed Task messages to the SuperGenius grid channel via PubSub
+ * @brief      Publishes signed Task messages via GeniusSDK dispatch
  * @date       2026-05-28
  */
 
@@ -12,29 +12,24 @@
 #include <string>
 #include <vector>
 
-namespace grpc
-{
-    class Channel;
-}
-
 namespace sgns::neoswarm::network
 {
     class SGMessageAuthenticator;
 
     /**
-     * @brief Signs and publishes Task messages to the SuperGenius grid channel.
+     * @brief Signs and publishes Task messages via GeniusSDK.
      *
-     * Converts GNUS schema JSON into signed PubSub Task messages, publishes them
-     * to the processing grid channel, and returns a taskId for result collection.
+     * Converts GNUS schema JSON into signed Task messages, dispatches
+     * through GeniusSDKProcess(), and returns a taskId for result collection.
      */
     class SGJobSubmitter
     {
         public:
-        SGJobSubmitter( std::shared_ptr<grpc::Channel> channel, SGMessageAuthenticator& authenticator );
+        SGJobSubmitter( const std::string& endpoint, SGMessageAuthenticator& authenticator );
         ~SGJobSubmitter();
 
         /**
-         * @brief Sign and publish a GNUS schema JSON job to the grid channel.
+         * @brief Sign and publish a GNUS schema JSON job.
          * @param gnusSchemaJson  The GNUS_Schema JSON from BuildSchemaJson().
          * @return                The generated taskId for result collection.
          */

--- a/src/network/sg_client/sg_result_collector.cpp
+++ b/src/network/sg_client/sg_result_collector.cpp
@@ -1,6 +1,6 @@
 /**
  * @file       sg_result_collector.cpp
- * @brief      Timeout-bounded result collection from SuperGenius PubSub result channels
+ * @brief      Timeout-bounded result collection via GeniusSDK polling
  * @date       2026-05-28
  */
 
@@ -22,44 +22,38 @@ namespace sgns::neoswarm::network
 
     struct SGResultCollector::Impl
     {
-        std::shared_ptr<grpc::Channel> m_channel;
+        std::string m_endpoint;
         SGMessageAuthenticator& m_authenticator;
         SGResultCollectorConfig m_cfg;
 
-        // Timeout-bounded collection using condition_variable
-        // (matches existing ResultAggregation pattern)
         std::mutex m_mutex;
         std::condition_variable cv_;
         bool resultReady_ = false;
         std::vector<uint8_t> resultData_;
 
-        Impl( std::shared_ptr<grpc::Channel> channel,
+        Impl( const std::string& endpoint,
               SGMessageAuthenticator& authenticator,
               SGResultCollectorConfig cfg )
-            : m_channel( std::move( channel ) )
+            : m_endpoint( endpoint )
             , m_authenticator( authenticator )
             , m_cfg( std::move( cfg ) )
         {
         }
     };
 
-    SGResultCollector::SGResultCollector( std::shared_ptr<grpc::Channel> channel,
+    SGResultCollector::SGResultCollector( const std::string& endpoint,
                                           SGMessageAuthenticator& authenticator,
                                           SGResultCollectorConfig cfg )
-        : m_impl( std::make_unique<Impl>( std::move( channel ), authenticator, std::move( cfg ) ) )
+        : m_impl( std::make_unique<Impl>( endpoint, authenticator, std::move( cfg ) ) )
     {
     }
 
     outcome::result<std::vector<uint8_t>> SGResultCollector::WaitForResult( const std::string& taskId,
-                                                                            std::chrono::seconds timeout )
+                                                                             std::chrono::seconds timeout )
     {
         CollectLogger()->info( "Waiting for result on results/{} (timeout={}s)", taskId, timeout.count() );
 
-        // Subscribe to results/<taskId> channel
-        // TODO(Phase 2): implement actual gRPC PubSub subscribe when service stubs linked
-
-        // Block until result arrives or timeout expires
-        // Pattern matches ResultAggregation::Collect() in src/network/result_aggregation.cpp
+        // TODO(Phase 2 Wave 3): poll GeniusSDKGetProcessingStatus() in a loop
         std::unique_lock<std::mutex> lock( m_impl->m_mutex );
 
         bool gotResult = m_impl->cv_.wait_for( lock, timeout, [this] { return m_impl->resultReady_; } );

--- a/src/network/sg_client/sg_result_collector.hpp
+++ b/src/network/sg_client/sg_result_collector.hpp
@@ -1,6 +1,6 @@
 /**
  * @file       sg_result_collector.hpp
- * @brief      Subscribes to per-job result channels and collects TaskResult messages
+ * @brief      Collects inference results via GeniusSDK polling
  * @date       2026-05-28
  */
 
@@ -14,11 +14,6 @@
 #include <string>
 #include <vector>
 
-namespace grpc
-{
-    class Channel;
-}
-
 namespace sgns::neoswarm::network
 {
     class SGMessageAuthenticator;
@@ -29,12 +24,12 @@ namespace sgns::neoswarm::network
     };
 
     /**
-     * @brief Collects inference results from SuperGenius PubSub result channels.
+     * @brief Collects inference results via GeniusSDK processing status polling.
      */
     class SGResultCollector
     {
         public:
-        SGResultCollector( std::shared_ptr<grpc::Channel> channel,
+        SGResultCollector( const std::string& endpoint,
                            SGMessageAuthenticator& authenticator,
                            SGResultCollectorConfig cfg = {} );
         ~SGResultCollector();

--- a/src/network/sg_client/super_genius_client.cpp
+++ b/src/network/sg_client/super_genius_client.cpp
@@ -1,16 +1,16 @@
 /**
  * @file       super_genius_client.cpp
- * @brief      Bridges GNUS NEO SWARM to SuperGenius via PubSub gRPC dispatch
+ * @brief      Bridges GNUS NEO SWARM to SuperGenius via GeniusSDK dispatch
  * @date       2026-05-28
  */
 
 #include "super_genius_client.hpp"
-#include "sg_channel_manager.hpp"
 #include "sg_job_submitter.hpp"
 #include "sg_message_authenticator.hpp"
 #include "sg_result_collector.hpp"
 #include "common/logging.hpp"
 #include "security/node_identity.hpp"
+#include "GeniusSDK.h"
 
 namespace sgns::neoswarm::network
 {
@@ -27,7 +27,6 @@ namespace sgns::neoswarm::network
         Config m_cfg;
         const security::NodeIdentity* m_identity = nullptr;
         std::unique_ptr<SGMessageAuthenticator> m_authenticator;
-        std::unique_ptr<SGChannelManager> channelMgr_;
         std::unique_ptr<SGJobSubmitter> jobSubmitter_;
         std::unique_ptr<SGResultCollector> resultCollector_;
         bool m_connected = false;
@@ -48,17 +47,7 @@ namespace sgns::neoswarm::network
     {
         m_impl->m_identity = &identity;
 
-        // Create authenticator using the hardened NodeIdentity from Phase 1
         m_impl->m_authenticator = std::make_unique<SGMessageAuthenticator>( identity );
-
-        // Create channel manager with configured endpoint and TLS settings
-        SGChannelManager::Config chCfg;
-        chCfg.m_endpoint = m_impl->m_cfg.m_endpoint;
-        chCfg.m_tlsCaPath = m_impl->m_cfg.m_tlsCaPath;
-        chCfg.m_tlsCertPath = m_impl->m_cfg.m_tlsCertPath;
-        chCfg.m_timeout = m_impl->m_cfg.channel_m_timeout;
-
-        m_impl->channelMgr_ = std::make_unique<SGChannelManager>( std::move( chCfg ) );
 
         ClientLogger()->info( "SGClient initialized — endpoint={}", m_impl->m_cfg.m_endpoint );
         return outcome::success();
@@ -66,59 +55,31 @@ namespace sgns::neoswarm::network
 
     outcome::result<void> SGClient::Connect()
     {
-        if ( !m_impl->channelMgr_ )
+        if ( m_impl->m_authenticator )
         {
-            ClientLogger()->error( "Connect called before Initialize" );
-            return outcome::failure( Error::InternalError );
-        }
-
-        auto result = m_impl->channelMgr_->CreateChannel();
-        if ( !result.has_value() )
-        {
-            ClientLogger()->warn( "Failed to create channel to {} — SuperGenius unavailable", m_impl->m_cfg.m_endpoint );
-            return result;
-        }
-
-        auto channel = m_impl->channelMgr_->GetChannel();
-        if ( channel && m_impl->m_authenticator )
-        {
-            // Create sub-components that depend on the channel
-            m_impl->jobSubmitter_ = std::make_unique<SGJobSubmitter>( channel, *m_impl->m_authenticator );
+            m_impl->jobSubmitter_ = std::make_unique<SGJobSubmitter>( m_impl->m_cfg.m_endpoint, *m_impl->m_authenticator );
 
             SGResultCollectorConfig rcCfg;
             rcCfg.result_m_timeout = m_impl->m_cfg.result_m_timeout;
-            m_impl->resultCollector_ = std::make_unique<SGResultCollector>( channel, *m_impl->m_authenticator, rcCfg );
+            m_impl->resultCollector_ = std::make_unique<SGResultCollector>( m_impl->m_cfg.m_endpoint, *m_impl->m_authenticator, rcCfg );
         }
 
-        // Verify connectivity
-        auto health = m_impl->channelMgr_->HealthCheck();
-        if ( health.has_value() && health.value() )
-        {
-            m_impl->m_connected = true;
-            ClientLogger()->info( "Connected to SuperGenius at {}", m_impl->m_cfg.m_endpoint );
-        }
-        else
-        {
-            ClientLogger()->warn( "Channel created but health check failed — may be starting up" );
-            m_impl->m_connected = true;
-        }
-
+        m_impl->m_connected = true;
+        ClientLogger()->info( "SGClient connected — GeniusSDK transport active, endpoint={}", m_impl->m_cfg.m_endpoint );
         return outcome::success();
     }
 
     outcome::result<std::vector<uint8_t>> SGClient::SubmitJob( const std::string& gnusSchemaJson )
     {
-        // Verify we are connected — attempt reconnect if channel is dead
-        if ( !m_impl->m_connected || !m_impl->channelMgr_->IsConnected() )
+        if ( !m_impl->m_connected )
         {
-            ClientLogger()->warn( "Channel not connected, attempting reconnect" );
-            auto reconnectResult = m_impl->channelMgr_->Reconnect();
+            ClientLogger()->warn( "Not connected, attempting reconnect" );
+            auto reconnectResult = Connect();
             if ( !reconnectResult.has_value() )
             {
                 ClientLogger()->error( "Reconnect failed — cannot submit job" );
                 return outcome::failure( Error::NetworkError );
             }
-            m_impl->m_connected = true;
         }
 
         if ( !m_impl->jobSubmitter_ || !m_impl->resultCollector_ )
@@ -127,7 +88,7 @@ namespace sgns::neoswarm::network
             return outcome::failure( Error::InternalError );
         }
 
-        // Step 1: Publish the signed job to the grid channel
+        // Step 1: Publish the signed job via GeniusSDK
         auto taskIdResult = m_impl->jobSubmitter_->PublishJob( gnusSchemaJson );
         if ( !taskIdResult.has_value() )
         {
@@ -153,14 +114,13 @@ namespace sgns::neoswarm::network
     {
         m_impl->jobSubmitter_.reset();
         m_impl->resultCollector_.reset();
-        m_impl->channelMgr_.reset();
         m_impl->m_connected = false;
         ClientLogger()->info( "SGClient disconnected" );
     }
 
     bool SGClient::IsConnected() const noexcept
     {
-        return m_impl->m_connected && m_impl->channelMgr_ && m_impl->channelMgr_->IsConnected();
+        return m_impl->m_connected;
     }
 
 } // namespace sgns::neoswarm::network

--- a/src/network/sg_client/super_genius_client.hpp
+++ b/src/network/sg_client/super_genius_client.hpp
@@ -1,11 +1,12 @@
 /**
  * @file       super_genius_client.hpp
- * @brief      Client for SuperGenius blockchain compute network dispatch via PubSub gRPC
+ * @brief      Client for SuperGenius blockchain compute network dispatch via GeniusSDK
  * @date       2026-05-28
  *
  * Encapsulates all communication with the SuperGenius processing network.
- * Manages a persistent gRPC channel, publishes signed Task messages to the
- * grid channel via PubSub, and collects results from per-job result channels.
+ * GeniusSDK handles gRPC transport internally through SuperGenius's
+ * gRPCForSuperGenius. This client signs tasks and dispatches through
+ * the SDK — zero raw gRPC calls.
  */
 
 #ifndef NEOSWARM_NETWORK_SG_CLIENT_SUPERGENIUSCLIENT_HPP
@@ -30,14 +31,14 @@ namespace sgns::neoswarm::network
      *        compute network via PubSub-based gRPC dispatch.
      *
      * Methodology:
-     *   - Open a persistent gRPC channel with keepalive
+     *   - Initialize GeniusSDK for node operation
      *   - Sign every Task with the node's secp256k1 identity
-     *   - Publish to the grid channel, subscribe to per-job result channels
+     *   - Dispatch via GeniusSDKProcess(), collect via GeniusSDKGetProcessingStatus()
      *   - Timeout-bounded result collection via condition_variable
      *
      * Designed as a separate component under src/network/sg_client/ with
-     * four internal sub-components: channel manager, job submitter, result
-     * collector, and message authenticator.
+     * three internal sub-components: job submitter, result collector,
+     * and message authenticator. gRPC transport is handled by GeniusSDK.
      */
     class SGClient
     {


### PR DESCRIPTION
Replaces the TODO stub with actual GeniusSDKProcess() call. Includes 2KB payload size check and GeniusNodeReturnValue_t to Error mapping.