### PR TITLE
fix(test): use GetPeerId/GetPublicKey accessors in security tests

### DIFF
--- a/test/security/test_message_signing.cpp
+++ b/test/security/test_message_signing.cpp
@@ -181,7 +181,7 @@ TEST( MessageSigning, VerifyAndStrip_MalformedJson_ReturnsFalse )
 {
     NodeIdentity ident;
     ASSERT_TRUE( ident.Generate().has_value() );
-    std::string pubKeyHex = PubKeyToHex( ident.PublicKey() );
+    std::string pubKeyHex = PubKeyToHex( ident.GetPublicKey() );
 
     std::string payload = "not json";
     EXPECT_FALSE( MessageSigning::VerifyAndStrip( payload, pubKeyHex ) );
@@ -191,7 +191,7 @@ TEST( MessageSigning, VerifyAndStrip_EmptyPayload_ReturnsFalse )
 {
     NodeIdentity ident;
     ASSERT_TRUE( ident.Generate().has_value() );
-    std::string pubKeyHex = PubKeyToHex( ident.PublicKey() );
+    std::string pubKeyHex = PubKeyToHex( ident.GetPublicKey() );
     std::string payload;
 
     EXPECT_FALSE( MessageSigning::VerifyAndStrip( payload, pubKeyHex ) );

--- a/test/security/test_node_identity.cpp
+++ b/test/security/test_node_identity.cpp
@@ -196,11 +196,11 @@ TEST( NodeIdentity, PeerId_ConsistentForSameKey )
     NodeIdentity ident1;
     ASSERT_TRUE( ident1.Generate().has_value() );
     ASSERT_TRUE( ident1.SaveToFile( kTestKeyPath ).has_value() );
-    std::string peerId1 = ident1.PeerId();
+    std::string peerId1 = ident1.GetPeerId();
 
     NodeIdentity ident2;
     ASSERT_TRUE( ident2.LoadFromFile( kTestKeyPath ).has_value() );
-    std::string peerId2 = ident2.PeerId();
+    std::string peerId2 = ident2.GetPeerId();
 
     EXPECT_EQ( peerId1, peerId2 );
     EXPECT_FALSE( peerId1.empty() );
@@ -232,7 +232,7 @@ TEST( NodeIdentity, LoadEncrypted_TruncatedFile_ReturnsError )
 TEST( NodeIdentity, PeerId_WithoutKey_ReturnsEmpty )
 {
     NodeIdentity ident;
-    EXPECT_TRUE( ident.PeerId().empty() );
+    EXPECT_TRUE( ident.GetPeerId().empty() );
 }
 
 TEST( NodeIdentity, LoadFromFile_EmptyPath_ReturnsError )


### PR DESCRIPTION
The security tests were written against the 01-04 plan template using `PeerId()` and `PublicKey()` method names. After the Get prefix refactor, the actual accessors are `GetPeerId()` and `GetPublicKey()`. This causes build failures on develop.

Fixes:
- test_node_identity.cpp: 3x `PeerId()` → `GetPeerId()`
- test_message_signing.cpp: 2x `PublicKey()` → `GetPublicKey()`

Build verified: test_node_identity (14/14) and test_message_signing (12/12) pass with real secp256k1 + AES-256-GCM.