### PR TITLE
Phase 7 Wave 1: core ELM types + IELM interface + neoswarm_elm library

### DIFF
--- a/.planning/active-workstream
+++ b/.planning/active-workstream
@@ -1,1 +1,1 @@
-poc
+neoswarm

--- a/.planning/workstreams/neoswarm/REQUIREMENTS.md
+++ b/.planning/workstreams/neoswarm/REQUIREMENTS.md
@@ -52,6 +52,12 @@ Requirements for production readiness milestone. Each maps to roadmap phases.
 - [ ] **TEST-03**: Knowledge module tests — FactValidation accuracy, KnowledgeRetrieval relevance
 - [ ] **TEST-04**: Network integration tests — two P2PNode instances exchange a task, ResultAggregation timeout
 
+### ELM (Phase 7 Expert Language Models + Router)
+
+- [x] **ELM-03**: ELMRole enum (10 values: Planner=0 through Science=9) + ELMContext struct in common/types.hpp (07-01)
+- [x] **ELM-05**: ChainStep + ExecutionChain structs for flat sequential ELM chains (07-01)
+- [x] **ELM-core**: IELM abstract interface with 6 pure virtuals: GetName, GetRole, IsLoaded, Load, Process(input, ELMContext), GetConfidence (07-01)
+
 ### Network (Promoted from v2)
 
 - [x] **NET-01**: libp2p P2P network with GossipSub pubsub (implemented: `P2PNode` in `src/network/p2p_node.*` — Noise encryption, Yamux multiplexing)
@@ -126,11 +132,14 @@ Which phases cover which requirements. Updated 2026-06-18 after refactor.
 | TEST-03 | Phase 6 | Pending |
 | TEST-04 | Phase 6 | Pending |
 | NET-01 | Phase 2 | ✅ Done (libp2p GossipSub) |
+| ELM-03 | Phase 7 | ✅ Done (07-01) |
+| ELM-05 | Phase 7 | ✅ Done (07-01) |
+| ELM-core | Phase 7 | ✅ Done (07-01) |
 
 **Coverage:**
-- v1 requirements: 27 total (26 original + NET-01 promoted)
-- Done: 16 (59%)
-- Pending: 11 (41%)
+- v1 requirements: 30 total (26 original + NET-01 promoted + 3 ELM Phase 7)
+- Done: 19 (63%)
+- Pending: 11 (37%)
 - Unmapped: 0
 
 ---

--- a/.planning/workstreams/neoswarm/ROADMAP.md
+++ b/.planning/workstreams/neoswarm/ROADMAP.md
@@ -168,7 +168,7 @@ These phases evolve GNUS-NEO-SWARM from a production-hardened single-node infere
 
 ### Phases
 
-- [ ] **Phase 7: Expert Language Models + Router** — Role-based and domain-specific ELM orchestration with rule-based routing
+- [~] **Phase 7: Expert Language Models + Router** — Role-based and domain-specific ELM orchestration with rule-based routing
 - [ ] **Phase 8: Agentic Memory (GAML v1)** — Structured long-term memory with bridge blocks, facts, policies, CRDT convergence
 - [ ] **Phase 9: Swarm Networking + Distributed Execution** — Multi-node execution with reputation-weighted consensus
 - [ ] **Phase 10: AI Safety + Secure Agent Architecture** — Node-local safety, policy profiles, Tool Intermediary boundary
@@ -193,7 +193,7 @@ These phases evolve GNUS-NEO-SWARM from a production-hardened single-node infere
 **Plans:** 6 plans in 6 waves
 
 Plans:
-- [ ] 07-01-PLAN.md — Core types (ELMRole, ELMContext, ExecutionChain) + IELM interface + CMake scaffolding
+- [x] 07-01-PLAN.md — Core types (ELMRole, ELMContext, ExecutionChain) + IELM interface + CMake scaffolding
 - [ ] 07-02-PLAN.md — RoleELM (7 shared-backbone role templates) + DomainELM (Math/Code/Science, dual engine mode)
 - [ ] 07-03-PLAN.md — SpecialistAdapter (legacy Grammar→Refiner, Math→Math) + GroundingELM (knowledge pipeline) + ToolSupportELM (stub)
 - [ ] 07-04-PLAN.md — PromptAnalyzer extension (grounding/formatting features) + ELMChainBuilder (6 heuristic triggers)

--- a/.planning/workstreams/neoswarm/ROADMAP.md
+++ b/.planning/workstreams/neoswarm/ROADMAP.md
@@ -190,6 +190,16 @@ These phases evolve GNUS-NEO-SWARM from a production-hardened single-node infere
 - Router evolution path: heuristic MVP → lightweight classifier → cognitive planner
 - All ELMs behind abstract interfaces — implementations are swappable per architecture doc 03 §5.2.1
 
+**Plans:** 6 plans in 6 waves
+
+Plans:
+- [ ] 07-01-PLAN.md — Core types (ELMRole, ELMContext, ExecutionChain) + IELM interface + CMake scaffolding
+- [ ] 07-02-PLAN.md — RoleELM (7 shared-backbone role templates) + DomainELM (Math/Code/Science, dual engine mode)
+- [ ] 07-03-PLAN.md — SpecialistAdapter (legacy Grammar→Refiner, Math→Math) + GroundingELM (knowledge pipeline) + ToolSupportELM (stub)
+- [ ] 07-04-PLAN.md — PromptAnalyzer extension (grounding/formatting features) + ELMChainBuilder (6 heuristic triggers)
+- [ ] 07-05-PLAN.md — ApiServer RunELMChain orchestration + ELM registry + main.cpp elms JSON config
+- [ ] 07-06-PLAN.md — ELM unit tests (18 tests) + types tests + pipeline integration tests
+
 ### Phase 8: Agentic Memory (GAML v1)
 
 **Goal:** Replace stateless inference with structured long-term memory.
@@ -273,7 +283,7 @@ Phase 11: Advanced Cognition ◄────────── Phases 7–10
 
 | Phase | SPEC | PLAN | Status |
 |-------|------|------|--------|
-| 7. ELMs + Router | ✗ | ✗ | Not started |
+| 7. ELMs + Router | ✗ | ✓ | Planned (6 plans, 6 waves) |
 | 8. GAML Memory | ✗ | ✗ | Not started |
 | 9. Swarm Networking | ✗ | ✗ | Not started |
 | 10. AI Safety + Secure Agents | ✗ | ✗ | Not started |

--- a/.planning/workstreams/neoswarm/STATE.md
+++ b/.planning/workstreams/neoswarm/STATE.md
@@ -19,7 +19,7 @@ Progress: [████████░░░░░░░░░░░░░░] 5
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 7 (Phase 1: 3 source-complete, + Phase 2: 0)
+- Total plans completed: 8 (Phase 1: 3 source-complete, Phase 7: 1)
 - Refactor work: 22 commits across 6 phases (Phase 1,2a,2b,5,6,7 cleanup)
 
 **By Phase:**
@@ -34,6 +34,7 @@ Progress: [████████░░░░░░░░░░░░░░] 5
 | 6. Testing & Validation | 0/TBD | - | Needs plans |
 
 **Recent Trend:**
+- 2026-07-16: Phase 7 Wave 1 complete — ELM core types, IELM interface, CMake scaffolding (3 tasks, ~5 min)
 - 2026-06-22: Workstream bifurcation — C++ docs moved from root .planning/ into neoswarm/
 - 2026-06-18: Full SuperGenius coding-standards refactor complete — 24 source files, 10 roadmap phases
 - 2026-06-18: .planning/ documentation overhaul — ROADMAP corrected for GeniusSDK/libp2p, REQUIREMENTS re-verified, MLX artifacts purged
@@ -75,7 +76,7 @@ Post-production cognitive system evolution. Defined in ROADMAP.md, referencing `
 
 | Phase | SPEC | PLAN | Status |
 |-------|------|------|--------|
-| 7. ELMs + Router | ✗ | ✓ | Planned (6 plans) |
+| 7. ELMs + Router | ✗ | ✓ | Active (1/6 plans done) |
 | 8. GAML Memory | ✗ | ✗ | Not started |
 | 9. Swarm Networking | ✗ | ✗ | Not started |
 | 10. AI Safety + Secure Agents | ✗ | ✗ | Not started |
@@ -96,6 +97,6 @@ Items acknowledged and carried forward from previous milestone close:
 
 ## Session Continuity
 
-Last session: 2026-06-18
-Stopped at: REFACTOR_ROADMAP complete, .planning/ documentation updated, ready for Phase 2 planning
+Last session: 2026-07-16
+Stopped at: Completed 07-01-PLAN.md (ELM core types, IELM interface, CMake scaffolding)
 Resume file: None

--- a/.planning/workstreams/neoswarm/STATE.md
+++ b/.planning/workstreams/neoswarm/STATE.md
@@ -75,7 +75,7 @@ Post-production cognitive system evolution. Defined in ROADMAP.md, referencing `
 
 | Phase | SPEC | PLAN | Status |
 |-------|------|------|--------|
-| 7. ELMs + Router | ✗ | ✗ | Not started |
+| 7. ELMs + Router | ✗ | ✓ | Planned (6 plans) |
 | 8. GAML Memory | ✗ | ✗ | Not started |
 | 9. Swarm Networking | ✗ | ✗ | Not started |
 | 10. AI Safety + Secure Agents | ✗ | ✗ | Not started |

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-01-PLAN.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-01-PLAN.md
@@ -1,0 +1,434 @@
+---
+phase: 07-expert-language-models-router
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/common/types.hpp
+  - src/elm/i_elm.hpp
+  - src/elm/CMakeLists.txt
+  - src/CMakeLists.txt
+autonomous: true
+requirements:
+  - ELM-03 (ELMRole enum + ELMContext in common/types.hpp)
+  - ELM-05 (ChainStep + ExecutionChain structs)
+  - ELM-core (IELM interface definition)
+
+must_haves:
+  truths:
+    - "ELMRole enum compiles with 10 distinct values (Planner=0 through Science=9)"
+    - "ELMContext struct carries original task, last output, step confidences, and grounding facts"
+    - "ExecutionChain is a flat vector of ChainStep with reasoning string"
+    - "IELM interface has 6 pure virtuals: GetName, GetRole, IsLoaded, Load, Process(input,ELMContext), GetConfidence"
+    - "ExecutionMode::Chain=3 exists and is distinct from existing values"
+    - "neoswarm_elm library target compiles (empty or with i_elm.hpp only)"
+  artifacts:
+    - path: "src/common/types.hpp"
+      provides: "ELMRole, ELMContext, ChainStep, ExecutionChain, PromptFeatures extension, ExecutionMode::Chain"
+      contains: "enum class ELMRole"
+    - path: "src/elm/i_elm.hpp"
+      provides: "IELM abstract interface"
+      contains: "class IELM"
+    - path: "src/elm/CMakeLists.txt"
+      provides: "neoswarm_elm CMake library target"
+      contains: "add_library(neoswarm_elm"
+    - path: "src/CMakeLists.txt"
+      provides: "add_subdirectory for elm/"
+      contains: "add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/elm"
+  key_links:
+    - from: "src/elm/i_elm.hpp"
+      to: "src/common/types.hpp"
+      via: "#include \"common/types.hpp\""
+      pattern: "include.*common/types\\.hpp"
+    - from: "src/elm/CMakeLists.txt"
+      to: "src/common"
+      via: "target_link_libraries PUBLIC neoswarm_common"
+      pattern: "target_link_libraries.*neoswarm_common"
+---
+
+<objective>
+Establish the Phase 7 type system and abstract interface. All subsequent plans depend on the types, enums, structs, and the `IELM` interface defined here. This wave adds no behavior — it creates the contracts that all ELM implementations, adapters, the chain builder, and the orchestrator will implement against.
+
+**Purpose:** Foundation for swappable ELM architecture per doc 03 §5.2.1.
+**Output:** 1 modified file (types.hpp), 2 new files (i_elm.hpp, elm/CMakeLists.txt), 1 modified build config (src/CMakeLists.txt).
+</objective>
+
+<execution_context>
+@$HOME/.config/opencode/get-shit-done/workflows/execute-plan.md
+@$HOME/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md  (patterns #1, #10 — IELM, types)
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-VALIDATION.md
+@src/common/types.hpp
+@src/common/error.hpp
+@src/specialists/i_specialist.hpp
+@src/specialists/CMakeLists.txt
+@src/CMakeLists.txt
+./CLAUDE.md
+
+<interfaces>
+<!-- Key types from the codebase that IELM must reference -->
+From src/common/types.hpp (existing):
+```cpp
+struct Task { std::string m_id; std::string m_prompt; ExecutionMode m_mode; uint32_t m_maxTokens; float m_temperature; std::string m_nodeId; };
+struct KnowledgeFact { std::string m_source; std::string m_content; float m_relevanceScore; };
+enum class ExecutionMode : uint8_t { SingleNode = 0, Specialist = 1, Swarm = 2 };
+```
+
+From src/common/error.hpp:
+```cpp
+namespace sgns::neoswarm { namespace outcome = libp2p::outcome; }
+enum class Error : uint8_t { ModelLoadFailed = 1, InferenceFailed = 2, ... };
+```
+
+From src/specialists/i_specialist.hpp (exact analog for IELM):
+```cpp
+namespace sgns::neoswarm::specialists {
+class ISpecialist {
+    virtual ~ISpecialist() = default;
+    virtual std::string GetName() const = 0;
+    virtual bool IsLoaded() const = 0;
+    virtual outcome::result<void> Load(const std::string& model_path) = 0;
+    virtual outcome::result<std::string> Process(const std::string& input) = 0;
+    virtual float GetConfidence() const = 0;
+};
+}
+```
+IELM differs from ISpecialist per D-05: adds GetRole(), changes Process to take ELMContext.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>task 1: add ELM types to common/types.hpp</name>
+  <files>src/common/types.hpp</files>
+
+  <read_first>
+  - src/common/types.hpp (existing enum/struct patterns to replicate: ExecutionMode enum at lines 20-25, Task struct at lines 41-49, PromptFeatures struct at lines 82-90)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #10 (types.hpp additions)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md decisions D-05 (IELM signature), D-08 (ELMRole + ELMContext in types.hpp), D-09 (ExecutionChain flat list), D-12 (6 trigger heuristics)
+  - ./CLAUDE.md (naming: m_ prefix members, k-prefix constants, snake_case files, single exit point)
+  </read_first>
+
+  <behavior>
+    - Test 1: ELMRole enum compiles with 10 distinct values (Planner=0, PrimaryDraft=1, Verifier=2, Arbiter=3, Refiner=4, Grounding=5, ToolSupport=6, Math=7, Code=8, Science=9)
+    - Test 2: ExecutionMode::Chain=3 is distinct from SingleNode/Specialist/Swarm
+    - Test 3: PromptFeatures default-constructs with has_grounding_request_=false and has_formatting_request_=false
+    - Test 4: ELMContext default-constructs with all strings empty, vectors empty
+    - Test 5: ChainStep default-constructs with m_role=PrimaryDraft and m_domain=std::nullopt
+    - Test 6: ExecutionChain default-constructs with empty m_steps, empty m_reasoning, m_chainConfidence=0.0f
+    - Test 7: Existing types (Task, InferenceResponse, RouteDecision, etc.) still compile unchanged
+  </behavior>
+
+  <action>
+  Add four new type groups and extend three existing types in `src/common/types.hpp`, within `namespace sgns::neoswarm`:
+
+  **A) Add `ExecutionMode::Chain = 3`** (per D-09/D-13) — insert after `Swarm = 2` on line 24:
+  ```cpp
+          Swarm = 2,  ///< Mode 3 — Multiple nodes, weighted consensus
+          Chain = 3   ///< Mode 4 — Multi-step ELM chain (Phase 7+)
+  ```
+  The closing brace stays on the line after.
+
+  **B) Add `ELMRole` enum** — insert AFTER the `RouteTarget` enum (after line 36) and BEFORE the `Task` struct (before line 41):
+  ```cpp
+      // -----------------------------------------------------------------------
+      // ELM roles (doc 03 §5.2.1) — Phase 7
+      // -----------------------------------------------------------------------
+      enum class ELMRole : uint8_t
+      {
+          Planner = 0,      ///< Analyses task, determines execution plan
+          PrimaryDraft = 1, ///< Core draft generation (shared backbone)
+          Verifier = 2,     ///< Reviews outputs for correctness
+          Arbiter = 3,      ///< Resolves conflicts between outputs
+          Refiner = 4,      ///< Polishes formatting, style, grammar
+          Grounding = 5,    ///< Fact-checks against knowledge base
+          ToolSupport = 6,  ///< Tool-call formatting (stub in Phase 7)
+          Math = 7,         ///< Domain ELM — math
+          Code = 8,         ///< Domain ELM — code
+          Science = 9       ///< Domain ELM — science (shared-backbone only)
+      };
+  ```
+  Use `uint8_t` underlying type to match existing `ExecutionMode` and `RouteTarget` enums (pattern lines 20, 30). Doxygen comments on each value per CLAUDE.md standards.
+
+  **C) Add `PromptFeatures` fields** — add TWO new fields inside the `PromptFeatures` struct (after line 89 `has_grammar_request_`):
+  ```cpp
+          bool has_grounding_request_ = false;    ///< factual verification request detected (Phase 7)
+          bool has_formatting_request_ = false;   ///< structure/style formatting request detected (Phase 7)
+  ```
+  Add these before the closing brace and semicolon of the struct (existing layout: fields then `};`). Do NOT change existing field order, names, or defaults.
+
+  **D) Add `ELMContext` struct** — insert AFTER the `PromptFeatures` struct (after line 90's `};`) and BEFORE `NodeOutput` (before line 95):
+  ```cpp
+      // -----------------------------------------------------------------------
+      // ELM execution context (Phase 7 — doc 03 §5.2.1)
+      // -----------------------------------------------------------------------
+      struct ELMContext
+      {
+          std::string m_originalTask;                                   ///< the user's original prompt
+          std::string m_lastOutput;                                     ///< output of the immediately prior step
+          std::vector<std::pair<ELMRole, float>> m_stepConfidences;     ///< (role, confidence) per completed step
+          std::vector<KnowledgeFact> m_groundingFacts;                  ///< facts from GroundingELM, if any
+      };
+  ```
+  `KnowledgeFact` is already in scope (defined later in the file at line 125) but the struct uses it by name — the forward-reference is fine because these are all in the same namespace and file.
+
+  **E) Add `ChainStep` and `ExecutionChain` structs** — insert AFTER the `ELMContext` struct and BEFORE `NodeOutput`:
+  ```cpp
+      // -----------------------------------------------------------------------
+      // Chain step and execution chain (Phase 7 — doc 03 §6.2)
+      // -----------------------------------------------------------------------
+      struct ChainStep
+      {
+          ELMRole m_role = ELMRole::PrimaryDraft;
+          std::optional<std::string> m_domain; ///< e.g. "math", "code" — for domain ELMs
+      };
+
+      struct ExecutionChain
+      {
+          std::vector<ChainStep> m_steps;
+          std::string m_reasoning;          ///< why this chain was chosen
+          float m_chainConfidence = 0.0f;   ///< builder's confidence in this chain
+      };
+  ```
+
+  **Style rules:** Use `m_` prefix for all members (CLAUDE.md), Doxygen `///<` trailing comments, Allman braces (opening brace on its own line), 4-space indent, 120-char max lines. Follow the exact same comment-header pattern as existing blocks (e.g., lines 17-18: `// ---...\n// Section title\n// ---...`).
+
+  **DO NOT modify existing structs/fields except where explicitly listed above** — existing code must compile unchanged.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja neoswarm_common 2>&1 | tail -5</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "enum class ELMRole" src/common/types.hpp` returns 1
+    - `grep -c "Chain = 3" src/common/types.hpp` returns 1
+    - `grep -c "has_grounding_request_" src/common/types.hpp` returns 1
+    - `grep -c "m_chainConfidence" src/common/types.hpp` returns 1
+    - `ninja neoswarm_common` succeeds with zero errors and zero warnings from types.hpp
+    - All 10 ELMRole values have distinct integer values (0–9)
+    - PromptFeatures unchanged fields (numeric_density_, has_code_syntax_, etc.) retain original defaults
+  </acceptance_criteria>
+
+  <done>ELMRole, ELMContext, ChainStep, ExecutionChain compile. ExecutionMode has Chain value. PromptFeatures has grounding + formatting flags.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>task 2: create IELM abstract interface</name>
+  <files>src/elm/i_elm.hpp</files>
+
+  <read_first>
+  - src/specialists/i_specialist.hpp (exact analog — I-prefix abstract class, outcome::result signatures, namespace convention, include guard pattern, Doxygen headers)
+  - src/common/types.hpp (for ELMRole and ELMContext forward-declaration)
+  - src/common/error.hpp (for outcome namespace)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #1 (i_elm.hpp — exact adaptation from ISpecialist)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md decision D-05 (IELM contract)
+  </read_first>
+
+  <behavior>
+    - Test 1: IELM class declaration compiles (header-only, no .cpp needed)
+    - Test 2: IELM has exactly 6 pure virtual methods: GetName(), GetRole(), IsLoaded(), Load(path), Process(input, context), GetConfidence()
+    - Test 3: Process() signature is: `outcome::result<std::string> Process(const std::string& input, const ELMContext& context) = 0;`
+    - Test 4: Include guard is NEOSWARM_ELM_IELM_HPP
+    - Test 5: Namespace is sgns::neoswarm::elm
+  </behavior>
+
+  <action>
+  Create `src/elm/i_elm.hpp` — copy the exact structure of `src/specialists/i_specialist.hpp` (lines 1-54) with these modifications per D-05:
+
+  **File header (Doxygen):**
+  ```cpp
+  /**
+   * @file       i_elm.hpp
+   * @brief      Abstract interface for Expert Language Models (doc 03 §5.2)
+   * @date       2026-07-16
+   */
+  ```
+
+  **Include guard:**
+  ```cpp
+  #ifndef NEOSWARM_ELM_IELM_HPP
+  #define NEOSWARM_ELM_IELM_HPP
+  ```
+
+  **Includes:**
+  ```cpp
+  #include "common/error.hpp"
+  #include "common/types.hpp"
+  #include <string>
+  ```
+
+  **Namespace:**
+  ```cpp
+  namespace sgns::neoswarm::elm
+  {
+  ```
+
+  **Class declaration — exact signatures:**
+  ```cpp
+  class IELM
+  {
+  public:
+      virtual ~IELM() = default;
+
+      /// @return Human-readable name of this ELM.
+      virtual std::string GetName() const = 0;
+
+      /// @return The ELM role this instance fulfills.
+      virtual ELMRole GetRole() const = 0;
+
+      /// @return True if the ELM model has been loaded.
+      virtual bool IsLoaded() const = 0;
+
+      /**
+       * @brief Load the ELM model from disk (if a dedicated model path is configured).
+       * @param model_path  Path to the model file (.mnn or similar).
+       * @return            outcome::success or ModelLoadFailed.
+       */
+      virtual outcome::result<void> Load( const std::string& model_path ) = 0;
+
+      /**
+       * @brief Process input through this ELM and return refined output.
+       * @param input    Text to process (typically output of previous chain step).
+       * @param context  ELM execution context (original task, prior outputs, confidences).
+       * @return         Refined text or InferenceFailed.
+       */
+      virtual outcome::result<std::string> Process( const std::string& input, const ELMContext& context ) = 0;
+
+      /**
+       * @brief Confidence in the last Process() call.
+       * @return  Confidence score in [0, 1].
+       */
+      virtual float GetConfidence() const = 0;
+  };
+  ```
+
+  **Closing:**
+  ```cpp
+  } // namespace sgns::neoswarm::elm
+  #endif // NEOSWARM_ELM_IELM_HPP
+  ```
+
+  **Style:** Allman braces, `const` parameters, Doxygen `@brief`/`@param`/`@return` on every method. No implementation (pure interface). The `ELMRole` and `ELMContext` types are already in scope via `#include "common/types.hpp"`.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja neoswarm_common 2>&1 | tail -5</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - File exists: `src/elm/i_elm.hpp`
+    - `grep -c "class IELM" src/elm/i_elm.hpp` returns 1
+    - `grep -c "GetRole" src/elm/i_elm.hpp` returns 1
+    - `grep -c "ELMContext" src/elm/i_elm.hpp` returns 2 (one in include, one in Process signature)
+    - Include guard matches pattern: NEOSWARM_ELM_IELM_HPP
+    - Namespace matches: sgns::neoswarm::elm
+    - Zero warnings when compiled as part of neoswarm_common or a dependent target
+  </acceptance_criteria>
+
+  <done>IELM interface compiles. 6 pure virtuals defined. GetRole() present between GetName() and IsLoaded(). Process() takes ELMContext.</done>
+</task>
+
+<task type="auto">
+  <name>task 3: create elm CMake library + register in src/CMakeLists.txt</name>
+  <files>src/elm/CMakeLists.txt, src/CMakeLists.txt</files>
+
+  <read_first>
+  - src/specialists/CMakeLists.txt (exact analog — STATIC library, PUBLIC include dirs, PUBLIC link libs)
+  - src/CMakeLists.txt (existing add_subdirectory lines pattern)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #9 (CMake — copy from specialists)
+  - ./CLAUDE.md (neoswarm_ prefix for library names)
+  </read_first>
+
+  <action>
+  Two file changes:
+
+  **1) Create `src/elm/CMakeLists.txt`** — copy exact pattern from `src/specialists/CMakeLists.txt`:
+  ```cmake
+  add_library(neoswarm_elm STATIC
+      # Source files will be added in Waves 2-4 as implementations are created.
+      # For Wave 1 this library is header-only (i_elm.hpp).
+      # The add_library call with empty source list is intentional — CMake allows it
+      # and subsequent waves will add .cpp files here.
+  )
+
+  target_include_directories(neoswarm_elm PUBLIC
+      $<BUILD_INTERFACE:${PROJECT_ROOT}/src>
+      $<INSTALL_INTERFACE:include>
+  )
+
+  target_link_libraries(neoswarm_elm PUBLIC neoswarm_common)
+  ```
+  Library name: `neoswarm_elm` (naming convention: `neoswarm_` prefix + snake_case). PUBLIC link to `neoswarm_common` — this provides `types.hpp`, `error.hpp`, and the `outcome` namespace. The empty STATIC library is valid CMake; subsequent waves add `.cpp` files to this target by editing this file.
+
+  **2) Modify `src/CMakeLists.txt`** — add ONE line after line 9 (the `specialists` add_subdirectory):
+  ```cmake
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/elm ${CMAKE_CURRENT_BINARY_DIR}/elm)
+  ```
+  Insert after the specialists line to maintain alphabetical grouping. The line format must match the existing pattern exactly: `add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/<name> ${CMAKE_CURRENT_BINARY_DIR}/<name>)`.
+
+  **Style:** No trailing whitespace. One blank line between the specialists entry and the new elm entry.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && cmake ../.. -G Ninja -DCMAKE_BUILD_TYPE=Debug 2>&1 | tail -5 && ninja neoswarm_elm 2>&1 | tail -5</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - File exists: `src/elm/CMakeLists.txt`
+    - `grep -c "neoswarm_elm" src/elm/CMakeLists.txt` returns 2 (library name + link)
+    - `grep -c "add_subdirectory.*elm" src/CMakeLists.txt` returns 1
+    - CMake configure succeeds: `cmake .. -G Ninja` exits 0
+    - `ninja neoswarm_elm` succeeds (builds the empty/header-only library)
+    - Library appears in build output: `ls build/OSX/Debug/elm/libneoswarm_elm.a` exists
+  </acceptance_criteria>
+
+  <done>neoswarm_elm library target compiles and links against neoswarm_common. Phase directory registered in build.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| N/A (Wave 1) | Data types and abstract interface only — no data flow, no user input processed |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-07-01 | Tampering | `ELMContext::m_originalTask` | accept | Plain string field — no validation needed at type level. Consumers (ApiServer::RunELMChain) validate at use. |
+| T-07-02 | Spoofing | `ELMRole` enum cast from untrusted int | mitigate | Use `enum class` (strongly typed, no implicit int conversion). Runtime role lookup in registry via `std::unordered_map<ELMRole, ...>` prevents out-of-range abuse. |
+</threat_model>
+
+<verification>
+- `cd build/OSX/Debug && ninja neoswarm_common neoswarm_elm` — both targets compile
+- `grep "Chain = 3" src/common/types.hpp` — ExecutionMode::Chain exists
+- `grep "class IELM" src/elm/i_elm.hpp` — interface exists
+- `grep "GetRole" src/elm/i_elm.hpp` — GetRole() present (D-05)
+- Full test suite unaffected: `ctest --output-on-failure` (existing tests still pass, no new tests yet)
+</verification>
+
+<success_criteria>
+- [ ] `ninja neoswarm_common neoswarm_elm` succeeds
+- [ ] `src/common/types.hpp` contains ELMRole (10 values, 0–9), ELMContext, ChainStep, ExecutionChain
+- [ ] `src/common/types.hpp` contains ExecutionMode::Chain=3
+- [ ] `src/common/types.hpp` PromptFeatures has `has_grounding_request_` and `has_formatting_request_`
+- [ ] `src/elm/i_elm.hpp` defines IELM with 6 pure virtuals including GetRole() and Process(input, ELMContext)
+- [ ] `src/elm/CMakeLists.txt` defines STATIC library `neoswarm_elm`
+- [ ] `src/CMakeLists.txt` has `add_subdirectory` for `elm`
+- [ ] Existing code compiles unchanged (zero regressions)
+</success_criteria>
+
+<output>
+After completion, create `.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-01-SUMMARY.md`
+</output>

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-01-PLAN.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-01-PLAN.md
@@ -21,11 +21,11 @@ must_haves:
     - "ELMContext struct carries original task, last output, step confidences, and grounding facts"
     - "ExecutionChain is a flat vector of ChainStep with reasoning string"
     - "IELM interface has 6 pure virtuals: GetName, GetRole, IsLoaded, Load, Process(input,ELMContext), GetConfidence"
-    - "ExecutionMode::Chain=3 exists and is distinct from existing values"
+    - "ExecutionMode::ElmAssisted=3 exists and is distinct from existing values"
     - "neoswarm_elm library target compiles (empty or with i_elm.hpp only)"
   artifacts:
     - path: "src/common/types.hpp"
-      provides: "ELMRole, ELMContext, ChainStep, ExecutionChain, PromptFeatures extension, ExecutionMode::Chain"
+      provides: "ELMRole, ELMContext, ChainStep, ExecutionChain, PromptFeatures extension, ExecutionMode::ElmAssisted"
       contains: "enum class ELMRole"
     - path: "src/elm/i_elm.hpp"
       provides: "IELM abstract interface"
@@ -118,7 +118,7 @@ IELM differs from ISpecialist per D-05: adds GetRole(), changes Process to take 
 
   <behavior>
     - Test 1: ELMRole enum compiles with 10 distinct values (Planner=0, PrimaryDraft=1, Verifier=2, Arbiter=3, Refiner=4, Grounding=5, ToolSupport=6, Math=7, Code=8, Science=9)
-    - Test 2: ExecutionMode::Chain=3 is distinct from SingleNode/Specialist/Swarm
+    - Test 2: ExecutionMode::ElmAssisted=3 is distinct from SingleNode/Specialist/Swarm
     - Test 3: PromptFeatures default-constructs with has_grounding_request_=false and has_formatting_request_=false
     - Test 4: ELMContext default-constructs with all strings empty, vectors empty
     - Test 5: ChainStep default-constructs with m_role=PrimaryDraft and m_domain=std::nullopt
@@ -129,10 +129,10 @@ IELM differs from ISpecialist per D-05: adds GetRole(), changes Process to take 
   <action>
   Add four new type groups and extend three existing types in `src/common/types.hpp`, within `namespace sgns::neoswarm`:
 
-  **A) Add `ExecutionMode::Chain = 3`** (per D-09/D-13) — insert after `Swarm = 2` on line 24:
+  **A) Add `ExecutionMode::ElmAssisted = 3`** (per D-09/D-13) — insert after `Swarm = 2` on line 24:
   ```cpp
           Swarm = 2,  ///< Mode 3 — Multiple nodes, weighted consensus
-          Chain = 3   ///< Mode 4 — Multi-step ELM chain (Phase 7+)
+          ElmAssisted = 3   ///< Mode 4 — Multi-step ELM chain (Phase 7+)
   ```
   The closing brace stays on the line after.
 
@@ -209,7 +209,7 @@ IELM differs from ISpecialist per D-05: adds GetRole(), changes Process to take 
 
   <acceptance_criteria>
     - `grep -c "enum class ELMRole" src/common/types.hpp` returns 1
-    - `grep -c "Chain = 3" src/common/types.hpp` returns 1
+    - `grep -c "ElmAssisted = 3" src/common/types.hpp` returns 1
     - `grep -c "has_grounding_request_" src/common/types.hpp` returns 1
     - `grep -c "m_chainConfidence" src/common/types.hpp` returns 1
     - `ninja neoswarm_common` succeeds with zero errors and zero warnings from types.hpp
@@ -412,7 +412,7 @@ IELM differs from ISpecialist per D-05: adds GetRole(), changes Process to take 
 
 <verification>
 - `cd build/OSX/Debug && ninja neoswarm_common neoswarm_elm` — both targets compile
-- `grep "Chain = 3" src/common/types.hpp` — ExecutionMode::Chain exists
+- `grep "ElmAssisted = 3" src/common/types.hpp` — ExecutionMode::ElmAssisted exists
 - `grep "class IELM" src/elm/i_elm.hpp` — interface exists
 - `grep "GetRole" src/elm/i_elm.hpp` — GetRole() present (D-05)
 - Full test suite unaffected: `ctest --output-on-failure` (existing tests still pass, no new tests yet)
@@ -421,7 +421,7 @@ IELM differs from ISpecialist per D-05: adds GetRole(), changes Process to take 
 <success_criteria>
 - [ ] `ninja neoswarm_common neoswarm_elm` succeeds
 - [ ] `src/common/types.hpp` contains ELMRole (10 values, 0–9), ELMContext, ChainStep, ExecutionChain
-- [ ] `src/common/types.hpp` contains ExecutionMode::Chain=3
+- [ ] `src/common/types.hpp` contains ExecutionMode::ElmAssisted=3
 - [ ] `src/common/types.hpp` PromptFeatures has `has_grounding_request_` and `has_formatting_request_`
 - [ ] `src/elm/i_elm.hpp` defines IELM with 6 pure virtuals including GetRole() and Process(input, ELMContext)
 - [ ] `src/elm/CMakeLists.txt` defines STATIC library `neoswarm_elm`

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-01-SUMMARY.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-01-SUMMARY.md
@@ -1,0 +1,156 @@
+---
+phase: 07-expert-language-models-router
+plan: 01
+subsystem: ai
+tags: [elm, ielm, types, interface, cmake, c++17, neoswarm]
+
+# Dependency graph
+requires:
+  - phase: 07-expert-language-models-router
+    provides: "Context decisions D-05, D-08, D-09, D-12; analog patterns from ISpecialist and types.hpp"
+provides:
+  - "ELMRole enum (10 values: Planner=0 through Science=9)"
+  - "ELMContext, ChainStep, ExecutionChain structs in common/types.hpp"
+  - "ExecutionMode::Chain=3 execution mode"
+  - "IELM abstract interface with 6 pure virtuals (GetName, GetRole, IsLoaded, Load, Process, GetConfidence)"
+  - "neoswarm_elm CMake STATIC library target"
+  - "PromptFeatures extensions: has_grounding_request_, has_formatting_request_"
+affects:
+  - "07-02 (RoleELM + DomainELM implement IELM)"
+  - "07-03 (SpecialistAdapter, GroundingELM, ToolSupportELM)"
+  - "07-04 (ELMChainBuilder uses types)"
+  - "07-05 (ApiServer RunELMChain orchestration)"
+  - "07-06 (ELM tests)"
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "I-prefix abstract interface pattern (IELM modeled after ISpecialist)"
+    - "enum class with uint8_t underlying type for extensible role system"
+    - "m_-prefixed member naming throughout new structs"
+    - "Doxygen @brief/@param/@return on all public interface methods"
+    - "outcome::result<T> error propagation (no exceptions)"
+
+key-files:
+  created:
+    - "src/elm/i_elm.hpp — IELM abstract interface (6 pure virtuals)"
+    - "src/elm/CMakeLists.txt — neoswarm_elm STATIC library target"
+    - "src/elm/elm_stub.cpp — Wave 1 CMake compilation stub (removed in Wave 2)"
+  modified:
+    - "src/common/types.hpp — ELMRole, ELMContext, ChainStep, ExecutionChain, Chain=3, PromptFeatures extensions"
+    - "src/CMakeLists.txt — add_subdirectory for elm/"
+
+key-decisions:
+  - "IELM::Process takes (input, ELMContext) — not just input (D-05)"
+  - "ExecutionChain is a flat ordered list (D-09); DAG extension reserved for Phase 9"
+  - "ELM structs placed after KnowledgeFact in types.hpp (forward-reference issue with std::vector<KnowledgeFact>)"
+  - "CMake empty STATIC library rejected — added elm_stub.cpp as compilation verification stub (removed in Wave 2)"
+
+patterns-established:
+  - "IELM interface: 6 pure virtuals with GetRole() between GetName() and IsLoaded()"
+  - "ELMContext carries originalTask, lastOutput, stepConfidences, groundingFacts"
+  - "ChainStep has optional domain field for domain ELM routing"
+  - "ExecutionChain has m_reasoning and m_chainConfidence for transparency"
+
+requirements-completed: [ELM-03, ELM-05, ELM-core]
+
+# Metrics
+duration: 5 min
+completed: 2026-07-16
+---
+
+# Phase 7 Plan 01: ELM Core Types, Interface, and CMake Scaffolding Summary
+
+**Foundation types (ELMRole, ELMContext, ChainStep, ExecutionChain), IELM swappable interface (modeled on ISpecialist), and neoswarm_elm CMake library for Wave 1 of the Expert Language Models + Router phase.**
+
+## Performance
+
+- **Duration:** 5 min
+- **Started:** 2026-07-16T02:23:25Z
+- **Completed:** 2026-07-16T02:28:30Z
+- **Tasks:** 3
+- **Files modified:** 5
+
+## Accomplishments
+
+- `ELMRole` enum with 10 distinct values (Planner=0 through Science=9) in `common/types.hpp`
+- `ExecutionMode::Chain=3` added for multi-step ELM chain execution
+- `ELMContext` struct carrying original task, last output, step confidences, and grounding facts
+- `ChainStep` + `ExecutionChain` flat-list chain representation with reasoning string
+- `IELM` abstract interface with 6 pure virtuals including `GetRole()` and `Process(input, ELMContext)`
+- `neoswarm_elm` CMake STATIC library target registered in the build system
+- 16/17 existing tests pass with zero regressions (1 pre-existing GeniusSDK FFI failure unchanged)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: add ELM types to common/types.hpp** — `4a414a0` (feat)
+2. **Task 2: create IELM abstract interface** — `e57de82` (feat)
+3. **Task 3: create elm CMake library + register in src/CMakeLists.txt** — `dab6271` (feat)
+
+## Files Created/Modified
+
+- `src/common/types.hpp` — Added ELMRole enum, ELMContext/ChainStep/ExecutionChain structs, Chain=3 mode, PromptFeatures grounding/formatting fields
+- `src/elm/i_elm.hpp` — IELM abstract interface (6 pure virtuals, sgns::neoswarm::elm namespace)
+- `src/elm/CMakeLists.txt` — neoswarm_elm STATIC library (PUBLIC link neoswarm_common)
+- `src/elm/elm_stub.cpp` — Wave 1 compilation stub (removed in Wave 2 when real .cpp files arrive)
+- `src/CMakeLists.txt` — Added `add_subdirectory` for `elm/`
+
+## Decisions Made
+
+- **IELM::Process signature:** Takes `(const std::string& input, const ELMContext& context)` per D-05 — context carries original task and prior step outputs for chain execution
+- **Struct placement:** ELMContext/ChainStep/ExecutionChain placed after KnowledgeFact in types.hpp (not before NodeOutput as planned) because `std::vector<KnowledgeFact>` requires a complete type definition — the plan's forward-reference assumption was incorrect
+- **CMake stub:** The plan expected empty STATIC libraries to work in CMake, but this CMake version requires at least one source file. Added `elm_stub.cpp` as a compile-check stub (will be removed in Wave 2 when real .cpp implementations arrive)
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 — Blocking] CMake rejected empty STATIC library**
+
+- **Found during:** Task 3 (create elm CMake library)
+- **Issue:** `add_library(neoswarm_elm STATIC)` with empty source list failed with "No SOURCES given to target". The plan stated "The empty STATIC library is valid CMake" — this CMake version (3.x on macOS) requires at least one source file.
+- **Fix:** Created `src/elm/elm_stub.cpp` — a minimal compilation unit that includes `i_elm.hpp` and does a `sizeof(IELM)` check to verify the abstract interface compiles correctly. This file is documented to be removed in Wave 2.
+- **Files modified:** `src/elm/CMakeLists.txt` (added elm_stub.cpp to source list), `src/elm/elm_stub.cpp` (new)
+- **Verification:** `ninja neoswarm_elm` succeeds, `libneoswarm_elm.a` produced
+- **Committed in:** `dab6271` (part of Task 3 commit)
+
+**2. [Rule 1 — Bug] Plan acceptance criteria expected 2 `ELMContext` grep matches but only 1 exists**
+
+- **Found during:** Task 2 (acceptance criteria check)
+- **Issue:** Plan AC said `grep -c "ELMContext" src/elm/i_elm.hpp` should return 2 (one in include, one in Process). The `#include "common/types.hpp"` line does not contain the literal string "ELMContext", so grep finds only 1 occurrence (in the Process signature).
+- **Fix:** This is a plan-documentation error, not a code bug. The single occurrence in `Process()` is correct and sufficient.
+- **Files modified:** None (code is correct as written)
+- **Verification:** The interface compiles and all 6 pure virtuals are correctly declared
+
+---
+
+**Total deviations:** 2 auto-fixed (1 blocking, 1 bug)
+**Impact on plan:** Both deviations were necessary to complete the plan. The CMake stub is a temporary workaround documented for removal in Wave 2. The grep count issue was a plan acceptance-criteria error with zero impact on correctness.
+
+## Threat Flags
+
+None — Wave 1 is data types and abstract interface only. No data flow, no user input processed, no trust boundaries crossed.
+
+## Issues Encountered
+
+- CMake empty STATIC library not supported (resolved with elm_stub.cpp — see deviation #1)
+- `test_genius_elm_ffi` pre-existing failure (GeniusSDK ELM FFI, unrelated to these changes) — 16/17 tests pass, unchanged from baseline
+
+## Known Stubs
+
+- `src/elm/elm_stub.cpp` — Temporary compilation unit for CMake source requirement. Contains a dead-code `sizeof(IELM)` verification function. **Planned removal in Wave 2** when real `.cpp` ELM implementations are added to `neoswarm_elm`.
+
+## Next Phase Readiness
+
+- ELM types and interface are ready for Wave 2 implementation (07-02-PLAN.md: RoleELM + DomainELM)
+- `IELM` interface provides the contract all concrete ELMs must implement
+- `ELMContext` carries all required chain execution state
+- `neoswarm_elm` library is linked and ready for source additions
+
+---
+
+*Phase: 07-expert-language-models-router*
+*Completed: 2026-07-16*

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-01-SUMMARY.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-01-SUMMARY.md
@@ -11,7 +11,7 @@ requires:
 provides:
   - "ELMRole enum (10 values: Planner=0 through Science=9)"
   - "ELMContext, ChainStep, ExecutionChain structs in common/types.hpp"
-  - "ExecutionMode::Chain=3 execution mode"
+  - "ExecutionMode::ElmAssisted=3 execution mode"
   - "IELM abstract interface with 6 pure virtuals (GetName, GetRole, IsLoaded, Load, Process, GetConfidence)"
   - "neoswarm_elm CMake STATIC library target"
   - "PromptFeatures extensions: has_grounding_request_, has_formatting_request_"
@@ -38,7 +38,7 @@ key-files:
     - "src/elm/CMakeLists.txt — neoswarm_elm STATIC library target"
     - "src/elm/elm_stub.cpp — Wave 1 CMake compilation stub (removed in Wave 2)"
   modified:
-    - "src/common/types.hpp — ELMRole, ELMContext, ChainStep, ExecutionChain, Chain=3, PromptFeatures extensions"
+    - "src/common/types.hpp — ELMRole, ELMContext, ChainStep, ExecutionChain, ElmAssisted=3, PromptFeatures extensions"
     - "src/CMakeLists.txt — add_subdirectory for elm/"
 
 key-decisions:
@@ -75,7 +75,7 @@ completed: 2026-07-16
 ## Accomplishments
 
 - `ELMRole` enum with 10 distinct values (Planner=0 through Science=9) in `common/types.hpp`
-- `ExecutionMode::Chain=3` added for multi-step ELM chain execution
+- `ExecutionMode::ElmAssisted=3` added for multi-step ELM chain execution
 - `ELMContext` struct carrying original task, last output, step confidences, and grounding facts
 - `ChainStep` + `ExecutionChain` flat-list chain representation with reasoning string
 - `IELM` abstract interface with 6 pure virtuals including `GetRole()` and `Process(input, ELMContext)`
@@ -92,7 +92,7 @@ Each task was committed atomically:
 
 ## Files Created/Modified
 
-- `src/common/types.hpp` — Added ELMRole enum, ELMContext/ChainStep/ExecutionChain structs, Chain=3 mode, PromptFeatures grounding/formatting fields
+- `src/common/types.hpp` — Added ELMRole enum, ELMContext/ChainStep/ExecutionChain structs, ElmAssisted=3 mode, PromptFeatures grounding/formatting fields
 - `src/elm/i_elm.hpp` — IELM abstract interface (6 pure virtuals, sgns::neoswarm::elm namespace)
 - `src/elm/CMakeLists.txt` — neoswarm_elm STATIC library (PUBLIC link neoswarm_common)
 - `src/elm/elm_stub.cpp` — Wave 1 compilation stub (removed in Wave 2 when real .cpp files arrive)

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-02-PLAN.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-02-PLAN.md
@@ -1,0 +1,527 @@
+---
+phase: 07-expert-language-models-router
+plan: 02
+type: execute
+wave: 2
+depends_on:
+  - 07-01
+files_modified:
+  - src/elm/role_elm.hpp
+  - src/elm/role_elm.cpp
+  - src/elm/domain_elm.hpp
+  - src/elm/domain_elm.cpp
+  - src/elm/CMakeLists.txt
+autonomous: true
+requirements:
+  - ELM-01 (7 role-based ELMs behind IELM)
+  - ELM-02 (domain ELMs: Math/Code/Science)
+
+must_haves:
+  truths:
+    - "RoleELM constructed with ELMRole::Verifier and a MockEngine returns template-augmented output"
+    - "RoleELM not-loaded returns input unchanged with confidence=0.0f (fail-close)"
+    - "RoleELM::GetRole() returns the role it was constructed with"
+    - "DomainELM with shared engine behaves like RoleELM (prompt template + Infer)"
+    - "DomainELM::Load(path) with non-empty path creates its own MNNInferenceEngine"
+    - "DomainELM::Load() with empty path uses shared engine (already loaded)"
+  artifacts:
+    - path: "src/elm/role_elm.hpp"
+      provides: "RoleELM class declaration — shared-backbone role ELM"
+      contains: "class RoleELM : public IELM"
+    - path: "src/elm/role_elm.cpp"
+      provides: "RoleELM implementation — 7 prompt templates, BuildPrompt, Process, Load"
+      contains: "RoleELM::Process"
+    - path: "src/elm/domain_elm.hpp"
+      provides: "DomainELM class declaration — optional own-engine domain ELM"
+      contains: "class DomainELM : public IELM"
+    - path: "src/elm/domain_elm.cpp"
+      provides: "DomainELM implementation — shared/own engine dual mode"
+      contains: "DomainELM::Process"
+  key_links:
+    - from: "src/elm/role_elm.cpp"
+      to: "InferenceEngine::Infer"
+      via: "m_engine->Infer(task)"
+      pattern: ".*m_engine->Infer"
+    - from: "src/elm/domain_elm.cpp"
+      to: "MNNInferenceEngine"
+      via: "m_ownEngine->LoadModel"
+      pattern: "m_ownEngine"
+---
+
+<objective>
+Implement the 7 role-based ELMs (Planner, PrimaryDraft, Verifier, Arbiter, Refiner, Grounding, ToolSupport) and 3 domain ELMs (Math, Code, Science) behind the `IELM` interface. Role ELMs use the shared MNN backbone with role-specific prompt templates. Domain ELMs use the shared backbone by default or optionally load a dedicated `.mnn` model file.
+
+**Purpose:** Per D-01 and D-02 — hybrid backing with shared backbone default + optional per-role model path. Per D-03 — prompt templates are named constants in implementation, not user-editable config.
+
+**Output:** 4 new files (role_elm.hpp/cpp, domain_elm.hpp/cpp), 1 modified file (CMakeLists.txt to add .cpp sources).
+</objective>
+
+<execution_context>
+@$HOME/.config/opencode/get-shit-done/workflows/execute-plan.md
+@$HOME/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md  (D-01, D-02, D-03, D-04, D-16)
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md  (patterns #2, #3, #4 — role_elm, domain_elm)
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md  (§Pattern 1: Shared-Backbone Role ELM)
+@src/specialists/grammar_specialist.cpp  (EXACT analog for BuildPrompt + Process + confidence pattern)
+@src/specialists/grammar_specialist.hpp
+@src/specialists/math_specialist.cpp  (analog for optional own-engine pattern)
+@src/core/engine/inference_engine.hpp  (InferenceEngine::Infer signature)
+@src/core/engine/mnn_inference_engine.hpp  (MNNInferenceEngine — for own-engine construction)
+@src/elm/i_elm.hpp  (IELM interface from Wave 1)
+@src/common/types.hpp  (ELMRole, ELMContext, Task, InferenceResponse)
+@src/common/error.hpp  (Error enum, outcome namespace)
+@src/common/logging.hpp  (CreateLogger pattern)
+@src/elm/CMakeLists.txt  (to add .cpp sources)
+./CLAUDE.md
+
+<interfaces>
+From src/core/engine/inference_engine.hpp:
+```cpp
+virtual outcome::result<InferenceResponse> Infer(const Task& task) = 0;
+virtual outcome::result<void> LoadModel(const std::string& model_path) = 0;
+virtual bool IsLoaded() const = 0;
+```
+
+From src/elm/i_elm.hpp (Wave 1 contract):
+```cpp
+class IELM {
+    virtual std::string GetName() const = 0;
+    virtual ELMRole GetRole() const = 0;
+    virtual bool IsLoaded() const = 0;
+    virtual outcome::result<void> Load(const std::string& model_path) = 0;
+    virtual outcome::result<std::string> Process(const std::string& input, const ELMContext& context) = 0;
+    virtual float GetConfidence() const = 0;
+};
+```
+
+From src/common/types.hpp — Task struct:
+```cpp
+struct Task {
+    std::string m_id; std::string m_prompt; ExecutionMode m_mode; uint32_t m_maxTokens; float m_temperature; std::string m_nodeId;
+};
+```
+
+GrammarSpecialist::Process() pattern (grammar_specialist.cpp:56-81):
+1. Check !m_loaded || !m_engine → return input unchanged, confidence=0
+2. Task construction (m_id, m_prompt from BuildPrompt, m_maxTokens, m_temperature)
+3. m_engine->Infer(task) → check has_value
+4. confidence = 1.0f - std::min(perplexity / 10.0f, 1.0f)
+5. Return output on success, input unchanged on failure
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>task 1: create RoleELM class (header + implementation, 7 role templates)</name>
+  <files>src/elm/role_elm.hpp, src/elm/role_elm.cpp</files>
+
+  <read_first>
+  - src/specialists/grammar_specialist.hpp (exact analog — class layout, member names, constructor DI pattern)
+  - src/specialists/grammar_specialist.cpp (exact analog — Logger, constructor, Load, BuildPrompt, Process)
+  - src/elm/i_elm.hpp (IELM interface being implemented)
+  - src/common/types.hpp (ELMRole, ELMContext, Task, InferenceResponse)
+  - src/common/error.hpp (Error::ModelLoadFailed, Error::InferenceFailed, outcome namespace)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md patterns #2 (role_elm.hpp), #3 (role_elm.cpp)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md D-03 (templates as named constants), D-04 (missing model fallback)
+  </read_first>
+
+  <behavior>
+    - Test 1: RoleELM(Verifier, MockEngine) → Process("test", ctx) → output contains "test" and GetConfidence() > 0.0f
+    - Test 2: RoleELM(Verifier, nullptr) → Process("hello", ctx) → returns "hello" unchanged, GetConfidence() == 0.0f
+    - Test 3: RoleELM::GetName() returns "Planner" for Planner role, "Verifier" for Verifier role, etc.
+    - Test 4: RoleELM::GetRole() returns the ELMRole passed to constructor
+    - Test 5: RoleELM::IsLoaded() returns false before Load(), true after Load()
+    - Test 6: each of 7 roles produces a distinct prompt template (non-empty, contains role-specific instructions)
+  </behavior>
+
+  <action>
+  Create `src/elm/role_elm.hpp` and `src/elm/role_elm.cpp`. Follow the EXACT structure of `GrammarSpecialist` (grammar_specialist.hpp:22-49, grammar_specialist.cpp:1-83) with these adaptations:
+
+  **role_elm.hpp — class declaration:**
+  - Namespace: `sgns::neoswarm::elm`
+  - Inherits: `public IELM`
+  - Constructor: `explicit RoleELM( ELMRole role, std::shared_ptr<core::InferenceEngine> engine = nullptr );`
+  - Members: `ELMRole m_role;`, `std::string m_name;`, `std::shared_ptr<core::InferenceEngine> m_engine;`, `bool m_loaded = false;`, `float m_lastConfidence = 0.0f;`
+  - Public inline overrides: `GetName()` returns `m_name`, `GetRole()` returns `m_role`, `IsLoaded()` returns `m_loaded`, `GetConfidence()` returns `m_lastConfidence`
+  - Public non-inline: `Load(const std::string& model_path) override`, `Process(const std::string& input, const ELMContext& context) override`
+  - Private: `std::string BuildPrompt( const std::string& input, const ELMContext& context ) const;`
+  - Include guard: `NEOSWARM_ELM_ROLE_ELM_HPP`
+  - Doxygen file header with `@file`, `@brief`, `@date 2026-07-16`
+
+  **role_elm.cpp — implementation:**
+
+  Logger (anonymous namespace, copy grammar_specialist.cpp:14-19):
+  ```cpp
+  namespace { auto RoleLogger() { return neoswarm::CreateLogger("RoleELM"); } }
+  ```
+
+  Constructor (copy grammar_specialist.cpp:22-25 DI pattern):
+  ```cpp
+  RoleELM::RoleELM( ELMRole role, std::shared_ptr<core::InferenceEngine> engine )
+      : m_role( role )
+      , m_engine( std::move( engine ) )
+  {
+      // Set m_name from role enum — static map for O(1) lookup
+      static const std::unordered_map<ELMRole, std::string> kRoleNames = {
+          { ELMRole::Planner,      "Planner" },
+          { ELMRole::PrimaryDraft, "PrimaryDraft" },
+          { ELMRole::Verifier,     "Verifier" },
+          { ELMRole::Arbiter,      "Arbiter" },
+          { ELMRole::Refiner,      "Refiner/Formatter" },
+          { ELMRole::Grounding,    "Grounding" },
+          { ELMRole::ToolSupport,  "ToolSupport" },
+          { ELMRole::Math,         "Math" },
+          { ELMRole::Code,         "Code" },
+          { ELMRole::Science,      "Science" },
+      };
+      auto it = kRoleNames.find( m_role );
+      m_name = ( it != kRoleNames.end() ) ? it->second : "Unknown";
+  }
+  ```
+  (Only the role-based ELMs use this class — Planner through Refiner. Domain/special ELMs get their own classes. But having all 10 names in the map is safe and future-proof.)
+
+  Load() (copy grammar_specialist.cpp:30-40):
+  ```cpp
+  outcome::result<void> RoleELM::Load( const std::string& model_path )
+  {
+      if ( !m_engine )
+      {
+          RoleLogger()->warn( "RoleELM::Load — no engine available for role {}", m_name );
+          return outcome::failure( Error::ModelLoadFailed );
+      }
+      BOOST_OUTCOME_TRY( m_engine->LoadModel( model_path ) );
+      m_loaded = true;
+      RoleLogger()->info( "RoleELM loaded: {} (model={})", m_name, model_path );
+      return outcome::success();
+  }
+  ```
+
+  BuildPrompt() — **7 role-specific prompt templates** using the `[INST]...[/INST]` format from grammar_specialist.cpp:45-51. Each template is a named `static const char*` in a private helper method (or directly in BuildPrompt via switch). The template must:
+  - Start with role identity: `"You are a {role_description}. "`
+  - Include specific instructions for what to produce
+  - End with `[/INST]` to close the instruction block
+  - Reference `context.m_originalTask` for the original user task
+  - Reference `context.m_lastOutput` for the prior step's output (if chain position > 1)
+
+  Switch on `m_role` to select the template. Exact prompt text per role:
+
+  **Planner (ELMRole::Planner):**
+  ```
+  "[INST] You are a Planner. Analyze the following task and determine:\n"
+  "1. The primary domain (Math/Code/Science/General)\n"
+  "2. Estimated complexity (Low/Medium/High)\n"
+  "3. Recommended execution steps\n\n"
+  "Task: " + input + "\n\nAnalysis: [/INST]"
+  ```
+
+  **PrimaryDraft (ELMRole::PrimaryDraft):**
+  ```
+  "[INST] You are a Primary Draft generator. Respond to the following task directly and completely. "
+  "Provide a well-structured answer with clear reasoning.\n\n"
+  "Task: " + input + "\n\nResponse: [/INST]"
+  ```
+
+  **Verifier (ELMRole::Verifier):**
+  ```
+  "[INST] You are a Verifier. Review the following output for factual accuracy, logical consistency, and completeness. "
+  "List any errors or omissions found. If the output is correct, state 'Verified: no issues found.'\n\n"
+  "Original task: " + context.m_originalTask + "\n"
+  "Output to verify:\n" + input + "\n\nVerification result: [/INST]"
+  ```
+  (This template uses `context.m_originalTask` — demonstrates ELMContext usage.)
+
+  **Arbiter (ELMRole::Arbiter):**
+  ```
+  "[INST] You are an Arbiter. Review conflicting outputs and determine the most correct resolution. "
+  "Synthesize the best answer from the available information. Explain your reasoning.\n\n"
+  "Task: " + input + "\n\nArbitration: [/INST]"
+  ```
+
+  **Refiner (ELMRole::Refiner):**
+  ```
+  "[INST] You are a Refiner/Formatter. Polish the following text for grammar, spelling, clarity, and professional formatting. "
+  "Return only the refined text without explanation.\n\n"
+  "Text to refine:\n" + input + "\n\nRefined: [/INST]"
+  ```
+
+  **Grounding (ELMRole::Grounding):**
+  ```
+  "[INST] You are a Grounding specialist. Verify the following claims against known facts. "
+  "For each claim, state whether it is supported, contradicted, or unverifiable. "
+  "Cite specific facts where possible.\n\n"
+  "Claims to verify:\n" + input + "\n\nVerification: [/INST]"
+  ```
+  (Note: RoleELM for Grounding is the shared-backbone fallback. GroundingELM in Wave 3 wraps the knowledge/ pipeline and takes precedence.)
+
+  **ToolSupport (ELMRole::ToolSupport):**
+  ```
+  "[INST] You are a Tool-Support specialist. Identify any tool calls needed to answer the following task. "
+  "List tool name, parameters, and expected output format.\n\n"
+  "Task: " + input + "\n\nTool calls: [/INST]"
+  ```
+
+  Process() — copy EXACT pattern from grammar_specialist.cpp:56-81:
+  1. `if ( !m_loaded || !m_engine )` → log warn, `m_lastConfidence = 0.0f`, return `input` unchanged
+  2. Build `Task` obj: `m_id = m_name + "-" + std::to_string(std::hash<std::string>{}(input))`, `m_prompt = BuildPrompt(input, context)`, `m_maxTokens = static_cast<uint32_t>(input.size() + 128)` (slightly larger than grammar's +64 to accommodate context), `m_temperature = 0.2f` (low temp for deterministic roles; Verifier/Arbiter need precision)
+  3. `auto res = m_engine->Infer(task);`
+  4. If `!res.has_value()` → log warn, `m_lastConfidence = 0.0f`, return `input` unchanged
+  5. `m_lastConfidence = 1.0f - std::min(res.value().m_perplexity / 10.0f, 1.0f);` (exact same formula)
+  6. Return `res.value().m_output`
+
+  **Style:** Allman braces, `m_` members, `const` parameters, `outcome::result`, no exceptions, no `#ifdef`, single exit point per function. `<algorithm>` for `std::transform` if needed. `<unordered_map>` for role names. `#include <functional>` for `std::hash`.
+
+  **DO:** use `BOOST_OUTCOME_TRY` macro for error propagation (exact pattern from grammar_specialist.cpp:37). Log at info level for Load, warn for failures, debug for confidence values.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja neoswarm_elm 2>&1 | tail -10</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "class RoleELM" src/elm/role_elm.hpp` returns 1
+    - `grep -c "RoleELM::Process" src/elm/role_elm.cpp` returns 1
+    - `grep -c "BuildPrompt" src/elm/role_elm.cpp` returns 1
+    - `grep "\[INST\].*Planner" src/elm/role_elm.cpp` finds Planner template text — all 7 roles represented
+    - `grep -c "m_loaded" src/elm/role_elm.cpp` returns ≥3 (constructor init + Load set + Process check)
+    - `grep -c "m_lastConfidence = 0.0f" src/elm/role_elm.cpp` returns ≥2 (fail-close: not-loaded path + inference-failure path)
+    - `ninja neoswarm_elm` succeeds with zero warnings from new files
+    - All functions ≤100 lines (CLAUDE.md rule). If BuildPrompt with 7 switch cases exceeds 100 lines, extract a private helper `static const char* GetPromptTemplate(ELMRole)`.
+    - No `#ifdef`, no sleep_for, no try/catch in Process/Load (only `BOOST_OUTCOME_TRY`)
+  </acceptance_criteria>
+
+  <done>RoleELM compiles. 7 prompt templates defined. Process() follows GrammarSpecialist pattern exactly. Fail-close on not-loaded.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>task 2: create DomainELM class (header + implementation, shared/own engine dual mode)</name>
+  <files>src/elm/domain_elm.hpp, src/elm/domain_elm.cpp</files>
+
+  <read_first>
+  - src/specialists/math_specialist.hpp (analog — optional own-engine pattern, configurable model path)
+  - src/specialists/math_specialist.cpp (analog — Load + Process + confidence)
+  - src/elm/role_elm.cpp (sibling pattern — BuildPrompt + Process flow, just created in task 1)
+  - src/core/engine/mnn_inference_engine.hpp (MNNInferenceEngine — for own-engine creation when model path provided)
+  - src/core/engine/inference_engine.hpp (InferenceEngine abstract interface)
+  - src/elm/i_elm.hpp (IELM interface)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #4 (domain_elm)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md D-02 (per-role model path), D-04 (missing model fallback)
+  </read_first>
+
+  <behavior>
+    - Test 1: DomainELM(Code, MockEngine) → Process("int main()", ctx) → output augmented, confidence > 0
+    - Test 2: DomainELM(Code, nullptr) → Process("code", ctx) → returns input unchanged, confidence=0 (fail-close)
+    - Test 3: DomainELM(Science, MockEngine) → Process("photosynthesis", ctx) → returns shared-backbone output
+    - Test 4: DomainELM::Load("path/to/model.mnn") with non-empty path → attempts own-engine creation
+    - Test 5: DomainELM::Load("") with shared engine available → m_loaded=true (uses shared)
+    - Test 6: DomainELM::GetRole() returns the ELMRole passed to constructor
+  </behavior>
+
+  <action>
+  Create `src/elm/domain_elm.hpp` and `src/elm/domain_elm.cpp`.
+
+  **domain_elm.hpp — class declaration:**
+  - Namespace: `sgns::neoswarm::elm`
+  - Inherits: `public IELM`
+  - Constructor: `explicit DomainELM( ELMRole role, std::shared_ptr<core::InferenceEngine> sharedEngine = nullptr );`
+  - Members:
+    ```cpp
+    ELMRole m_role;
+    std::string m_name;
+    std::shared_ptr<core::InferenceEngine> m_sharedEngine;  // shared backbone (never owns)
+    std::unique_ptr<core::InferenceEngine> m_ownEngine;      // own .mnn model (owns)
+    bool m_loaded = false;
+    bool m_ownsEngine = false;  // true when m_ownEngine was created
+    float m_lastConfidence = 0.0f;
+    ```
+  - Public overrides: GetName/GetRole/IsLoaded/GetConfidence (inline, same pattern as RoleELM)
+  - Public non-inline: Load, Process
+  - Private: BuildPrompt (same signature as RoleELM)
+  - Include guard: `NEOSWARM_ELM_DOMAIN_ELM_HPP`
+
+  **domain_elm.cpp — implementation:**
+
+  Logger: `CreateLogger("DomainELM")` (anonymous namespace, same pattern)
+
+  Constructor: stores role, name (from same kRoleNames map as RoleELM), sharedEngine
+
+  **Load() — dual-mode logic (D-02, D-04):**
+  ```cpp
+  outcome::result<void> DomainELM::Load( const std::string& model_path )
+  {
+      if ( !model_path.empty() )
+      {
+          // Per D-02: load own model file
+          m_ownEngine = std::make_unique<core::MNNInferenceEngine>();
+          BOOST_OUTCOME_TRY( m_ownEngine->LoadModel( model_path ) );
+          m_ownsEngine = true;
+          m_loaded = true;
+          DomainLogger()->info( "DomainELM loaded own model: {} ({})", m_name, model_path );
+          return outcome::success();
+      }
+
+      // Per D-01: use shared backbone
+      if ( !m_sharedEngine )
+      {
+          // Per D-04: no engine available → error
+          DomainLogger()->warn( "DomainELM::Load — no engine available for {}", m_name );
+          return outcome::failure( Error::ModelLoadFailed );
+      }
+      // Shared engine is already loaded by ApiServer
+      m_loaded = true;
+      m_ownsEngine = false;
+      DomainLogger()->info( "DomainELM using shared backbone: {}", m_name );
+      return outcome::success();
+  }
+  ```
+  (Use `#include "core/engine/mnn_inference_engine.hpp"` for MNNInferenceEngine. `BOOST_OUTCOME_TRY` for error propagation.)
+
+  **BuildPrompt() — domain-specific templates:**
+  Three templates, selected by `m_role`:
+
+  **Math (ELMRole::Math):**
+  ```
+  "[INST] You are a Math specialist. Solve the following problem step by step. "
+  "Show your work. Provide the final answer clearly.\n\n"
+  "Problem: " + input + "\n\nSolution: [/INST]"
+  ```
+
+  **Code (ELMRole::Code):**
+  ```
+  "[INST] You are a Code specialist. Write clean, correct, well-commented code to solve the following task. "
+  "Include error handling and edge cases.\n\n"
+  "Task: " + input + "\n\nCode: [/INST]"
+  ```
+
+  **Science (ELMRole::Science):**
+  ```
+  "[INST] You are a Science specialist. Explain the following scientific concept clearly and accurately. "
+  "Include relevant principles, evidence, and consensus view where applicable.\n\n"
+  "Topic: " + input + "\n\nExplanation: [/INST]"
+  ```
+  (Science ships as shared-backbone-only per OpenCode's discretion — no trained model exists. The template is the only artifact.)
+
+  **Process() — dual-engine selection:**
+  Same structure as RoleELM::Process() with one critical difference at the Infer call:
+  ```cpp
+  // Select active engine: own if loaded, shared otherwise
+  auto& engine = ( m_ownsEngine && m_ownEngine ) ? m_ownEngine : m_sharedEngine;
+  if ( !engine )
+  {
+      DomainLogger()->warn( "DomainELM::Process — no engine available" );
+      m_lastConfidence = 0.0f;
+      return outcome::success( input );
+  }
+  auto res = engine->Infer( task );
+  ```
+  Rest is identical: check result, compute confidence, return output or fail-close.
+
+  **Style:** Same as RoleELM. Use `outcome::result`, `BOOST_OUTCOME_TRY`, Allman braces, `m_` members, single exit point, no exceptions, no `#ifdef`. Functions ≤100 lines. If Process() exceeds 100, extract `SelectEngine()` private helper.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja neoswarm_elm 2>&1 | tail -10</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "class DomainELM" src/elm/domain_elm.hpp` returns 1
+    - `grep -c "DomainELM::Process" src/elm/domain_elm.cpp` returns 1
+    - `grep -c "m_ownEngine" src/elm/domain_elm.cpp` returns ≥2 (creation in Load, selection in Process)
+    - `grep -c "m_sharedEngine" src/elm/domain_elm.cpp` returns ≥2 (constructor init, Process fallback)
+    - `grep "MNNInferenceEngine" src/elm/domain_elm.cpp` returns 1 (own-engine creation)
+    - `grep "\[INST\].*Math" src/elm/domain_elm.cpp` finds Math template — all 3 domains represented
+    - `ninja neoswarm_elm` succeeds with zero warnings from new files
+    - Functions ≤100 lines
+  </acceptance_criteria>
+
+  <done>DomainELM compiles. Dual-engine mode: Load(path) creates own engine, Load("") uses shared backbone. 3 domain templates.</done>
+</task>
+
+<task type="auto">
+  <name>task 3: register role_elm.cpp and domain_elm.cpp in elm/CMakeLists.txt</name>
+  <files>src/elm/CMakeLists.txt</files>
+
+  <read_first>
+  - src/elm/CMakeLists.txt (created in Wave 1, currently empty source list)
+  - src/specialists/CMakeLists.txt (pattern for STATIC library with source files)
+  </read_first>
+
+  <action>
+  Modify `src/elm/CMakeLists.txt` — replace the empty comment with the actual source files from this wave:
+  ```cmake
+  add_library(neoswarm_elm STATIC
+      role_elm.cpp
+      domain_elm.cpp
+  )
+
+  target_include_directories(neoswarm_elm PUBLIC
+      $<BUILD_INTERFACE:${PROJECT_ROOT}/src>
+      $<INSTALL_INTERFACE:include>
+  )
+
+  target_link_libraries(neoswarm_elm PUBLIC neoswarm_common neoswarm_core)
+  ```
+  Key change from Wave 1: added `neoswarm_core` to PUBLIC link libraries (needed for `InferenceEngine`, `MNNInferenceEngine`). Added `role_elm.cpp` and `domain_elm.cpp` to source list. The comment placeholder is removed.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && cmake ../.. -G Ninja -DCMAKE_BUILD_TYPE=Debug 2>&1 | tail -5 && ninja neoswarm_elm 2>&1 | tail -10</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "role_elm.cpp" src/elm/CMakeLists.txt` returns 1
+    - `grep -c "domain_elm.cpp" src/elm/CMakeLists.txt` returns 1
+    - `grep -c "neoswarm_core" src/elm/CMakeLists.txt` returns 1
+    - CMake configure succeeds
+    - `ninja neoswarm_elm` succeeds (role_elm.cpp.o + domain_elm.cpp.o compiled + linked into libneoswarm_elm.a)
+    - `ls build/OSX/Debug/elm/libneoswarm_elm.a` exists
+  </acceptance_criteria>
+
+  <done>neoswarm_elm library builds role_elm.cpp + domain_elm.cpp. Links against neoswarm_common + neoswarm_core.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| user input → BuildPrompt() | Prompt text concatenated into `[INST]` template — user input is data, not instruction |
+| ELM output → next ELM input | Sequential chain handoff — output of step N becomes input of step N+1 (trusted for Phase 7 local-only) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-07-02-01 | Spoofing | `RoleELM::BuildPrompt()` — user input inside `[INST]` block | mitigate | User input is placed AFTER the role instruction, separated by `\n\nTask:` delimiter. The `[INST]` block closes with `[/INST]` — structural delimiting prevents prompt injection (user cannot escape the instruction block). Per RESEARCH.md §Security Domain. |
+| T-07-02-02 | Denial of Service | `DomainELM::Load()` — path traversal on model_path | mitigate | Path is sourced from config file only (not user input at runtime). Path traversal is limited to filesystem access the process already has. Config file is trusted input (operator-edited). Accept for Phase 7; path validation added in Phase 10. |
+| T-07-02-03 | Elevation | ELM output → next ELM without sanitization | accept | Phase 7 is local-only, single-user. ELM-to-ELM handoff is trusted. Sanitization gates added in Phase 10 per RESEARCH.md. |
+</threat_model>
+
+<verification>
+- `cd build/OSX/Debug && ninja neoswarm_elm` — builds clean
+- `grep "RoleELM::Process" src/elm/role_elm.cpp` — Process method exists
+- `grep "m_ownEngine" src/elm/domain_elm.cpp` — dual-engine mode implemented
+- `grep -c "\[INST\]" src/elm/role_elm.cpp` returns at least 7 (one per role template)
+- `grep -c "\[INST\]" src/elm/domain_elm.cpp` returns at least 3 (one per domain)
+- Full test suite: `ctest --output-on-failure` — existing tests pass (no new tests run yet)
+</verification>
+
+<success_criteria>
+- [ ] `ninja neoswarm_elm` succeeds
+- [ ] `role_elm.hpp/cpp` — 7 role prompt templates, BuildPrompt method, Process follows GrammarSpecialist pattern
+- [ ] `domain_elm.hpp/cpp` — dual-engine mode (shared backbone default, own-engine on explicit path), 3 domain templates
+- [ ] Fail-close: not-loaded → return input unchanged, confidence=0.0f (D-04)
+- [ ] Confidence formula: `1.0f - min(perplexity/10.0f, 1.0f)` (matches existing specialists)
+- [ ] D-03 satisfied: templates are `static const char*` strings in .cpp, not config-editable
+- [ ] Zero warnings from new code
+- [ ] All functions ≤100 lines
+</success_criteria>
+
+<output>
+After completion, create `.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-02-SUMMARY.md`
+</output>

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-03-PLAN.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-03-PLAN.md
@@ -1,0 +1,591 @@
+---
+phase: 07-expert-language-models-router
+plan: 03
+type: execute
+wave: 3
+depends_on:
+  - 07-01
+files_modified:
+  - src/elm/specialist_adapter.hpp
+  - src/elm/specialist_adapter.cpp
+  - src/elm/grounding_elm.hpp
+  - src/elm/grounding_elm.cpp
+  - src/elm/tool_support_elm.hpp
+  - src/elm/tool_support_elm.cpp
+  - src/elm/CMakeLists.txt
+autonomous: true
+requirements:
+  - ELM-04 (adapters wrap GrammarSpecialist → Refiner, MathSpecialist → Math domain)
+  - ELM-07 (GroundingELM wraps knowledge/ pipeline)
+  - ELM-08 (ToolSupportELM is a pass-through stub)
+
+must_haves:
+  truths:
+    - "SpecialistAdapter wrapping a GrammarSpecialist delegates Process() to ISpecialist::Process()"
+    - "SpecialistAdapter::GetConfidence() reflects the wrapped specialist's confidence"
+    - "GroundingELM::Process() calls Retrieve → Inject → Infer → Validate in order"
+    - "GroundingELM without knowledge pipeline returns input unchanged (fail-close)"
+    - "ToolSupportELM::Process() always returns input unchanged with confidence=0.0f"
+    - "ToolSupportELM::IsLoaded() always returns false"
+  artifacts:
+    - path: "src/elm/specialist_adapter.hpp"
+      provides: "SpecialistAdapter class — composition-based wrapper for ISpecialist"
+      contains: "class SpecialistAdapter : public IELM"
+    - path: "src/elm/specialist_adapter.cpp"
+      provides: "SpecialistAdapter implementation — delegation to ISpecialist"
+      contains: "m_specialist->Process"
+    - path: "src/elm/grounding_elm.hpp"
+      provides: "GroundingELM class — wraps knowledge pipeline"
+      contains: "class GroundingELM : public IELM"
+    - path: "src/elm/grounding_elm.cpp"
+      provides: "GroundingELM implementation — Retrieve→Inject→Infer→Validate pipeline"
+      contains: "m_knowledge->Retrieve"
+    - path: "src/elm/tool_support_elm.hpp"
+      provides: "ToolSupportELM class — interface-conforming stub"
+      contains: "class ToolSupportELM : public IELM"
+    - path: "src/elm/tool_support_elm.cpp"
+      provides: "ToolSupportELM implementation — pass-through with logged not-implemented"
+      contains: "not implemented"
+  key_links:
+    - from: "src/elm/specialist_adapter.cpp"
+      to: "src/specialists/i_specialist.hpp"
+      via: "m_specialist->Process(input)"
+      pattern: "m_specialist->Process"
+    - from: "src/elm/grounding_elm.cpp"
+      to: "src/knowledge/knowledge_retrieval.hpp"
+      via: "m_knowledge->Retrieve(query)"
+      pattern: "m_knowledge->Retrieve"
+---
+
+<objective>
+Implement the legacy specialist adapters and two special-purpose ELMs. The `SpecialistAdapter` wraps existing `GrammarSpecialist`/`MathSpecialist` behind the `IELM` interface via composition. `GroundingELM` composes the 3-stage knowledge pipeline (Retrieve→Inject→Infer→Validate). `ToolSupportELM` is a stub that conforms to the interface but passes through with confidence=0.0f.
+
+**Purpose:** Per D-06/D-07 — legacy mapping and composition-based adapters. Per D-17 — GroundingELM wraps knowledge/. Per D-18 — ToolSupportELM stub.
+
+**Output:** 6 new files + 1 modified CMakeLists.txt.
+</objective>
+
+<execution_context>
+@$HOME/.config/opencode/get-shit-done/workflows/execute-plan.md
+@$HOME/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md  (D-06, D-07, D-17, D-18)
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md  (patterns #5, #6, #7 — grounding, tool-support, adapter)
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md  (§Pattern 2: Adapter, §Q5: Knowledge Pipeline API)
+@src/specialists/i_specialist.hpp  (ISpecialist interface — exact Process/GetConfidence signatures)
+@src/specialists/grammar_specialist.hpp  (GrammarSpecialist constructor: shared_ptr<InferenceEngine>)
+@src/specialists/math_specialist.hpp  (MathSpecialist constructor: shared_ptr<InferenceEngine>)
+@src/knowledge/knowledge_retrieval.hpp  (Retrieve() signature, IsLoaded())
+@src/knowledge/context_injection.hpp  (Inject() signature)
+@src/knowledge/fact_validation.hpp  (Validate() signature, ValidationResult, IsAvailable())
+@src/core/engine/inference_engine.hpp  (InferenceEngine::Infer signature)
+@src/elm/i_elm.hpp  (IELM interface)
+@src/common/types.hpp  (ELMRole, ELMContext, KnowledgeFact, Task)
+@src/common/error.hpp  (Error enum)
+@src/api/api_server.cpp:204-217  (AugmentPrompt — exact Retrieve→Inject pattern to replicate)
+@src/specialists/grammar_specialist.cpp:56-63  (fail-close not-loaded pattern)
+@src/elm/CMakeLists.txt  (to add sources)
+./CLAUDE.md
+
+<interfaces>
+From src/specialists/i_specialist.hpp:
+```cpp
+virtual outcome::result<std::string> Process(const std::string& input) = 0;
+virtual float GetConfidence() const = 0;
+```
+
+From src/knowledge/knowledge_retrieval.hpp:
+```cpp
+outcome::result<std::vector<KnowledgeFact>> Retrieve(const std::string& query) const;
+bool IsLoaded() const;
+```
+
+From src/knowledge/context_injection.hpp:
+```cpp
+std::string Inject(const std::string& prompt, const std::vector<KnowledgeFact>& facts) const;
+```
+
+From src/knowledge/fact_validation.hpp:
+```cpp
+ValidationResult Validate(const std::string& output, const std::vector<KnowledgeFact>& grounding_facts) const;
+bool IsAvailable() const;
+// ValidationResult: { bool passed_; float m_contradictionScore; vector<string> m_contradictions; string suggestion_; }
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>task 1: create SpecialistAdapter class (composition wrapper for ISpecialist)</name>
+  <files>src/elm/specialist_adapter.hpp, src/elm/specialist_adapter.cpp</files>
+
+  <read_first>
+  - src/specialists/i_specialist.hpp (exact ISpecialist interface — Process, GetConfidence signatures)
+  - src/specialists/grammar_specialist.hpp (GrammarSpecialist constructor signature)
+  - src/elm/i_elm.hpp (IELM interface being adapted to)
+  - src/common/types.hpp (ELMRole, ELMContext)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #7 (specialist_adapter)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md D-06 (legacy mapping), D-07 (composition, not inheritance)
+  </read_first>
+
+  <behavior>
+    - Test 1: SpecialistAdapter wraps MockISpecialist → Process("input", ctx) → delegates and returns MockISpecialist output
+    - Test 2: SpecialistAdapter::GetConfidence() returns MockISpecialist::GetConfidence()
+    - Test 3: SpecialistAdapter::IsLoaded() returns wrapped specialist's IsLoaded()
+    - Test 4: SpecialistAdapter::GetRole() returns ELMRole::Refiner when constructed for Refiner
+    - Test 5: SpecialistAdapter::Load("path") delegates to wrapped specialist's Load("path")
+    - Test 6: ELMContext is dropped when forwarding to ISpecialist::Process(string) — Process(input, ctx) calls m_specialist->Process(input)
+  </behavior>
+
+  <action>
+  Create `src/elm/specialist_adapter.hpp` and `src/elm/specialist_adapter.cpp`. This is a COMPOSITION-BASED adapter (D-07 — "adapters use composition (has-a ISpecialist), not inheritance").
+
+  **specialist_adapter.hpp:**
+  - Namespace: `sgns::neoswarm::elm`
+  - Inherits: `public IELM`
+  - Constructor: `SpecialistAdapter( std::shared_ptr<specialists::ISpecialist> specialist, ELMRole role, const std::string& name );`
+  - Members:
+    ```cpp
+    std::shared_ptr<specialists::ISpecialist> m_specialist;
+    ELMRole m_role;
+    std::string m_name;
+    float m_lastConfidence = 0.0f;
+    ```
+  - Public overrides (all inline in header — simple delegation):
+    ```cpp
+    std::string GetName() const override { return m_name; }
+    ELMRole GetRole() const override { return m_role; }
+    bool IsLoaded() const override { return m_specialist && m_specialist->IsLoaded(); }
+    float GetConfidence() const override { return m_lastConfidence; }
+    ```
+  - Public non-inline: Load, Process (declared in header, defined in .cpp)
+  - Include: `"i_elm.hpp"`, `"specialists/i_specialist.hpp"`, `<memory>`
+  - Include guard: `NEOSWARM_ELM_SPECIALIST_ADAPTER_HPP`
+
+  **specialist_adapter.cpp:**
+
+  Constructor — dependency injection pattern (copy grammar_specialist.cpp:22-25):
+  ```cpp
+  SpecialistAdapter::SpecialistAdapter( std::shared_ptr<specialists::ISpecialist> specialist, ELMRole role, const std::string& name )
+      : m_specialist( std::move( specialist ) )
+      , m_role( role )
+      , m_name( name )
+  {
+  }
+  ```
+
+  Load() — direct delegation:
+  ```cpp
+  outcome::result<void> SpecialistAdapter::Load( const std::string& model_path )
+  {
+      if ( !m_specialist )
+      {
+          return outcome::failure( Error::ModelLoadFailed );
+      }
+      return m_specialist->Load( model_path );
+  }
+  ```
+
+  Process() — **the critical adaptation**: maps `IELM::Process(input, ELMContext)` → `ISpecialist::Process(input)`:
+  ```cpp
+  outcome::result<std::string> SpecialistAdapter::Process( const std::string& input, const ELMContext& /*ctx*/ )
+  {
+      if ( !m_specialist )
+      {
+          m_lastConfidence = 0.0f;
+          return outcome::success( input );
+      }
+      auto result = m_specialist->Process( input );
+      if ( result.has_value() )
+      {
+          m_lastConfidence = m_specialist->GetConfidence();
+      }
+      else
+      {
+          m_lastConfidence = 0.0f;
+          return outcome::success( input );  // fail-close
+      }
+      return result;
+  }
+  ```
+  Key: `ELMContext` parameter is named `/*ctx*/` (unused — ISpecialist doesn't accept context per D-06). Per PATTERNS.md: "maps `IELM::Process(input, ELMContext)` → `ISpecialist::Process(input)` — drops the ELMContext parameter". On failure, returns input unchanged (fail-close pattern).
+
+  **Legacy mapping (D-06):** The adapter will be instantiated in ApiServer (Wave 5) as:
+  - `SpecialistAdapter(m_grammarSpec, ELMRole::Refiner, "Refiner/Formatter")` — GrammarSpecialist → Refiner
+  - `SpecialistAdapter(m_mathSpec, ELMRole::Math, "Math")` — MathSpecialist → Math domain
+  SymbolicFallback stays internal to MathSpecialist (not exposed as ELM).
+
+  **Style:** Allman braces, `m_` members, `const` parameters, no exceptions, single exit point. Logger: `CreateLogger("SpecialistAdapter")` in anonymous namespace.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja neoswarm_elm 2>&1 | tail -10</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "class SpecialistAdapter" src/elm/specialist_adapter.hpp` returns 1
+    - `grep -c "m_specialist->Process" src/elm/specialist_adapter.cpp` returns 1
+    - `grep -c "ELMContext" src/elm/specialist_adapter.cpp` returns 1 (in Process signature, unused)
+    - `grep "has-a ISpecialist"` or `grep "m_specialist"` in header confirms composition, not inheritance
+    - `ninja neoswarm_elm` succeeds with zero warnings
+    - `#include "specialists/i_specialist.hpp"` present in header (for ISpecialist type)
+    - No `#include` of grammar_specialist.hpp or math_specialist.hpp — adapter is generic for any ISpecialist
+  </acceptance_criteria>
+
+  <done>SpecialistAdapter compiles. Composition wrapper. Process(input, ctx) delegates to ISpecialist::Process(input). ELMContext dropped.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>task 2: create GroundingELM class (4-stage knowledge pipeline wrapper)</name>
+  <files>src/elm/grounding_elm.hpp, src/elm/grounding_elm.cpp</files>
+
+  <read_first>
+  - src/knowledge/knowledge_retrieval.hpp (Retrieve, IsLoaded signatures)
+  - src/knowledge/context_injection.hpp (Inject signature)
+  - src/knowledge/fact_validation.hpp (Validate, IsAvailable, ValidationResult)
+  - src/api/api_server.cpp:204-217 (AugmentPrompt — exactly the Retrieve→Inject pattern to replicate)
+  - src/specialists/grammar_specialist.cpp:56-81 (Process flow — Infer + confidence pattern)
+  - src/elm/i_elm.hpp (IELM interface)
+  - src/common/types.hpp (ELMContext, KnowledgeFact, Task)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #5 (grounding_elm)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md D-17 (GroundingELM wraps knowledge/)
+  </read_first>
+
+  <behavior>
+    - Test 1: GroundingELM with MockKnowledge+MockEngine → Process("Is the sky blue?", ctx) → output augmented, confidence > 0
+    - Test 2: GroundingELM with no knowledge retrieval → Process("test", ctx) → returns input unchanged (fail-close)
+    - Test 3: GroundingELM::IsLoaded() returns false when knowledge not loaded
+    - Test 4: GroundingELM::GetRole() returns ELMRole::Grounding
+    - Test 5: calls knowledge pipeline in order: Retrieve → Inject → Infer → Validate (verify via mock call counting)
+  </behavior>
+
+  <action>
+  Create `src/elm/grounding_elm.hpp` and `src/elm/grounding_elm.cpp`. This ELM wraps the existing 3-stage knowledge pipeline (Retrieve→Inject→Infer→Validate) behind `IELM`.
+
+  **grounding_elm.hpp:**
+  - Namespace: `sgns::neoswarm::elm`
+  - Inherits: `public IELM`
+  - Constructor:
+    ```cpp
+    GroundingELM( std::shared_ptr<core::InferenceEngine> engine,
+                  std::shared_ptr<knowledge::KnowledgeRetrieval> knowledge,
+                  std::unique_ptr<knowledge::ContextInjection> contextInj,
+                  std::unique_ptr<knowledge::FactValidation> factVal );
+    ```
+  - Members:
+    ```cpp
+    std::shared_ptr<core::InferenceEngine> m_engine;
+    std::shared_ptr<knowledge::KnowledgeRetrieval> m_knowledge;
+    std::unique_ptr<knowledge::ContextInjection> m_contextInj;
+    std::unique_ptr<knowledge::FactValidation> m_factVal;
+    bool m_loaded = false;
+    float m_lastConfidence = 0.0f;
+    ```
+  - Public inline overrides: GetName (returns `"Grounding"`), GetRole (returns `ELMRole::Grounding`), IsLoaded, GetConfidence
+  - Public non-inline: Load, Process
+  - Includes: `"i_elm.hpp"`, `"core/engine/inference_engine.hpp"`, `"knowledge/knowledge_retrieval.hpp"`, `"knowledge/context_injection.hpp"`, `"knowledge/fact_validation.hpp"`, `<memory>`
+  - Include guard: `NEOSWARM_ELM_GROUNDING_ELM_HPP`
+
+  **grounding_elm.cpp:**
+
+  Logger: `CreateLogger("GroundingELM")`
+
+  Constructor: stores `engine`, `knowledge`, `contextInj`, `factVal`. `m_loaded` set in Load().
+
+  Load() — lightweight (no model file; the knowledge pipeline is already loaded by ApiServer):
+  ```cpp
+  outcome::result<void> GroundingELM::Load( const std::string& /*model_path*/ )
+  {
+      if ( !m_knowledge || !m_knowledge->IsLoaded() )
+      {
+          GroundingLogger()->warn( "GroundingELM — knowledge retrieval not available" );
+          return outcome::failure( Error::KnowledgeUnavailable );
+      }
+      m_loaded = true;
+      GroundingLogger()->info( "GroundingELM loaded" );
+      return outcome::success();
+  }
+  ```
+
+  **Process() — 4-stage pipeline (D-17: replicates AugmentPrompt + Infer + Validate):**
+
+  ```
+  Stage 1: Retrieve(query)
+  Stage 2: Inject(task + facts) → augmented prompt
+  Stage 3: Infer(augmented prompt) → output
+  Stage 4: Validate(output, facts) → adjust confidence if contradictions found
+  ```
+
+  Exact implementation:
+  ```cpp
+  outcome::result<std::string> GroundingELM::Process( const std::string& input, const ELMContext& context )
+  {
+      // Fail-close: no knowledge pipeline
+      if ( !m_loaded || !m_knowledge || !m_engine )
+      {
+          GroundingLogger()->warn( "GroundingELM not loaded — returning input unchanged" );
+          m_lastConfidence = 0.0f;
+          return outcome::success( input );
+      }
+
+      // Stage 1: Retrieve facts (copy AugmentPrompt pattern: api_server.cpp:308-312)
+      auto factsRes = m_knowledge->Retrieve( input );
+      if ( !factsRes.has_value() || factsRes.value().empty() )
+      {
+          GroundingLogger()->debug( "GroundingELM — no facts retrieved, returning input" );
+          m_lastConfidence = 0.5f;  // low confidence: no grounding available
+          return outcome::success( input );
+      }
+      std::vector<KnowledgeFact> facts = std::move( factsRes.value() );
+
+      // Stage 2: Inject facts into prompt (copy AugmentPrompt: api_server.cpp:319)
+      std::string augmentedPrompt;
+      if ( m_contextInj )
+      {
+          augmentedPrompt = m_contextInj->Inject( input, facts );
+      }
+      else
+      {
+          augmentedPrompt = input;
+      }
+
+      // Stage 3: Infer (copy grammar_specialist.cpp:69-81 Process pattern)
+      Task task;
+      task.m_id = "grounding-" + std::to_string( std::hash<std::string>{}( input ) );
+      task.m_prompt = augmentedPrompt;
+      task.m_maxTokens = static_cast<uint32_t>( input.size() + 256 );  // room for fact context
+      task.m_temperature = 0.1f;  // low temp for factual accuracy
+
+      auto res = m_engine->Infer( task );
+      if ( !res.has_value() )
+      {
+          GroundingLogger()->warn( "GroundingELM inference failed — returning input unchanged" );
+          m_lastConfidence = 0.0f;
+          return outcome::success( input );
+      }
+
+      std::string output = res.value().m_output;
+
+      // Stage 4: Validate output against facts
+      float confidence = 1.0f - std::min( res.value().m_perplexity / 10.0f, 1.0f );
+      if ( m_factVal && m_factVal->IsAvailable() )
+      {
+          auto valResult = m_factVal->Validate( output, facts );
+          if ( !valResult.passed_ )
+          {
+              GroundingLogger()->warn( "GroundingELM — fact validation found {} contradictions",
+                                       valResult.m_contradictions.size() );
+              // Reduce confidence proportionally to contradiction severity
+              confidence *= ( 1.0f - std::min( valResult.m_contradictionScore, 0.9f ) );
+          }
+      }
+
+      m_lastConfidence = confidence;
+      return outcome::success( output );
+  }
+  ```
+
+  **Style:** Allman braces, `m_` members, `const` parameters, `outcome::result`, no exceptions, single exit point per function. `BOOST_OUTCOME_TRY` not needed here since we manually check `has_value()` on each stage to implement graceful degradation. Functions ≤100 lines (Process() is ~50 lines).
+
+  **Note:** GroundingELM returns `input` unchanged when Retrieve returns empty — this differs from the shared-backbone RoleELM::Grounding template (which does full inference). GroundingELM takes precedence in the registry; the RoleELM version is a fallback for when no knowledge pipeline is configured.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja neoswarm_elm 2>&1 | tail -10</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "class GroundingELM" src/elm/grounding_elm.hpp` returns 1
+    - `grep -c "GroundingELM::Process" src/elm/grounding_elm.cpp` returns 1
+    - `grep -c "m_knowledge->Retrieve" src/elm/grounding_elm.cpp` returns 1
+    - `grep -c "m_contextInj->Inject" src/elm/grounding_elm.cpp` returns 1
+    - `grep -c "m_factVal->Validate" src/elm/grounding_elm.cpp` returns 1
+    - `grep -c "m_engine->Infer" src/elm/grounding_elm.cpp` returns 1
+    - All 4 pipeline stages present in correct order (Retrieve → Inject → Infer → Validate)
+    - `ninja neoswarm_elm` succeeds with zero warnings
+    - Functions ≤100 lines
+    - Fail-close pattern present: `!m_loaded || !m_knowledge || !m_engine` guard → return input unchanged
+  </acceptance_criteria>
+
+  <done>GroundingELM compiles. 4-stage pipeline: Retrieve→Inject→Infer→Validate. Fail-close on missing knowledge. Contradiction score reduces confidence.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>task 3: create ToolSupportELM stub (pass-through with logged not-implemented)</name>
+  <files>src/elm/tool_support_elm.hpp, src/elm/tool_support_elm.cpp</files>
+
+  <read_first>
+  - src/specialists/grammar_specialist.cpp:56-63 (not-loaded fail-close path — EXACT pattern to replicate for entire stub)
+  - src/elm/i_elm.hpp (IELM interface)
+  - src/common/types.hpp (ELMRole, ELMContext)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #6 (tool_support_elm)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md D-18 (ToolSupportELM stub)
+  </read_first>
+
+  <behavior>
+    - Test 1: ToolSupportELM::Process("any input", ctx) → returns "any input" unchanged
+    - Test 2: ToolSupportELM::GetConfidence() returns 0.0f always
+    - Test 3: ToolSupportELM::IsLoaded() returns false always
+    - Test 4: ToolSupportELM::Load("anything") returns outcome::success() (no-op)
+    - Test 5: ToolSupportELM::GetRole() returns ELMRole::ToolSupport
+    - Test 6: ToolSupportELM::GetName() returns "ToolSupport"
+  </behavior>
+
+  <action>
+  Create `src/elm/tool_support_elm.hpp` and `src/elm/tool_support_elm.cpp`. Per D-18: "interface-conforming stub (pass-through with logged not-implemented status). Real tool-call formatting requires Phase 10's Tool Intermediary boundary."
+
+  **tool_support_elm.hpp:**
+  - Namespace: `sgns::neoswarm::elm`
+  - Inherits: `public IELM`
+  - Constructor: default (no parameters — no engine, no dependencies)
+  - Members:
+    ```cpp
+    float m_lastConfidence = 0.0f;
+    ```
+  - Public overrides (ALL inline in header — this is a minimal stub):
+    ```cpp
+    std::string GetName() const override { return "ToolSupport"; }
+    ELMRole GetRole() const override { return ELMRole::ToolSupport; }
+    bool IsLoaded() const override { return false; }
+    float GetConfidence() const override { return m_lastConfidence; }
+    ```
+  - Non-inline: Load (declared, no-op), Process (declared, pass-through)
+  - Includes: `"i_elm.hpp"`, `"common/types.hpp"`
+  - Include guard: `NEOSWARM_ELM_TOOL_SUPPORT_ELM_HPP`
+
+  **tool_support_elm.cpp:**
+
+  Logger: `CreateLogger("ToolSupportELM")`
+
+  Load() — no-op:
+  ```cpp
+  outcome::result<void> ToolSupportELM::Load( const std::string& /*model_path*/ )
+  {
+      ToolLogger()->info( "ToolSupportELM — stub, no model to load" );
+      return outcome::success();
+  }
+  ```
+
+  Process() — pass-through with logged not-implemented (replicates grammar_specialist.cpp:56-63 fail-close pattern verbatim):
+  ```cpp
+  outcome::result<std::string> ToolSupportELM::Process( const std::string& input, const ELMContext& /*ctx*/ )
+  {
+      ToolLogger()->warn( "ToolSupportELM not implemented — returning input unchanged" );
+      m_lastConfidence = 0.0f;
+      return outcome::success( input );
+  }
+  ```
+  Key: Returns `input` verbatim, confidence=0, logs warning. Same fail-close pattern as every other ELM's not-loaded path. ELMContext is unused (named `/*ctx*/`).
+
+  **Style:** Allman braces, minimal class (one member variable, no engine, no model). No `#include` beyond `i_elm.hpp` and `types.hpp`. This is the simplest ELM — ~15 lines of actual code.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja neoswarm_elm 2>&1 | tail -10</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "class ToolSupportELM" src/elm/tool_support_elm.hpp` returns 1
+    - `grep -c "ToolSupportELM::Process" src/elm/tool_support_elm.cpp` returns 1
+    - `grep "not implemented" src/elm/tool_support_elm.cpp` (logged message text)
+    - `grep "m_lastConfidence = 0.0f" src/elm/tool_support_elm.cpp` (confidence zero always)
+    - `grep "IsLoaded.*false" src/elm/tool_support_elm.hpp` (always returns false)
+    - `ninja neoswarm_elm` succeeds with zero warnings
+    - No engine dependency — class does NOT include inference_engine.hpp
+    - Stub behavior: process(anyInput) == anyInput (pass-through)
+  </acceptance_criteria>
+
+  <done>ToolSupportELM compiles. Interface-conforming stub. Pass-through with logged warning. IsLoaded()=false always.</done>
+</task>
+
+<task type="auto">
+  <name>task 4: register new .cpp files in elm/CMakeLists.txt</name>
+  <files>src/elm/CMakeLists.txt</files>
+
+  <read_first>
+  - src/elm/CMakeLists.txt (current state with role_elm.cpp + domain_elm.cpp)
+  </read_first>
+
+  <action>
+  Modify `src/elm/CMakeLists.txt` — add the three new .cpp files to the STATIC library source list:
+  ```cmake
+  add_library(neoswarm_elm STATIC
+      role_elm.cpp
+      domain_elm.cpp
+      specialist_adapter.cpp
+      grounding_elm.cpp
+      tool_support_elm.cpp
+  )
+
+  target_include_directories(neoswarm_elm PUBLIC
+      $<BUILD_INTERFACE:${PROJECT_ROOT}/src>
+      $<INSTALL_INTERFACE:include>
+  )
+
+  target_link_libraries(neoswarm_elm PUBLIC neoswarm_common neoswarm_core neoswarm_knowledge neoswarm_specialists)
+  ```
+  Key changes: added `specialist_adapter.cpp`, `grounding_elm.cpp`, `tool_support_elm.cpp` to sources. Added `neoswarm_knowledge` and `neoswarm_specialists` to PUBLIC link libraries — needed by GroundingELM (knowledge pipeline) and SpecialistAdapter (ISpecialist).
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && cmake ../.. -G Ninja -DCMAKE_BUILD_TYPE=Debug 2>&1 | tail -5 && ninja neoswarm_elm 2>&1 | tail -10</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "specialist_adapter.cpp" src/elm/CMakeLists.txt` returns 1
+    - `grep -c "grounding_elm.cpp" src/elm/CMakeLists.txt` returns 1
+    - `grep -c "tool_support_elm.cpp" src/elm/CMakeLists.txt` returns 1
+    - `grep -c "neoswarm_knowledge" src/elm/CMakeLists.txt` returns 1
+    - `grep -c "neoswarm_specialists" src/elm/CMakeLists.txt` returns 1
+    - CMake configure succeeds
+    - `ninja neoswarm_elm` succeeds — all 5 .cpp files compile + link into libneoswarm_elm.a
+    - `nm build/OSX/Debug/elm/libneoswarm_elm.a | grep "SpecialistAdapter"` confirms symbols present
+  </acceptance_criteria>
+
+  <done>All 5 ELM .cpp files registered. Library links against neoswarm_common + neoswarm_core + neoswarm_knowledge + neoswarm_specialists.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| ELM → knowledge pipeline | GroundingELM passes user input to KnowledgeRetrieval::Retrieve() — input validated only by TF-IDF stub |
+| ISpecialist → IELM | SpecialistAdapter trusts ISpecialist::Process() output — no sanitization of specialist output |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-07-03-01 | Denial of Service | `GroundingELM::Process()` — Retrieve with malicious input | accept | TF-IDF stub is computationally bounded (in-memory, no I/O). Real semantic embeddings (Phase 8+) will need rate limiting. Phase 7: acceptable. |
+| T-07-03-02 | Elevation | `SpecialistAdapter::Process()` — ISpecialist output trusted without re-validation | accept | ISpecialist implementations are internal (not user-extensible). Output is text-only. Trust boundary is within the same process. Phase 10 adds output sanitization. |
+| T-07-03-03 | Spoofing | `ToolSupportELM` — pass-through returns user input as-is | accept | By design (D-18). The stub's logged warning + zero confidence signals that no processing occurred. Consumers check confidence before treating output as augmented. |
+</threat_model>
+
+<verification>
+- `cd build/OSX/Debug && ninja neoswarm_elm` — builds clean
+- `grep "m_specialist->Process" src/elm/specialist_adapter.cpp` — adapter delegates
+- `grep "m_knowledge->Retrieve" src/elm/grounding_elm.cpp` — pipeline stage 1
+- `grep "not implemented" src/elm/tool_support_elm.cpp` — stub logged
+- Existing tests still pass: `ctest --output-on-failure` (no regressions)
+</verification>
+
+<success_criteria>
+- [ ] `ninja neoswarm_elm` succeeds
+- [ ] SpecialistAdapter delegates to ISpecialist via composition (D-06, D-07)
+- [ ] SpecialistAdapter drops ELMContext when calling ISpecialist::Process(string)
+- [ ] GroundingELM: 4-stage pipeline (Retrieve→Inject→Infer→Validate) in correct order (D-17)
+- [ ] GroundingELM fail-close: no knowledge → return input unchanged, confidence=0.0f
+- [ ] ToolSupportELM: pass-through stub, always confidence=0.0f, always IsLoaded=false (D-18)
+- [ ] All functions ≤100 lines
+- [ ] Zero warnings from new code
+</success_criteria>
+
+<output>
+After completion, create `.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-03-SUMMARY.md`
+</output>

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-04-PLAN.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-04-PLAN.md
@@ -1,0 +1,459 @@
+---
+phase: 07-expert-language-models-router
+plan: 04
+type: execute
+wave: 4
+depends_on:
+  - 07-01
+files_modified:
+  - src/router/prompt_analyzer.hpp
+  - src/router/prompt_analyzer.cpp
+  - src/elm/elm_chain_builder.hpp
+  - src/elm/elm_chain_builder.cpp
+  - src/elm/CMakeLists.txt
+autonomous: true
+requirements:
+  - ELM-05 (ELMChainBuilder produces ExecutionChain from RouteDecision + PromptFeatures)
+  - ELM-10 (RuleBasedRouter unchanged; new chain builder is separate)
+
+must_haves:
+  truths:
+    - "ELMChainBuilder::Build with high numeric density returns Math→Verifier chain"
+    - "ELMChainBuilder::Build with code syntax returns Planner→Code chain"
+    - "ELMChainBuilder::Build with low complexity returns single-step PrimaryDraft chain"
+    - "ELMChainBuilder::Build with high complexity returns 4-step Planner→PrimaryDraft→Verifier→Refiner chain"
+    - "PromptAnalyzer::Analyze sets has_grounding_request_ when grounding keywords present"
+    - "PromptAnalyzer::Analyze sets has_formatting_request_ when formatting keywords present"
+    - "RuleBasedRouter source files unchanged — only prompt_analyzer is modified"
+  artifacts:
+    - path: "src/router/prompt_analyzer.hpp"
+      provides: "HasGroundingRequest + HasFormattingRequest method declarations"
+      contains: "HasGroundingRequest"
+    - path: "src/router/prompt_analyzer.cpp"
+      provides: "2 new feature detectors + Analyze() integration"
+      contains: "has_grounding_request_ = HasGroundingRequest"
+    - path: "src/elm/elm_chain_builder.hpp"
+      provides: "ELMChainBuilder class declaration"
+      contains: "class ELMChainBuilder"
+    - path: "src/elm/elm_chain_builder.cpp"
+      provides: "6 heuristic triggers → ExecutionChain"
+      contains: "ELMChainBuilder::Build"
+  key_links:
+    - from: "src/elm/elm_chain_builder.cpp"
+      to: "src/common/types.hpp"
+      via: "ExecutionChain + ChainStep structs"
+      pattern: "ExecutionChain"
+    - from: "src/router/prompt_analyzer.cpp"
+      to: "PromptFeatures"
+      via: "features.has_grounding_request_ = ..."
+      pattern: "has_grounding_request_"
+---
+
+<objective>
+Extend the `PromptAnalyzer` with two new feature detectors (grounding request, formatting request) and create the `ELMChainBuilder` class that maps `RouteDecision` + `PromptFeatures` to an `ExecutionChain` using 6 heuristic triggers from doc 03 §6.2. Per D-11, the `RuleBasedRouter` remains unchanged — its responsibilities stay the same, and the chain builder is a separate class.
+
+**Purpose:** Per D-11 (router split) and D-12 (6 heuristic triggers). The chain builder is stateless and deterministic — testable with simple feature vectors.
+
+**Output:** 4 files modified/created, ELM CMakeLists.txt updated.
+</objective>
+
+<execution_context>
+@$HOME/.config/opencode/get-shit-done/workflows/execute-plan.md
+@$HOME/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md  (D-11, D-12)
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md  (patterns #8, #11 — elm_chain_builder, prompt_analyzer)
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md  (§Pattern 3: ELMChainBuilder, §Q3: PromptAnalyzer analysis)
+@src/router/prompt_analyzer.hpp  (existing class — add 2 methods)
+@src/router/prompt_analyzer.cpp  (existing implementation — add 2 methods + Analyze update)
+@src/router/rule_based_router.hpp  (analog for ELMChainBuilder: Config struct, constructor, public method)
+@src/router/rule_based_router.cpp  (analog for decision-tree pattern)
+@src/common/types.hpp  (ELMRole, ChainStep, ExecutionChain, RouteDecision, PromptFeatures)
+@src/common/error.hpp  (Error enum)
+@src/elm/CMakeLists.txt  (to add elm_chain_builder.cpp)
+./CLAUDE.md
+
+<interfaces>
+From src/common/types.hpp (existing, used by chain builder):
+```cpp
+struct PromptFeatures { float numeric_density_; bool has_code_syntax_; float complexity_; size_t token_count_; bool has_math_keywords_; bool has_grammar_request_; bool has_grounding_request_; bool has_formatting_request_; };
+struct RouteDecision { RouteTarget m_target; float confidence_; std::string m_reasoning; ExecutionMode m_mode; };
+struct ChainStep { ELMRole m_role; std::optional<std::string> m_domain; };
+struct ExecutionChain { std::vector<ChainStep> m_steps; std::string m_reasoning; float m_chainConfidence; };
+enum class ELMRole : uint8_t { Planner=0, PrimaryDraft=1, Verifier=2, Arbiter=3, Refiner=4, Grounding=5, ToolSupport=6, Math=7, Code=8, Science=9 };
+```
+
+PromptAnalyzer::HasGrammarRequest() keyword-detection pattern (prompt_analyzer.cpp:142-161):
+```cpp
+static const std::vector<std::string> kGrammarKeywords = { "grammar", "spelling", ... };
+std::string lower = prompt; std::transform(...); // lowercase
+for (const auto& kw : kGrammarKeywords) { if (lower.find(kw) != npos) return true; }
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>task 1: add HasGroundingRequest and HasFormattingRequest to PromptAnalyzer</name>
+  <files>src/router/prompt_analyzer.hpp, src/router/prompt_analyzer.cpp</files>
+
+  <read_first>
+  - src/router/prompt_analyzer.hpp (existing class — add 2 new private method declarations)
+  - src/router/prompt_analyzer.cpp (HasGrammarRequest at lines 142-161 — EXACT pattern to replicate)
+  - src/router/prompt_analyzer.cpp (Analyze() at lines 166-176 — where to integrate new features)
+  - src/common/types.hpp (PromptFeatures struct with new has_grounding_request_ and has_formatting_request_ fields from Wave 1)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #11 (prompt_analyzer modifications)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md (§Q3: "New features needed")
+  </read_first>
+
+  <behavior>
+    - Test 1: HasGroundingRequest("is it true that...") → true
+    - Test 2: HasGroundingRequest("tell me a story") → false
+    - Test 3: HasFormattingRequest("format as markdown") → true
+    - Test 4: HasFormattingRequest("what is 2+2") → false
+    - Test 5: Analyze("verify the claim that...") → features.has_grounding_request_ == true
+    - Test 6: Analyze("rewrite in bullet points") → features.has_formatting_request_ == true
+    - Test 7: Existing tests (HasGrammarRequest, HasMathKeywords, etc.) still pass unchanged
+  </behavior>
+
+  <action>
+  Two file modifications — do NOT change any existing method signatures, only add new methods and update Analyze().
+
+  **A) prompt_analyzer.hpp** — add 2 private method declarations after `HasGrammarRequest` (after line 62):
+  ```cpp
+          /**
+           * @brief Check for grounding/factuality verification requests.
+           * @param prompt  Input string.
+           * @return        True if grounding keywords are present.
+           */
+          bool HasGroundingRequest( const std::string& prompt ) const;
+
+          /**
+           * @brief Check for formatting/structure/style requests.
+           * @param prompt  Input string.
+           * @return        True if formatting keywords are present.
+           */
+          bool HasFormattingRequest( const std::string& prompt ) const;
+  ```
+  Use the EXACT same Doxygen style as existing methods (`@brief`, `@param`, `@return`). Place after `HasGrammarRequest` (line 62) and before `CountTokens` (line 69).
+
+  **B) prompt_analyzer.cpp** — add 2 new method implementations:
+
+  **HasGroundingRequest:** Replicate the EXACT keyword-detection pattern from `HasGrammarRequest` (lines 142-161):
+  ```cpp
+  bool PromptAnalyzer::HasGroundingRequest( const std::string& prompt ) const
+  {
+      static const std::vector<std::string> kGroundingKeywords = {
+          "is it true", "verify", "according to", "fact check", "factual",
+          "evidence", "source", "citation", "is this correct", "fact-check",
+          "validate", "cross-reference", "confirm that", "is it accurate" };
+
+      std::string lower = prompt;
+      std::transform( lower.begin(), lower.end(), lower.begin(),
+                      []( unsigned char c ) { return std::tolower( c ); } );
+
+      for ( const auto& kw : kGroundingKeywords )
+      {
+          if ( lower.find( kw ) != std::string::npos )
+          {
+              return true;
+          }
+      }
+      return false;
+  }
+  ```
+
+  **HasFormattingRequest:** Same pattern:
+  ```cpp
+  bool PromptAnalyzer::HasFormattingRequest( const std::string& prompt ) const
+  {
+      static const std::vector<std::string> kFormattingKeywords = {
+          "format as", "make this look", "structure this", "organize",
+          "write as", "rewrite in", "convert to", "summarize",
+          "bullet", "outline", "markdown", "json format",
+          "table", "list", "diagram", "flowchart", "presentation",
+          "professional", "polish this", "clean up" };
+
+      std::string lower = prompt;
+      std::transform( lower.begin(), lower.end(), lower.begin(),
+                      []( unsigned char c ) { return std::tolower( c ); } );
+
+      for ( const auto& kw : kFormattingKeywords )
+      {
+          if ( lower.find( kw ) != std::string::npos )
+          {
+              return true;
+          }
+      }
+      return false;
+  }
+  ```
+
+  **C) Update Analyze()** — add 2 lines at the end of `PromptAnalyzer::Analyze()` (after line 174 `f.has_grammar_request_ = ...`):
+  ```cpp
+      f.has_grounding_request_ = HasGroundingRequest( prompt );
+      f.has_formatting_request_ = HasFormattingRequest( prompt );
+  ```
+  Place these immediately after the existing `f.has_grammar_request_ = HasGrammarRequest( prompt );` line. The Analyze() method now sets all 8 feature fields (6 existing + 2 new).
+
+  **Style:** Match existing code exactly — `static const std::vector<std::string>`, `std::transform` with `std::tolower`, `std::string::npos` check, final `return false`. Do NOT refactor existing methods. Do NOT change any existing keyword lists. Use `#include <algorithm>` (already present) and `#include <cctype>` (check if present, add if not) for `std::tolower`.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja neoswarm_router 2>&1 | tail -10 && ./test/test_router --gtest_filter="*" 2>&1 | tail -20</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "HasGroundingRequest" src/router/prompt_analyzer.hpp` returns 1 (declaration)
+    - `grep -c "HasFormattingRequest" src/router/prompt_analyzer.hpp` returns 1 (declaration)
+    - `grep -c "HasGroundingRequest" src/router/prompt_analyzer.cpp` returns 2 (definition + Analyze call)
+    - `grep -c "HasFormattingRequest" src/router/prompt_analyzer.cpp` returns 2 (definition + Analyze call)
+    - `grep -c "is it true" src/router/prompt_analyzer.cpp` returns 1 (grounding keyword)
+    - `grep -c "format as" src/router/prompt_analyzer.cpp` returns 1 (formatting keyword)
+    - `ninja neoswarm_router` succeeds
+    - `./test/test_router` — all existing router tests still pass (zero regressions)
+    - New features set by Analyze(): `has_grounding_request_` and `has_formatting_request_` populated
+  </acceptance_criteria>
+
+  <done>PromptAnalyzer extended with HasGroundingRequest and HasFormattingRequest. Analyze() sets both new features. Existing tests pass.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>task 2: create ELMChainBuilder class (6 heuristic triggers → ExecutionChain)</name>
+  <files>src/elm/elm_chain_builder.hpp, src/elm/elm_chain_builder.cpp</files>
+
+  <read_first>
+  - src/router/rule_based_router.hpp (exact analog — Config struct, constructor, public method, private helpers pattern)
+  - src/router/rule_based_router.cpp (exact analog — decision-tree logic, logging at end, outcome::result return)
+  - src/common/types.hpp (ELMRole, ChainStep, ExecutionChain, RouteDecision, PromptFeatures)
+  - src/common/error.hpp (Error enum, outcome namespace)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #8 (elm_chain_builder)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md D-12 (6 heuristic triggers)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md (§Pattern 3: trigger mapping table)
+  </read_first>
+
+  <behavior>
+    - Test 1: Build with numeric_density=0.5 (above 0.30 threshold) → chain has 2 steps: [Math, Verifier]
+    - Test 2: Build with has_code_syntax=true → chain has 2 steps: [Planner, Code]
+    - Test 3: Build with has_grounding_request=true → chain has 3 steps: [Grounding, PrimaryDraft, Verifier]
+    - Test 4: Build with has_formatting_request=true → chain has 2 steps: [PrimaryDraft, Refiner]
+    - Test 5: Build with complexity=1.0 (below low threshold 2.0) → chain has 1 step: [PrimaryDraft]
+    - Test 6: Build with complexity=6.0 (above high threshold 5.0) → chain has 4 steps: [Planner, PrimaryDraft, Verifier, Refiner]
+    - Test 7: Build with no triggers (complexity between low/high, no special flags) → chain has 1 step: [PrimaryDraft]
+    - Test 8: chain.m_reasoning is non-empty for every trigger path
+  </behavior>
+
+  <action>
+  Create `src/elm/elm_chain_builder.hpp` and `src/elm/elm_chain_builder.cpp`. Copy the EXACT class structure from `RuleBasedRouter` (rule_based_router.hpp:24-55) but adapted for the different I/O contract.
+
+  **elm_chain_builder.hpp:**
+  - Namespace: `sgns::neoswarm::elm`
+  - Class: `ELMChainBuilder` (NOT inheriting IRouter — this is a separate class per D-11)
+  - Public Config struct:
+    ```cpp
+    struct Config
+    {
+        float numeric_density_threshold_ = 0.30f;
+        float complexity_high_threshold_ = 5.0f;
+        float complexity_low_threshold_ = 2.0f;
+        float confidence_threshold_ = 0.6f;
+    };
+    ```
+  - Two constructors: `ELMChainBuilder()` (default) and `explicit ELMChainBuilder( Config cfg )` (copy RuleBasedRouter pattern)
+  - Public method: `outcome::result<ExecutionChain> Build( const RouteDecision& decision, const PromptFeatures& features );`
+  - Private: `Config m_cfg;`
+  - Include guard: `NEOSWARM_ELM_ELM_CHAIN_BUILDER_HPP`
+  - Includes: `"common/error.hpp"`, `"common/types.hpp"`
+
+  **elm_chain_builder.cpp:**
+
+  Logger (copy rule_based_router.cpp anonymous namespace pattern):
+  ```cpp
+  namespace { auto BuilderLogger() { return neoswarm::CreateLogger("ELMChainBuilder"); } }
+  ```
+
+  Constructors (copy rule_based_router.cpp pattern):
+  ```cpp
+  ELMChainBuilder::ELMChainBuilder() = default;
+  ELMChainBuilder::ELMChainBuilder( Config cfg ) : m_cfg( std::move( cfg ) ) {}
+  ```
+
+  **Build() — 6-trigger decision tree (D-12, RESEARCH.md §Pattern 3 trigger mapping):**
+
+  The decision tree checks triggers in priority order. Higher-priority triggers (numeric density, code syntax) are checked first. The first matching trigger determines the chain.
+
+  ```cpp
+  outcome::result<ExecutionChain> ELMChainBuilder::Build( const RouteDecision& decision, const PromptFeatures& features )
+  {
+      ExecutionChain chain;
+
+      // Trigger 1: Numeric density → Math + Verifier
+      if ( features.numeric_density_ > m_cfg.numeric_density_threshold_ )
+      {
+          chain.m_steps.push_back( { ELMRole::Math, "math" } );
+          chain.m_steps.push_back( { ELMRole::Verifier } );
+          chain.m_reasoning = "High numeric density — routing to Math + Verifier";
+      }
+      // Trigger 2: Code syntax → Planner + Code
+      else if ( features.has_code_syntax_ )
+      {
+          chain.m_steps.push_back( { ELMRole::Planner } );
+          chain.m_steps.push_back( { ELMRole::Code, "code" } );
+          chain.m_reasoning = "Code syntax detected — Planner → Code domain";
+      }
+      // Trigger 3: Grounding-sensitive → Grounding + Draft + Verify
+      else if ( features.has_grounding_request_ )
+      {
+          chain.m_steps.push_back( { ELMRole::Grounding } );
+          chain.m_steps.push_back( { ELMRole::PrimaryDraft } );
+          chain.m_steps.push_back( { ELMRole::Verifier } );
+          chain.m_reasoning = "Grounding-sensitive — Grounding → Draft → Verify";
+      }
+      // Trigger 4: Formatting-sensitive → Draft + Refiner
+      else if ( features.has_formatting_request_ )
+      {
+          chain.m_steps.push_back( { ELMRole::PrimaryDraft } );
+          chain.m_steps.push_back( { ELMRole::Refiner } );
+          chain.m_reasoning = "Formatting-sensitive — Draft → Refiner";
+      }
+      // Trigger 5: Low complexity → single-step draft
+      else if ( features.complexity_ < m_cfg.complexity_low_threshold_ )
+      {
+          chain.m_steps.push_back( { ELMRole::PrimaryDraft } );
+          chain.m_reasoning = "Low complexity — single-step PrimaryDraft";
+      }
+      // Trigger 6: High complexity/uncertainty → full chain
+      else if ( features.complexity_ >= m_cfg.complexity_high_threshold_ )
+      {
+          chain.m_steps.push_back( { ELMRole::Planner } );
+          chain.m_steps.push_back( { ELMRole::PrimaryDraft } );
+          chain.m_steps.push_back( { ELMRole::Verifier } );
+          chain.m_steps.push_back( { ELMRole::Refiner } );
+          chain.m_reasoning = "High complexity — Planner → Draft → Verify → Refine";
+      }
+      // Default: single-step draft
+      else
+      {
+          chain.m_steps.push_back( { ELMRole::PrimaryDraft } );
+          chain.m_reasoning = "Default — single-step PrimaryDraft";
+      }
+
+      // Carry forward the router's confidence
+      chain.m_chainConfidence = decision.confidence_;
+
+      BuilderLogger()->debug( "Built chain: {} step(s), reason='{}', confidence={:.2f}",
+                              chain.m_steps.size(), chain.m_reasoning, chain.m_chainConfidence );
+      return outcome::success( std::move( chain ) );
+  }
+  ```
+
+  **Design notes:**
+  - `ChainStep` uses designated initializer `{ ELMRole::Math, "math" }` — the `m_role` field is first (default `PrimaryDraft`), `m_domain` is `std::optional<std::string>`.
+  - Domain steps set `m_domain` to the domain string (e.g., `"math"`, `"code"`) so the chain executor can look up the right DomainELM.
+  - Role-only steps don't set `m_domain` — it defaults to `std::nullopt`.
+  - The decision tree is ordered by priority: domain triggers (Math, Code) take precedence over quality triggers (Grounding, Formatting) which take precedence over complexity-based routing.
+  - Per D-10: no parallel edges. Every chain is a flat sequential list.
+
+  **Style:** Allman braces, `m_` members, `const` parameters, `outcome::result`, single exit point per function. Functions ≤100 lines (Build() is ~50 lines). Logger uses `debug()` level (not info — this is called on every request). Use `<string>` for std::string, `<vector>` for std::vector (included transitively via types.hpp).
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja neoswarm_elm 2>&1 | tail -10</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "class ELMChainBuilder" src/elm/elm_chain_builder.hpp` returns 1
+    - `grep -c "ELMChainBuilder::Build" src/elm/elm_chain_builder.cpp` returns 1
+    - `grep -c "numeric_density_ >" src/elm/elm_chain_builder.cpp` returns 1 (trigger 1)
+    - `grep -c "has_code_syntax_" src/elm/elm_chain_builder.cpp` returns 1 (trigger 2)
+    - `grep -c "has_grounding_request_" src/elm/elm_chain_builder.cpp` returns 1 (trigger 3)
+    - `grep -c "has_formatting_request_" src/elm/elm_chain_builder.cpp` returns 1 (trigger 4)
+    - `grep -c "complexity_low_threshold_" src/elm/elm_chain_builder.cpp` returns 1 (trigger 5)
+    - `grep -c "complexity_high_threshold_" src/elm/elm_chain_builder.cpp` returns 1 (trigger 6)
+    - All 6 triggers represented with distinct chain structures
+    - `chain.m_reasoning` assigned in every branch (non-empty for any path)
+    - `ninja neoswarm_elm` succeeds with zero warnings
+    - No `#include "rule_based_router.hpp"` — ELMChainBuilder is independent of RuleBasedRouter
+  </acceptance_criteria>
+
+  <done>ELMChainBuilder compiles. 6 heuristic triggers implemented. Decision tree with priority ordering. Stateless Build() returns ExecutionChain.</done>
+</task>
+
+<task type="auto">
+  <name>task 3: register elm_chain_builder.cpp in elm/CMakeLists.txt</name>
+  <files>src/elm/CMakeLists.txt</files>
+
+  <read_first>
+  - src/elm/CMakeLists.txt (current state with 5 .cpp files)
+  </read_first>
+
+  <action>
+  Add `elm_chain_builder.cpp` to the `neoswarm_elm` STATIC library source list (alphabetically positioned between `domain_elm.cpp` and `grounding_elm.cpp`):
+  ```cmake
+  add_library(neoswarm_elm STATIC
+      role_elm.cpp
+      domain_elm.cpp
+      elm_chain_builder.cpp
+      grounding_elm.cpp
+      specialist_adapter.cpp
+      tool_support_elm.cpp
+  )
+  ```
+  The include dirs and link libraries are unchanged from Wave 3. Chain builder needs only `neoswarm_common` (for types.hpp) which is already linked.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && cmake ../.. -G Ninja -DCMAKE_BUILD_TYPE=Debug 2>&1 | tail -5 && ninja neoswarm_elm 2>&1 | tail -10</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "elm_chain_builder.cpp" src/elm/CMakeLists.txt` returns 1
+    - `ninja neoswarm_elm` succeeds
+    - `nm build/OSX/Debug/elm/libneoswarm_elm.a | grep "ChainBuilder"` confirms symbols present
+  </acceptance_criteria>
+
+  <done>elm_chain_builder.cpp registered. Library links with 6 source files.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| user prompt → PromptAnalyzer | Untrusted user input via `prompt` parameter — keyword detection only, no execution |
+| ELMChainBuilder output → ApiServer | ExecutionChain consumed by RunELMChain — trusted internal data flow |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-07-04-01 | Spoofing | `PromptAnalyzer` — user crafts prompt to trigger a specific chain | accept | Chain selection is advisory — the user is the operator of a local-only system. Selecting the "wrong" chain does not escalate privilege or cause harm. The chain builder is deterministic and transparent. |
+| T-07-04-02 | Denial of Service | `ELMChainBuilder` — empty ExecutionChain with no steps | mitigate | Default branch always produces at least 1 step (PrimaryDraft). Every else-if chain has a final else. The `m_steps` vector is never empty. |
+</threat_model>
+
+<verification>
+- `cd build/OSX/Debug && ninja neoswarm_router neoswarm_elm` — builds clean
+- `./test/test_router` — all existing router tests pass (RuleBasedRouter unchanged)
+- `grep "has_grounding_request_ = HasGroundingRequest" src/router/prompt_analyzer.cpp` — Analyze() updated
+- `grep "ELMChainBuilder::Build" src/elm/elm_chain_builder.cpp` — chain builder implemented
+- 6 triggers present and produce correct ChainStep counts (grep verification)
+</verification>
+
+<success_criteria>
+- [ ] `ninja neoswarm_router neoswarm_elm` succeeds
+- [ ] PromptAnalyzer has 2 new detectors (HasGroundingRequest, HasFormattingRequest) with keyword lists
+- [ ] Analyze() sets both new PromptFeatures fields
+- [ ] Existing router tests pass unchanged (RuleBasedRouter not modified)
+- [ ] ELMChainBuilder::Build() implements all 6 triggers with distinct chains
+- [ ] Zero warnings from new code
+- [ ] Functions ≤100 lines
+</success_criteria>
+
+<output>
+After completion, create `.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-04-SUMMARY.md`
+</output>

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-05-PLAN.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-05-PLAN.md
@@ -1,0 +1,606 @@
+---
+phase: 07-expert-language-models-router
+plan: 05
+type: execute
+wave: 5
+depends_on:
+  - 07-02
+  - 07-03
+  - 07-04
+files_modified:
+  - src/api/api_server.hpp
+  - src/api/api_server.cpp
+  - src/main.cpp
+autonomous: true
+requirements:
+  - ELM-06 (ApiServer::RunELMChain executes chains sequentially)
+  - ELM-09 (elms JSON config section with lazy loading)
+  - ELM-10 (RuleBasedRouter unchanged; chain builder separate)
+
+must_haves:
+  truths:
+    - "ApiServer::Process() with ExecutionMode::Chain routes to RunELMChain"
+    - "RunELMChain iterates through ExecutionChain steps sequentially"
+    - "Each chain step's output feeds into the next step via ELMContext"
+    - "ApiServer::Initialize() registers all 10 ELMs in the registry"
+    - "Eager ELMs load at Initialize(), lazy ELMs load on first use"
+    - "elms JSON config section parsed from config file into ApiServer::Config"
+    - "No new CLI flags added (D-15)"
+  artifacts:
+    - path: "src/api/api_server.hpp"
+      provides: "ElmEntry struct, ELM registry member, m_chainBuilder, RunELMChain declaration"
+      contains: "m_elmRegistry"
+    - path: "src/api/api_server.cpp"
+      provides: "RunELMChain implementation, Initialize() ELM setup, Process() Chain case"
+      contains: "RunELMChain"
+    - path: "src/main.cpp"
+      provides: "ElmConfigEntry struct, LoadConfigFile elms section parsing, Config population"
+      contains: "elms"
+  key_links:
+    - from: "src/api/api_server.cpp"
+      to: "src/elm/role_elm.hpp"
+      via: "#include \"elm/role_elm.hpp\""
+      pattern: "include.*elm.*role_elm"
+    - from: "src/api/api_server.cpp"
+      to: "src/elm/elm_chain_builder.hpp"
+      via: "m_chainBuilder->Build(route, features)"
+      pattern: "m_chainBuilder->Build"
+    - from: "src/main.cpp"
+      to: "src/api/api_server.hpp"
+      via: "serverCfg.m_elmConfigs"
+      pattern: "m_elmConfigs"
+---
+
+<objective>
+Wire the ELM subsystem into the composition root (`ApiServer`) and parse the `elms` JSON configuration section. `ApiServer::Initialize()` creates and registers all 10 ELMs in the registry, creates the `ELMChainBuilder`, and processes eager-load config entries. `ApiServer::Process()` gains a new `ExecutionMode::Chain` case that builds an `ExecutionChain` from route decision + prompt features, then executes it sequentially via `RunELMChain`. `main.cpp` extends `LoadConfigFile` and the `Args`→`Config` mapping to parse the `elms` array.
+
+**Purpose:** Per D-13 (RunELMChain), D-14 (elms JSON config), D-15 (no new CLI flags), D-16 (lazy loading default).
+
+**Output:** 3 modified files. This is the integration point where all Waves 1-4 artifacts connect.
+</objective>
+
+<execution_context>
+@$HOME/.config/opencode/get-shit-done/workflows/execute-plan.md
+@$HOME/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md  (D-13, D-14, D-15, D-16)
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md  (patterns #12, #13, #14 — api_server modifications, main.cpp modifications)
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md  (§Pattern 4: Sequential Chain Execution, §Q2: Process() branching, §Q6: JSON config parsing)
+@src/api/api_server.hpp  (existing class — add members + ElmEntry + RunELMChain declaration)
+@src/api/api_server.cpp  (existing implementation — add Initialize ELM code + RunELMChain + Process case)
+@src/main.cpp  (existing — add ElmConfigEntry + LoadConfigFile elms section + Config population)
+@src/common/types.hpp  (ELMRole, ELMContext, ExecutionChain, ChainStep, RouteDecision, PromptFeatures, ExecutionMode::Chain)
+@src/common/error.hpp  (Error enum)
+@src/elm/i_elm.hpp  (IELM)
+@src/elm/role_elm.hpp  (RoleELM constructor)
+@src/elm/domain_elm.hpp  (DomainELM constructor)
+@src/elm/grounding_elm.hpp  (GroundingELM constructor)
+@src/elm/tool_support_elm.hpp  (ToolSupportELM constructor)
+@src/elm/specialist_adapter.hpp  (SpecialistAdapter constructor)
+@src/elm/elm_chain_builder.hpp  (ELMChainBuilder::Build)
+@src/router/prompt_analyzer.hpp  (PromptAnalyzer — used to extract features for chain builder)
+./CLAUDE.md
+
+<interfaces>
+From src/common/types.hpp (from Wave 1):
+```cpp
+enum class ExecutionMode : uint8_t { SingleNode=0, Specialist=1, Swarm=2, Chain=3 };
+struct PromptFeatures { float numeric_density_; bool has_code_syntax_; float complexity_; size_t token_count_; bool has_math_keywords_; bool has_grammar_request_; bool has_grounding_request_; bool has_formatting_request_; };
+struct ELMContext { std::string m_originalTask; std::string m_lastOutput; vector<pair<ELMRole,float>> m_stepConfidences; vector<KnowledgeFact> m_groundingFacts; };
+struct ChainStep { ELMRole m_role; optional<string> m_domain; };
+struct ExecutionChain { vector<ChainStep> m_steps; string m_reasoning; float m_chainConfidence; };
+```
+
+ROLE constructors (from Waves 2-3):
+```cpp
+RoleELM(ELMRole role, shared_ptr<InferenceEngine> engine = nullptr);
+DomainELM(ELMRole role, shared_ptr<InferenceEngine> sharedEngine = nullptr);
+SpecialistAdapter(shared_ptr<ISpecialist> specialist, ELMRole role, const string& name);
+GroundingELM(shared_ptr<InferenceEngine> engine, shared_ptr<KnowledgeRetrieval> knowledge, unique_ptr<ContextInjection> ctxInj, unique_ptr<FactValidation> factVal);
+ToolSupportELM(); // default constructor
+```
+
+ApiServer existing members (from api_server.hpp:114-132):
+```cpp
+shared_ptr<GrammarSpecialist> m_grammarSpec;  // for SpecialistAdapter
+shared_ptr<MathSpecialist> m_mathSpec;        // for SpecialistAdapter
+shared_ptr<InferenceEngine> m_coreEngine;     // for all RoleELM/DomainELM
+shared_ptr<KnowledgeRetrieval> m_knowledge;   // for GroundingELM
+unique_ptr<ContextInjection> m_contextInj;    // for GroundingELM
+unique_ptr<FactValidation> m_factVal;         // for GroundingELM
+unique_ptr<RuleBasedRouter> m_router;         // for routing, contains PromptAnalyzer
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>task 1: extend ApiServer header with ELM registry + RunELMChain</name>
+  <files>src/api/api_server.hpp</files>
+
+  <read_first>
+  - src/api/api_server.hpp (existing class — member layout lines 108-137, Config struct lines 50-66)
+  - src/common/types.hpp (ELMRole, ExecutionChain, RouteDecision, ExecutionMode)
+  - src/elm/i_elm.hpp (IELM forward reference)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #12 (api_server.hpp modifications)
+  </read_first>
+
+  <action>
+  Modify `src/api/api_server.hpp` — four additions:
+
+  **A) Add includes** (after line 24 `#include "specialists/math_specialist.hpp"`):
+  ```cpp
+  #include "elm/i_elm.hpp"
+  #include "elm/elm_chain_builder.hpp"
+  #include <unordered_map>
+  ```
+  `#include <unordered_map>` is added for `std::unordered_map<ELMRole, ...>`. `elm/i_elm.hpp` provides `IELM` and `ELMRole`/`ELMContext` (via `common/types.hpp`). `elm_chain_builder.hpp` provides `ELMChainBuilder`.
+
+  **B) Add ElmEntry to Config struct** (inside `struct Config`, after line 66, before `};`):
+  ```cpp
+          // ELM configuration (Phase 7+)
+          struct ElmEntry
+          {
+              std::string role;     ///< e.g. "planner", "verifier", "math"
+              std::string model;    ///< optional dedicated model path
+              bool eager = false;   ///< load at Initialize() vs lazy
+          };
+          std::vector<ElmEntry> m_elmConfigs;
+  ```
+  `ElmEntry` is a nested struct within `Config`. Use the same naming convention as existing Config members (`m_` prefix). Default empty vector.
+
+  **C) Add ELM registry + chain builder members** (after `m_sgClient` on line 128, before the private method declarations):
+  ```cpp
+          // ELM subsystem (Phase 7+)
+          std::unordered_map<ELMRole, std::shared_ptr<elm::IELM>> m_elmRegistry;
+          std::unique_ptr<elm::ELMChainBuilder> m_chainBuilder;
+          std::unique_ptr<router::PromptAnalyzer> m_promptAnalyzer;  // for feature extraction in chain path
+  ```
+  `m_elmRegistry`: maps role enum to ELM instance. `m_chainBuilder`: builds chains from route decisions. `m_promptAnalyzer`: extracts features from the task prompt (currently owned by m_router's RuleBasedRouter; we need a separate instance for the chain path to avoid coupling).
+
+  **D) Add RunELMChain private method declaration** (after `RunSwarm` on line 132):
+  ```cpp
+          outcome::result<InferenceResponse> RunELMChain( const Task& task, const RouteDecision& route );
+  ```
+  Same signature pattern as existing `RunSingleNode`/`RunSpecialist`/`RunSwarm` (line 130-132).
+
+  **Style:** Follow existing member ordering: Config struct, public members, private members. `m_` prefix on all new members. Allman braces on nested struct. Doxygen comments where existing code has them.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja neoswarm_api 2>&1 | tail -10</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "m_elmRegistry" src/api/api_server.hpp` returns 1
+    - `grep -c "m_chainBuilder" src/api/api_server.hpp` returns 1
+    - `grep -c "RunELMChain" src/api/api_server.hpp` returns 1
+    - `grep -c "ElmEntry" src/api/api_server.hpp` returns 2 (struct + vector member)
+    - `grep "elm/i_elm.hpp" src/api/api_server.hpp` (new include present)
+    - `grep "elm/elm_chain_builder.hpp" src/api/api_server.hpp` (new include present)
+    - `ninja neoswarm_api` succeeds (compiles header — implementation not wired yet)
+  </acceptance_criteria>
+
+  <done>ApiServer header extended. ELM registry, chain builder, RunELMChain declared. ElmEntry in Config.</done>
+</task>
+
+<task type="auto">
+  <name>task 2: implement Initialize() ELM registration + Process() Chain case + RunELMChain</name>
+  <files>src/api/api_server.cpp</files>
+
+  <read_first>
+  - src/api/api_server.cpp (existing implementation — Initialize() lines 50-124, Process() lines 425-458, RunSpecialist() lines 282-337)
+  - src/elm/role_elm.hpp (RoleELM constructor)
+  - src/elm/domain_elm.hpp (DomainELM constructor)
+  - src/elm/grounding_elm.hpp (GroundingELM constructor)
+  - src/elm/tool_support_elm.hpp (ToolSupportELM constructor)
+  - src/elm/specialist_adapter.hpp (SpecialistAdapter constructor)
+  - src/elm/elm_chain_builder.hpp (ELMChainBuilder constructor, Build())
+  - src/common/types.hpp (ELMRole values, ELMContext, ExecutionChain, PromptFeatures)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #13 (api_server.cpp modifications)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md (§Pattern 4: Sequential Chain Execution)
+  - ./CLAUDE.md (no-exceptions, outcome::result, single exit point, functions ≤100 lines)
+  </read_first>
+
+  <action>
+  Three modifications to `src/api/api_server.cpp`:
+
+  **A) Add new includes** at top of file (after existing includes, around line 25):
+  ```cpp
+  #include "elm/role_elm.hpp"
+  #include "elm/domain_elm.hpp"
+  #include "elm/grounding_elm.hpp"
+  #include "elm/tool_support_elm.hpp"
+  #include "elm/specialist_adapter.hpp"
+  ```
+
+  **B) Extend Initialize()** — add ELM registration after the knowledge section (after line 120, before line 122 `ServerLogger()->info("ApiServer initialized...`):
+
+  ```cpp
+      // 8. ELM subsystem (Phase 7+)
+      m_chainBuilder = std::make_unique<elm::ELMChainBuilder>();
+      m_promptAnalyzer = std::make_unique<router::PromptAnalyzer>();
+
+      // Register role-based ELMs (shared backbone — D-01)
+      m_elmRegistry[ELMRole::Planner] = std::make_shared<elm::RoleELM>( ELMRole::Planner, m_coreEngine );
+      m_elmRegistry[ELMRole::PrimaryDraft] = std::make_shared<elm::RoleELM>( ELMRole::PrimaryDraft, m_coreEngine );
+      m_elmRegistry[ELMRole::Verifier] = std::make_shared<elm::RoleELM>( ELMRole::Verifier, m_coreEngine );
+      m_elmRegistry[ELMRole::Arbiter] = std::make_shared<elm::RoleELM>( ELMRole::Arbiter, m_coreEngine );
+
+      // Refiner wraps GrammarSpecialist via adapter (D-06)
+      if ( m_grammarSpec )
+      {
+          m_elmRegistry[ELMRole::Refiner] = std::make_shared<elm::SpecialistAdapter>(
+              m_grammarSpec, ELMRole::Refiner, "Refiner/Formatter" );
+      }
+      else
+      {
+          // Fallback: shared-backbone Refiner if no grammar specialist
+          m_elmRegistry[ELMRole::Refiner] = std::make_shared<elm::RoleELM>( ELMRole::Refiner, m_coreEngine );
+      }
+
+      // Domain ELMs (Math via adapter, Code/Science as DomainELM)
+      if ( m_mathSpec )
+      {
+          m_elmRegistry[ELMRole::Math] = std::make_shared<elm::SpecialistAdapter>(
+              m_mathSpec, ELMRole::Math, "Math" );
+      }
+      else
+      {
+          m_elmRegistry[ELMRole::Math] = std::make_shared<elm::DomainELM>( ELMRole::Math, m_coreEngine );
+      }
+      m_elmRegistry[ELMRole::Code] = std::make_shared<elm::DomainELM>( ELMRole::Code, m_coreEngine );
+      m_elmRegistry[ELMRole::Science] = std::make_shared<elm::DomainELM>( ELMRole::Science, m_coreEngine );
+
+      // GroundingELM — wraps knowledge pipeline (D-17)
+      if ( m_cfg.m_enableKnowledge && m_knowledge )
+      {
+          m_elmRegistry[ELMRole::Grounding] = std::make_shared<elm::GroundingELM>(
+              m_coreEngine, m_knowledge,
+              std::make_unique<knowledge::ContextInjection>(),
+              std::make_unique<knowledge::FactValidation>( m_knowledge ) );
+          (void)m_elmRegistry[ELMRole::Grounding]->Load( "" );
+      }
+      else
+      {
+          // Fallback: shared-backbone Grounding if knowledge unavailable
+          m_elmRegistry[ELMRole::Grounding] = std::make_shared<elm::RoleELM>( ELMRole::Grounding, m_coreEngine );
+      }
+
+      // ToolSupportELM — stub (D-18)
+      m_elmRegistry[ELMRole::ToolSupport] = std::make_shared<elm::ToolSupportELM>();
+
+      // Load eager ELMs from config (D-16)
+      for ( const auto& elmCfg : m_cfg.m_elmConfigs )
+      {
+          if ( elmCfg.eager && !elmCfg.model.empty() )
+          {
+              // Parse role string to ELMRole enum
+              auto role = ParseELMRole( elmCfg.role );
+              auto it = m_elmRegistry.find( role );
+              if ( it != m_elmRegistry.end() && it->second )
+              {
+                  auto loadRes = it->second->Load( elmCfg.model );
+                  if ( !loadRes.has_value() )
+                  {
+                      ServerLogger()->warn( "Failed to eagerly load ELM '{}': model={}",
+                                            elmCfg.role, elmCfg.model );
+                  }
+              }
+          }
+      }
+  ```
+  This uses a helper `ParseELMRole()` that converts a lowercase role string to ELMRole enum. Add this as a static free function in the anonymous namespace at the top of api_server.cpp:
+
+  ```cpp
+  static ELMRole ParseELMRole( const std::string& roleStr )
+  {
+      static const std::unordered_map<std::string, ELMRole> kRoleMap = {
+          { "planner",       ELMRole::Planner },
+          { "primarydraft",  ELMRole::PrimaryDraft },
+          { "verifier",      ELMRole::Verifier },
+          { "arbiter",       ELMRole::Arbiter },
+          { "refiner",       ELMRole::Refiner },
+          { "grounding",     ELMRole::Grounding },
+          { "toolsupport",   ELMRole::ToolSupport },
+          { "math",          ELMRole::Math },
+          { "code",          ELMRole::Code },
+          { "science",       ELMRole::Science },
+      };
+      auto it = kRoleMap.find( roleStr );
+      return ( it != kRoleMap.end() ) ? it->second : ELMRole::PrimaryDraft;
+  }
+  ```
+  Place this in the anonymous namespace alongside `CreateLogger`, `GenerateId`, etc.
+
+  **C) Add `case ExecutionMode::Chain:` in Process() switch** — insert BEFORE the closing `}` of the switch, after `case ExecutionMode::Swarm:` block (after line 455):
+  ```cpp
+          case ExecutionMode::Chain:
+              return RunELMChain( t, route );
+  ```
+  This eliminates the `-Wswitch` warning (all enum cases now handled). The existing `return outcome::failure( Error::InternalError );` fallthrough on line 457 is now unreachable for valid enum values but stays as a safety net for corrupted enums.
+
+  **D) Implement RunELMChain()** — add the full method between RunSwarm() and Process(). Follow the RunSpecialist pattern (lines 282-337) but adapted for multi-step sequential execution:
+
+  ```cpp
+  outcome::result<InferenceResponse> ApiServer::RunELMChain( const Task& task, const RouteDecision& route )
+  {
+      auto t0 = std::chrono::steady_clock::now();
+
+      std::vector<KnowledgeFact> facts;
+      Task augTask = task;
+      augTask.m_prompt = AugmentPrompt( task.m_prompt, facts );
+
+      // Extract prompt features for chain builder
+      PromptFeatures features;
+      if ( m_promptAnalyzer )
+      {
+          features = m_promptAnalyzer->Analyze( augTask.m_prompt );
+      }
+
+      // Build execution chain
+      auto chainResult = m_chainBuilder->Build( route, features );
+      if ( !chainResult.has_value() )
+      {
+          ServerLogger()->warn( "Chain builder failed — falling back to single node" );
+          return RunSingleNode( task, route );
+      }
+
+      // Initialise ELM context
+      ELMContext context;
+      context.m_originalTask = task.m_prompt;
+      context.m_groundingFacts = facts;
+      context.m_stepConfidences.reserve( chainResult.value().m_steps.size() );
+
+      std::string currentOutput = augTask.m_prompt;
+      float aggregateConfidence = 1.0f;
+
+      // Execute chain steps sequentially (D-09, D-13)
+      for ( const auto& step : chainResult.value().m_steps )
+      {
+          context.m_lastOutput = currentOutput;
+
+          // Look up ELM by role (domain steps use role for lookup, domain is metadata)
+          auto it = m_elmRegistry.find( step.m_role );
+          if ( it == m_elmRegistry.end() || !it->second )
+          {
+              ServerLogger()->warn( "ELM not found for role {} — skipping step",
+                                    static_cast<int>( step.m_role ) );
+              continue;
+          }
+
+          auto elm = it->second;
+
+          // Lazy-load if not loaded (D-16)
+          if ( !elm->IsLoaded() )
+          {
+              // Check config for a model path for this role
+              std::string modelPath;
+              for ( const auto& cfg : m_cfg.m_elmConfigs )
+              {
+                  if ( ParseELMRole( cfg.role ) == step.m_role && !cfg.model.empty() )
+                  {
+                      modelPath = cfg.model;
+                      break;
+                  }
+              }
+              if ( !modelPath.empty() )
+              {
+                  (void)elm->Load( modelPath );
+              }
+          }
+
+          if ( !elm->IsLoaded() )
+          {
+              ServerLogger()->warn( "ELM {} not loaded — skipping step", elm->GetName() );
+              continue;
+          }
+
+          // Execute this step
+          auto stepRes = elm->Process( currentOutput, context );
+          if ( !stepRes.has_value() )
+          {
+              ServerLogger()->warn( "ELM {} failed — stopping chain", elm->GetName() );
+              break;
+          }
+
+          currentOutput = stepRes.value();
+          float stepConf = elm->GetConfidence();
+          context.m_stepConfidences.push_back( { step.m_role, stepConf } );
+          aggregateConfidence = std::min( aggregateConfidence, stepConf );
+
+          ServerLogger()->debug( "Chain step {}: role={} conf={:.2f}",
+                                 elm->GetName(), static_cast<int>( step.m_role ), stepConf );
+      }
+
+      auto t1 = std::chrono::steady_clock::now();
+      double totalMs = std::chrono::duration<double, std::milli>( t1 - t0 ).count();
+
+      // Fact validation (copy from RunSpecialist:314-325)
+      if ( m_factVal && m_factVal->IsAvailable() && !facts.empty() )
+      {
+          auto valResult = m_factVal->Validate( currentOutput, facts );
+          if ( !valResult.passed_ )
+          {
+              ServerLogger()->warn( "Chain fact validation failed: {}", valResult.suggestion_ );
+          }
+      }
+
+      InferenceResponse resp;
+      resp.m_output = currentOutput;
+      resp.m_taskId = task.m_id;
+      resp.m_modeUsed = ExecutionMode::Chain;
+      resp.m_routeUsed = route.m_target;
+      resp.m_totalLatencyMs = totalMs;
+      resp.m_success = true;
+      resp.m_perplexity = 1.0f - aggregateConfidence;  // invert: low conf = high perplexity
+
+      ServerLogger()->info( "Chain complete: {} steps, {}ms, agg_conf={:.2f}",
+                            chainResult.value().m_steps.size(), totalMs, aggregateConfidence );
+      return outcome::success( std::move( resp ) );
+  }
+  ```
+
+  **Style:** Allman braces, `m_` members, `const` parameters, `outcome::result`, no exceptions, single exit point per function. `RunELMChain` must be ≤100 lines. If it exceeds, extract a private helper `ProcessChainStep()` or similar. Use `std::chrono::steady_clock` (already included). Use `std::move` for final return (matches existing patterns). Logger tags via `ServerLogger()` (already defined).
+
+  **Per-step timeout:** D-05/D-11 reference chain-step timeout as OpenCode's discretion. Per RESEARCH.md Q2 recommendation, Phase 7 uses synchronous blocking calls — MNN's token-generation loop provides the natural timeout via maxTokens. No `std::future` or async wrapping. This is deferred to Phase 10.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja neoswarm_api 2>&1 | tail -10</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "RunELMChain" src/api/api_server.cpp` returns 2 (definition + switch case)
+    - `grep -c "ExecutionMode::Chain" src/api/api_server.cpp` returns ≥1 (Process switch case)
+    - `grep -c "m_elmRegistry" src/api/api_server.cpp` returns ≥3 (Initialize setup + chain lookup)
+    - `grep -c "m_chainBuilder->Build" src/api/api_server.cpp` returns 1
+    - `grep -c "ParseELMRole" src/api/api_server.cpp` returns ≥2 (definition + usage)
+    - All 10 ELMRole values registered in Initialize(): `grep "ELMRole::Planner" src/api/api_server.cpp` returns 1, etc.
+    - `ninja neoswarm_api` succeeds with zero warnings
+    - RunELMChain ≤100 lines
+    - No `#include` of router headers beyond what already exists (prompt_analyzer is used directly)
+  </acceptance_criteria>
+
+  <done>ApiServer orchestrates ELM chains. 10 ELMs registered. Process() handles Chain mode. RunELMChain executes steps sequentially.</done>
+</task>
+
+<task type="auto">
+  <name>task 3: parse elms JSON config section in main.cpp</name>
+  <files>src/main.cpp</files>
+
+  <read_first>
+  - src/main.cpp (existing LoadConfigFile lines 89-138, Args struct lines 41-60, Config population lines 275-287)
+  - src/api/api_server.hpp (ApiServer::Config with m_elmConfigs — from task 1)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #14 (main.cpp modifications)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md (§Q6: JSON Config Parsing)
+  </read_first>
+
+  <action>
+  Three modifications to `src/main.cpp`:
+
+  **A) Add ElmConfigEntry to Args struct** (after line 60, before `};`):
+  ```cpp
+      // ELM configuration entries (Phase 7+)
+      struct ElmConfigEntry
+      {
+          std::string role;
+          std::string model;
+          bool eager = false;
+      };
+      std::vector<ElmConfigEntry> m_elmConfigs;
+  ```
+  Naming: `ElmConfigEntry` (not `ElmEntry` — that's in api_server.hpp). `m_` prefix per convention.
+
+  **B) Parse elms JSON section in LoadConfigFile()** — add after line 135 (`args.verbose_ = ...`) and before line 137 (`std::cout << "Loaded config..."`):
+  ```cpp
+      if ( j.contains( "elms" ) && j["elms"].is_array() )
+      {
+          for ( const auto& e : j["elms"] )
+          {
+              ElmConfigEntry entry;
+              if ( e.contains( "role" ) )
+              {
+                  entry.role = e["role"].get<std::string>();
+              }
+              if ( e.contains( "model" ) )
+              {
+                  entry.model = e["model"].get<std::string>();
+              }
+              if ( e.contains( "eager" ) )
+              {
+                  entry.eager = e["eager"].get<bool>();
+              }
+              if ( !entry.role.empty() )
+              {
+                  args.m_elmConfigs.push_back( std::move( entry ) );
+              }
+          }
+          std::cout << "Loaded " << args.m_elmConfigs.size() << " ELM config(s)\n";
+      }
+  ```
+  Uses the EXACT same pattern as existing config keys: `j.contains("key")` → `get<T>()`. Array iteration with `j["elms"].is_array()` guard. Empty `role` entries are silently skipped (invalid config entry).
+
+  **C) Map ElmConfigEntry to ApiServer::ElmEntry** — in the Config population block (after line 286 `cfg.m_sgSdkBasePath = ...`, before line 288 `api::ApiServer server(cfg)`):
+  ```cpp
+      // ELM configuration (Phase 7+)
+      for ( const auto& entry : args.m_elmConfigs )
+      {
+          api::ApiServer::ElmEntry cfgEntry;
+          cfgEntry.role = entry.role;
+          cfgEntry.model = entry.model;
+          cfgEntry.eager = entry.eager;
+          cfg.m_elmConfigs.push_back( std::move( cfgEntry ) );
+      }
+  ```
+  Transforms `Args::ElmConfigEntry` (simple POD) to `ApiServer::Config::ElmEntry` (nested struct with same fields). Uses `std::move` for the string members.
+
+  **Style:** Follow existing code conventions — `std::move` on vector push, `std::cerr` for warnings (already present), `std::cout` for info. No new includes needed (`nlohmann/json.hpp` already included, `<vector>` already included). No new CLI flags per D-15.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja neo-swarm 2>&1 | tail -10</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "ElmConfigEntry" src/main.cpp` returns 2 (struct definition + usage in LoadConfigFile)
+    - `grep "j.contains.*elms" src/main.cpp` returns 1 (JSON key check)
+    - `grep "m_elmConfigs" src/main.cpp` returns ≥3 (Args struct member, LoadConfigFile push, Config population)
+    - `grep "eager" src/main.cpp` returns 2 (ElmConfigEntry field + JSON key)
+    - No new CLI flags (grep `--elm` in main.cpp returns 0 per D-15)
+    - `ninja neo-swarm` succeeds
+    - Validate: `echo '{"elms":[{"role":"verifier","model":"v.mnn","eager":true}]}' > /tmp/test_elms.json && ./build/OSX/Debug/neo-swarm --model dummy --config /tmp/test_elms.json --prompt "test" --verbose 2>&1 | grep "ELM config"`
+      - Should show "Loaded 1 ELM config(s)" in output
+  </acceptance_criteria>
+
+  <done>elms JSON config section parsed. Config flows from file → Args → ApiServer::Config. No new CLI flags.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| JSON config file → process | `elms` section parsed via nlohmann/json — validated by existing try/catch |
+| user prompt → PromptAnalyzer → ELMChainBuilder | Untrusted prompt parsed for features — no execution, only keyword matching |
+| chain step output → next step input | Sequential ELM-to-ELM handoff — trusted within local process |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-07-05-01 | Tampering | `elms` JSON config — malicious model path | mitigate | `nlohmann/json` exceptions caught by existing `try/catch` in LoadConfigFile (main.cpp:99-107). Model path is validated by `MNNInferenceEngine::LoadModel()` which fails on non-existent files. Per D-04: missing file → outcome::result error + fallback to shared backbone. |
+| T-07-05-02 | Denial of Service | `RunELMChain` — many-step chain with large prompts | accept | Chain steps are bounded by trigger logic (max 4 steps). Prompt size bounded by MNN model context window. Bounded execution time per step (synchronous Infer call). Phase 7 is local-only; resource exhaustion is self-inflicted. |
+| T-07-05-03 | Spoofing | `ParseELMRole` — unknown role string | mitigate | Unknown role strings map to `ELMRole::PrimaryDraft` (safe default). Config entries with invalid roles trigger a logged warning but don't crash. |
+| T-07-05-04 | Elevation | `ExecutionMode::Chain` produced by router before RunELMChain is implemented | mitigate | The `case ExecutionMode::Chain:` branch is added BEFORE any router logic can produce Chain mode. During Wave 5 migration, test with explicit Chain mode first, then enable auto-routing. If Chain case is somehow missing, the switch falls through to `InternalError` return — safe failure. |
+</threat_model>
+
+<verification>
+- `cd build/OSX/Debug && ninja neo-swarm` — full binary links with neoswarm_elm
+- `./neo-swarm --help` — no new CLI flags (D-15)
+- Existing test suite: `ctest --output-on-failure` — all existing tests pass
+- Config parsing: test with a minimal `elms` JSON file, verify "Loaded N ELM config(s)" printed
+- Process() switch: code review confirms `case ExecutionMode::Chain:` present
+</verification>
+
+<success_criteria>
+- [ ] `ninja neo-swarm` succeeds (full binary links with neoswarm_elm)
+- [ ] ApiServer::Initialize() registers all 10 ELMs (D-01, D-06, D-17, D-18)
+- [ ] ApiServer::Process() handles `ExecutionMode::Chain` → RunELMChain (D-13)
+- [ ] RunELMChain executes steps sequentially with ELMContext accumulation (D-09)
+- [ ] Lazy loading default; eager opt-in via config (D-16)
+- [ ] `elms` JSON config section parsed and flowed to ApiServer::Config (D-14)
+- [ ] No new CLI flags (D-15)
+- [ ] Existing tests pass (zero regressions)
+- [ ] All functions ≤100 lines
+- [ ] Zero warnings
+</success_criteria>
+
+<output>
+After completion, create `.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-05-SUMMARY.md`
+</output>

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-05-PLAN.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-05-PLAN.md
@@ -19,7 +19,7 @@ requirements:
 
 must_haves:
   truths:
-    - "ApiServer::Process() with ExecutionMode::Chain routes to RunELMChain"
+    - "ApiServer::Process() with ExecutionMode::ElmAssisted routes to RunELMChain"
     - "RunELMChain iterates through ExecutionChain steps sequentially"
     - "Each chain step's output feeds into the next step via ELMContext"
     - "ApiServer::Initialize() registers all 10 ELMs in the registry"
@@ -52,7 +52,7 @@ must_haves:
 ---
 
 <objective>
-Wire the ELM subsystem into the composition root (`ApiServer`) and parse the `elms` JSON configuration section. `ApiServer::Initialize()` creates and registers all 10 ELMs in the registry, creates the `ELMChainBuilder`, and processes eager-load config entries. `ApiServer::Process()` gains a new `ExecutionMode::Chain` case that builds an `ExecutionChain` from route decision + prompt features, then executes it sequentially via `RunELMChain`. `main.cpp` extends `LoadConfigFile` and the `Args`→`Config` mapping to parse the `elms` array.
+Wire the ELM subsystem into the composition root (`ApiServer`) and parse the `elms` JSON configuration section. `ApiServer::Initialize()` creates and registers all 10 ELMs in the registry, creates the `ELMChainBuilder`, and processes eager-load config entries. `ApiServer::Process()` gains a new `ExecutionMode::ElmAssisted` case that builds an `ExecutionChain` from route decision + prompt features, then executes it sequentially via `RunELMChain`. `main.cpp` extends `LoadConfigFile` and the `Args`→`Config` mapping to parse the `elms` array.
 
 **Purpose:** Per D-13 (RunELMChain), D-14 (elms JSON config), D-15 (no new CLI flags), D-16 (lazy loading default).
 
@@ -71,7 +71,7 @@ Wire the ELM subsystem into the composition root (`ApiServer`) and parse the `el
 @src/api/api_server.hpp  (existing class — add members + ElmEntry + RunELMChain declaration)
 @src/api/api_server.cpp  (existing implementation — add Initialize ELM code + RunELMChain + Process case)
 @src/main.cpp  (existing — add ElmConfigEntry + LoadConfigFile elms section + Config population)
-@src/common/types.hpp  (ELMRole, ELMContext, ExecutionChain, ChainStep, RouteDecision, PromptFeatures, ExecutionMode::Chain)
+@src/common/types.hpp  (ELMRole, ELMContext, ExecutionChain, ChainStep, RouteDecision, PromptFeatures, ExecutionMode::ElmAssisted)
 @src/common/error.hpp  (Error enum)
 @src/elm/i_elm.hpp  (IELM)
 @src/elm/role_elm.hpp  (RoleELM constructor)
@@ -86,7 +86,7 @@ Wire the ELM subsystem into the composition root (`ApiServer`) and parse the `el
 <interfaces>
 From src/common/types.hpp (from Wave 1):
 ```cpp
-enum class ExecutionMode : uint8_t { SingleNode=0, Specialist=1, Swarm=2, Chain=3 };
+enum class ExecutionMode : uint8_t { SingleNode=0, Specialist=1, Swarm=2, ElmAssisted=3 };
 struct PromptFeatures { float numeric_density_; bool has_code_syntax_; float complexity_; size_t token_count_; bool has_math_keywords_; bool has_grammar_request_; bool has_grounding_request_; bool has_formatting_request_; };
 struct ELMContext { std::string m_originalTask; std::string m_lastOutput; vector<pair<ELMRole,float>> m_stepConfidences; vector<KnowledgeFact> m_groundingFacts; };
 struct ChainStep { ELMRole m_role; optional<string> m_domain; };
@@ -316,9 +316,9 @@ unique_ptr<RuleBasedRouter> m_router;         // for routing, contains PromptAna
   ```
   Place this in the anonymous namespace alongside `CreateLogger`, `GenerateId`, etc.
 
-  **C) Add `case ExecutionMode::Chain:` in Process() switch** — insert BEFORE the closing `}` of the switch, after `case ExecutionMode::Swarm:` block (after line 455):
+  **C) Add `case ExecutionMode::ElmAssisted:` in Process() switch** — insert BEFORE the closing `}` of the switch, after `case ExecutionMode::Swarm:` block (after line 455):
   ```cpp
-          case ExecutionMode::Chain:
+          case ExecutionMode::ElmAssisted:
               return RunELMChain( t, route );
   ```
   This eliminates the `-Wswitch` warning (all enum cases now handled). The existing `return outcome::failure( Error::InternalError );` fallthrough on line 457 is now unreachable for valid enum values but stays as a safety net for corrupted enums.
@@ -432,7 +432,7 @@ unique_ptr<RuleBasedRouter> m_router;         // for routing, contains PromptAna
       InferenceResponse resp;
       resp.m_output = currentOutput;
       resp.m_taskId = task.m_id;
-      resp.m_modeUsed = ExecutionMode::Chain;
+      resp.m_modeUsed = ExecutionMode::ElmAssisted;
       resp.m_routeUsed = route.m_target;
       resp.m_totalLatencyMs = totalMs;
       resp.m_success = true;
@@ -455,7 +455,7 @@ unique_ptr<RuleBasedRouter> m_router;         // for routing, contains PromptAna
 
   <acceptance_criteria>
     - `grep -c "RunELMChain" src/api/api_server.cpp` returns 2 (definition + switch case)
-    - `grep -c "ExecutionMode::Chain" src/api/api_server.cpp` returns ≥1 (Process switch case)
+    - `grep -c "ExecutionMode::ElmAssisted" src/api/api_server.cpp` returns ≥1 (Process switch case)
     - `grep -c "m_elmRegistry" src/api/api_server.cpp` returns ≥3 (Initialize setup + chain lookup)
     - `grep -c "m_chainBuilder->Build" src/api/api_server.cpp` returns 1
     - `grep -c "ParseELMRole" src/api/api_server.cpp` returns ≥2 (definition + usage)
@@ -577,7 +577,7 @@ unique_ptr<RuleBasedRouter> m_router;         // for routing, contains PromptAna
 | T-07-05-01 | Tampering | `elms` JSON config — malicious model path | mitigate | `nlohmann/json` exceptions caught by existing `try/catch` in LoadConfigFile (main.cpp:99-107). Model path is validated by `MNNInferenceEngine::LoadModel()` which fails on non-existent files. Per D-04: missing file → outcome::result error + fallback to shared backbone. |
 | T-07-05-02 | Denial of Service | `RunELMChain` — many-step chain with large prompts | accept | Chain steps are bounded by trigger logic (max 4 steps). Prompt size bounded by MNN model context window. Bounded execution time per step (synchronous Infer call). Phase 7 is local-only; resource exhaustion is self-inflicted. |
 | T-07-05-03 | Spoofing | `ParseELMRole` — unknown role string | mitigate | Unknown role strings map to `ELMRole::PrimaryDraft` (safe default). Config entries with invalid roles trigger a logged warning but don't crash. |
-| T-07-05-04 | Elevation | `ExecutionMode::Chain` produced by router before RunELMChain is implemented | mitigate | The `case ExecutionMode::Chain:` branch is added BEFORE any router logic can produce Chain mode. During Wave 5 migration, test with explicit Chain mode first, then enable auto-routing. If Chain case is somehow missing, the switch falls through to `InternalError` return — safe failure. |
+| T-07-05-04 | Elevation | `ExecutionMode::ElmAssisted` produced by router before RunELMChain is implemented | mitigate | The `case ExecutionMode::ElmAssisted:` branch is added BEFORE any router logic can produce Chain mode. During Wave 5 migration, test with explicit Chain mode first, then enable auto-routing. If Chain case is somehow missing, the switch falls through to `InternalError` return — safe failure. |
 </threat_model>
 
 <verification>
@@ -585,13 +585,13 @@ unique_ptr<RuleBasedRouter> m_router;         // for routing, contains PromptAna
 - `./neo-swarm --help` — no new CLI flags (D-15)
 - Existing test suite: `ctest --output-on-failure` — all existing tests pass
 - Config parsing: test with a minimal `elms` JSON file, verify "Loaded N ELM config(s)" printed
-- Process() switch: code review confirms `case ExecutionMode::Chain:` present
+- Process() switch: code review confirms `case ExecutionMode::ElmAssisted:` present
 </verification>
 
 <success_criteria>
 - [ ] `ninja neo-swarm` succeeds (full binary links with neoswarm_elm)
 - [ ] ApiServer::Initialize() registers all 10 ELMs (D-01, D-06, D-17, D-18)
-- [ ] ApiServer::Process() handles `ExecutionMode::Chain` → RunELMChain (D-13)
+- [ ] ApiServer::Process() handles `ExecutionMode::ElmAssisted` → RunELMChain (D-13)
 - [ ] RunELMChain executes steps sequentially with ELMContext accumulation (D-09)
 - [ ] Lazy loading default; eager opt-in via config (D-16)
 - [ ] `elms` JSON config section parsed and flowed to ApiServer::Config (D-14)

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-06-PLAN.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-06-PLAN.md
@@ -29,7 +29,7 @@ requirements:
 must_haves:
   truths:
     - "test_elm binary runs 17+ tests covering all ELM classes"
-    - "test_common_types binary includes tests for ELMRole distinctness, ELMContext defaults, ChainStep defaults, ExecutionChain defaults, ExecutionMode::Chain distinctness"
+    - "test_common_types binary includes tests for ELMRole distinctness, ELMContext defaults, ChainStep defaults, ExecutionChain defaults, ExecutionMode::ElmAssisted distinctness"
     - "test_pipeline binary includes ChainMode_BasicExecution and ChainMode_GeneralPrompt_SingleStep"
     - "All tests use MockEngine pattern — no real model files, no sleep_for, no wait conditions"
     - "ctest passes all test targets including new ELM tests"
@@ -282,7 +282,7 @@ endmacro()
 
   <read_first>
   - test/common/test_types.cpp (existing test structure — ExecutionMode test at lines 6-11, PromptFeatures test at lines 76-85)
-  - src/common/types.hpp (ELMRole, ELMContext, ChainStep, ExecutionChain, ExecutionMode::Chain)
+  - src/common/types.hpp (ELMRole, ELMContext, ChainStep, ExecutionChain, ExecutionMode::ElmAssisted)
   - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #16 (test_types.cpp extensions)
   </read_first>
 
@@ -303,13 +303,13 @@ endmacro()
   }
   ```
 
-  2. `TEST(ExecutionMode, ChainValue_IsDistinct)` — verify Chain=3 is different from all existing:
+  2. `TEST(ExecutionMode, ElmAssistedValue_IsDistinct)` — verify ElmAssisted=3 is different from all existing:
   ```cpp
-  TEST(ExecutionMode, ChainValue_IsDistinct)
+  TEST(ExecutionMode, ElmAssistedValue_IsDistinct)
   {
-      EXPECT_NE( static_cast<int>( ExecutionMode::Chain ), static_cast<int>( ExecutionMode::SingleNode ) );
-      EXPECT_NE( static_cast<int>( ExecutionMode::Chain ), static_cast<int>( ExecutionMode::Specialist ) );
-      EXPECT_NE( static_cast<int>( ExecutionMode::Chain ), static_cast<int>( ExecutionMode::Swarm ) );
+      EXPECT_NE( static_cast<int>( ExecutionMode::ElmAssisted ), static_cast<int>( ExecutionMode::SingleNode ) );
+      EXPECT_NE( static_cast<int>( ExecutionMode::ElmAssisted ), static_cast<int>( ExecutionMode::Specialist ) );
+      EXPECT_NE( static_cast<int>( ExecutionMode::ElmAssisted ), static_cast<int>( ExecutionMode::Swarm ) );
   }
   ```
 
@@ -362,14 +362,14 @@ endmacro()
 
   <acceptance_criteria>
     - `grep -c "ELMRole" test/common/test_types.cpp` returns ≥1 (new test added)
-    - `grep -c "ChainValue_IsDistinct" test/common/test_types.cpp` returns 1
+    - `grep -c "ElmAssistedValue_IsDistinct" test/common/test_types.cpp` returns 1
     - `grep -c "has_grounding_request_" test/common/test_types.cpp` returns ≥1 (assertion added to existing test)
     - `ninja test_common_types` succeeds
     - `./test/test_common_types` — all existing + new tests pass
     - Total test count in test_types: ≥15 (existing ~13 + ~5 new)
   </acceptance_criteria>
 
-  <done>test_types.cpp extended. ELMRole, ELMContext, ChainStep, ExecutionChain, ExecutionMode::Chain, PromptFeatures new fields tested.</done>
+  <done>test_types.cpp extended. ELMRole, ELMContext, ChainStep, ExecutionChain, ExecutionMode::ElmAssisted, PromptFeatures new fields tested.</done>
 </task>
 
 <task type="auto">
@@ -391,12 +391,12 @@ endmacro()
   {
       Task task;
       task.m_prompt = "Solve this complex problem: what is 847 * 963 + 42?";
-      task.m_mode = ExecutionMode::Chain;
+      task.m_mode = ExecutionMode::ElmAssisted;
       task.m_maxTokens = 64;
 
       auto res = server_->Process( task );
       ASSERT_TRUE( res.has_value() );
-      EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::Chain );
+      EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::ElmAssisted );
       EXPECT_FALSE( res.value().m_taskId.empty() );
       // In stub mode, chain execution still succeeds (falls back to single-node
       // for some steps since no real model is loaded)
@@ -410,19 +410,19 @@ endmacro()
   {
       Task task;
       task.m_prompt = "Tell me a short story.";
-      task.m_mode = ExecutionMode::Chain;
+      task.m_mode = ExecutionMode::ElmAssisted;
       task.m_maxTokens = 32;
 
       auto res = server_->Process( task );
       ASSERT_TRUE( res.has_value() );
-      EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::Chain );
+      EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::ElmAssisted );
   }
   ```
 
   Both tests verify that:
-  - ApiServer::Process() dispatches to the Chain path when mode is `ExecutionMode::Chain`
+  - ApiServer::Process() dispatches to the Chain path when mode is `ExecutionMode::ElmAssisted`
   - The chain executor doesn't crash or throw exceptions
-  - Responses have `m_modeUsed == ExecutionMode::Chain`
+  - Responses have `m_modeUsed == ExecutionMode::ElmAssisted`
 
   Since the `PipelineTest` fixture uses stub mode (no real MNN model loaded), the actual chain output is the stub response `"[stub response — no model loaded]"`. This is acceptable — the test verifies the control flow through the chain executor, not output quality.
 
@@ -507,7 +507,7 @@ endmacro()
 <success_criteria>
 - [ ] `ninja test_elm test_common_types test_pipeline` succeeds
 - [ ] `./test/test_elm` — 18 ELM unit tests pass
-- [ ] `./test/test_common_types` — ELMRole, ELMContext, ChainStep, ExecutionChain, ExecutionMode::Chain tests pass
+- [ ] `./test/test_common_types` — ELMRole, ELMContext, ChainStep, ExecutionChain, ExecutionMode::ElmAssisted tests pass
 - [ ] `./test/test_pipeline --gtest_filter="*Chain*"` — ChainMode integration tests pass
 - [ ] `./test/test_router` — existing router tests still pass (regression: ELM-10)
 - [ ] `ctest --output-on-failure` — full suite green

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-06-PLAN.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-06-PLAN.md
@@ -1,0 +1,521 @@
+---
+phase: 07-expert-language-models-router
+plan: 06
+type: execute
+wave: 6
+depends_on:
+  - 07-02
+  - 07-03
+  - 07-04
+  - 07-05
+files_modified:
+  - test/elm/test_elm.cpp
+  - test/common/test_types.cpp
+  - test/integration/test_pipeline.cpp
+  - test/CMakeLists.txt
+autonomous: true
+requirements:
+  - ELM-01 (ELM unit tests)
+  - ELM-02 (DomainELM tests)
+  - ELM-04 (SpecialistAdapter tests)
+  - ELM-05 (ELMChainBuilder tests)
+  - ELM-06 (RunELMChain integration tests)
+  - ELM-07 (GroundingELM tests)
+  - ELM-08 (ToolSupportELM tests)
+  - ELM-03 (ELMRole + ELMContext tests)
+  - ELM-09 (Config + Pipeline tests)
+  - ELM-10 (RuleBasedRouter regression: existing tests still pass)
+
+must_haves:
+  truths:
+    - "test_elm binary runs 17+ tests covering all ELM classes"
+    - "test_common_types binary includes tests for ELMRole distinctness, ELMContext defaults, ChainStep defaults, ExecutionChain defaults, ExecutionMode::Chain distinctness"
+    - "test_pipeline binary includes ChainMode_BasicExecution and ChainMode_GeneralPrompt_SingleStep"
+    - "All tests use MockEngine pattern — no real model files, no sleep_for, no wait conditions"
+    - "ctest passes all test targets including new ELM tests"
+  artifacts:
+    - path: "test/elm/test_elm.cpp"
+      provides: "17+ ELM unit tests"
+      contains: "TEST(RoleELM, Process_LoadedEngine_ReturnsResponse)"
+    - path: "test/common/test_types.cpp"
+      provides: "Extended types tests — ELMRole, ELMContext, ChainStep, ExecutionChain, ExecutionMode"
+      contains: "TEST(ELMRole, EnumValues_AreDistinct)"
+    - path: "test/integration/test_pipeline.cpp"
+      provides: "Chain mode integration tests"
+      contains: "ChainMode_BasicExecution"
+    - path: "test/CMakeLists.txt"
+      provides: "test_elm target registration"
+      contains: "neoswarm_test(test_elm"
+  key_links:
+    - from: "test/elm/test_elm.cpp"
+      to: "src/elm/role_elm.hpp"
+      via: "#include \"elm/role_elm.hpp\""
+      pattern: "include.*elm/role_elm"
+    - from: "test/elm/test_elm.cpp"
+      to: "MockEngine"
+      via: "class MockEngine : public core::InferenceEngine"
+      pattern: "class MockEngine"
+---
+
+<objective>
+Create comprehensive test coverage for all Phase 7 components. Unit tests for ELM classes (RoleELM, DomainELM, SpecialistAdapter, GroundingELM, ToolSupportELM, ELMChainBuilder) using the MockEngine pattern from existing specialist tests. Extended common types tests for new enums and structs. Integration tests for chain execution through ApiServer. All tests adhere to project standards: no `sleep_for`, no real model dependencies, fast and deterministic.
+
+**Purpose:** Verify all must_haves from Waves 1-5. Ensure existing tests pass (regression gate).
+
+**Output:** 1 new test file, 2 modified test files, 1 modified CMakeLists.txt.
+</objective>
+
+<execution_context>
+@$HOME/.config/opencode/get-shit-done/workflows/execute-plan.md
+@$HOME/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-VALIDATION.md
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md  (patterns #15, #16, #17, #18 — test patterns)
+@.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md  (§Q7: Existing Test Patterns)
+@test/specialists/test_grammar_specialist.cpp  (EXACT MockEngine pattern lines 17-46, FailingMockEngine lines 48-72)
+@test/common/test_types.cpp  (existing test structure — where to add new tests)
+@test/integration/test_pipeline.cpp  (existing PipelineTest fixture to extend)
+@test/CMakeLists.txt  (neoswarm_test macro pattern lines 42-53, 69-70)
+@src/core/engine/inference_engine.hpp  (MockEngine must implement all pure virtuals)
+@src/elm/i_elm.hpp  (IELM — what's being tested)
+@src/elm/role_elm.hpp  (RoleELM constructor)
+@src/elm/domain_elm.hpp  (DomainELM constructor)
+@src/elm/specialist_adapter.hpp  (SpecialistAdapter constructor)
+@src/elm/grounding_elm.hpp  (GroundingELM constructor)
+@src/elm/tool_support_elm.hpp  (ToolSupportELM constructor)
+@src/elm/elm_chain_builder.hpp  (ELMChainBuilder::Build)
+@src/common/types.hpp  (ELMRole, ELMContext, ChainStep, ExecutionChain, PromptFeatures)
+./CLAUDE.md
+
+<interfaces>
+MockEngine pattern (from test_grammar_specialist.cpp:17-46):
+```cpp
+class MockEngine : public core::InferenceEngine {
+public:
+    outcome::result<InferenceResponse> Infer(const Task& task) override {
+        InferenceResponse resp;
+        resp.m_output = task.m_prompt + " [response]";
+        resp.m_perplexity = 1.0f;
+        resp.m_success = true;
+        resp.m_taskId = task.m_id;
+        return outcome::success(resp);
+    }
+    outcome::result<void> StreamInfer(const Task&, std::function<void(const std::string&)>) override { return outcome::success(); }
+    outcome::result<void> LoadModel(const std::string&) override { return outcome::success(); }
+    bool IsLoaded() const override { return true; }
+    std::string BackendName() const override { return "mock"; }
+};
+```
+
+FailingMockEngine pattern (lines 48-72):
+```cpp
+class FailingMockEngine : public core::InferenceEngine {
+    outcome::result<InferenceResponse> Infer(const Task&) override { return outcome::failure(Error::InferenceFailed); }
+    outcome::result<void> StreamInfer(...) override { return outcome::failure(Error::InferenceFailed); }
+    outcome::result<void> LoadModel(...) override { return outcome::failure(Error::ModelLoadFailed); }
+    bool IsLoaded() const override { return false; }
+    std::string BackendName() const override { return "mock"; }
+};
+```
+
+neoswarm_test macro (test/CMakeLists.txt:42-53):
+```cmake
+macro(neoswarm_test name sources libs)
+    add_executable(${name} ${sources})
+    target_link_libraries(${name} PRIVATE ${libs} GTest::GTest GTest::Main)
+    target_compile_definitions(${name} PRIVATE SUPERGENIUS_TEST_DATA_DIR="...")
+    add_test(NAME ${name} COMMAND ${name})
+endmacro()
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>task 1: create test/elm/ directory and test_elm.cpp with all ELM unit tests</name>
+  <files>test/elm/test_elm.cpp</files>
+
+  <read_first>
+  - test/specialists/test_grammar_specialist.cpp (EXACT MockEngine pattern lines 17-72, test structure lines 79-139)
+  - src/core/engine/inference_engine.hpp (InferenceEngine virtual methods that MockEngine must implement)
+  - src/elm/role_elm.hpp (RoleELM constructor: RoleELM(ELMRole, shared_ptr<InferenceEngine>))
+  - src/elm/domain_elm.hpp (DomainELM constructor)
+  - src/elm/specialist_adapter.hpp (SpecialistAdapter constructor)
+  - src/elm/grounding_elm.hpp (GroundingELM constructor)
+  - src/elm/tool_support_elm.hpp (ToolSupportELM constructor)
+  - src/elm/elm_chain_builder.hpp (ELMChainBuilder::Build)
+  - src/common/types.hpp (ELMRole, ELMContext, PromptFeatures, RouteDecision, ExecutionChain)
+  - src/specialists/i_specialist.hpp (ISpecialist — to create mock specialists for adapter tests)
+  - src/knowledge/knowledge_retrieval.hpp (to create mock knowledge for grounding tests)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #15 (test_elm.cpp)
+  - ./CLAUDE.md (no sleep_for in tests)
+  </read_first>
+
+  <action>
+  Create directory `test/elm/` and file `test/elm/test_elm.cpp`. The file must compile standalone, use the MockEngine pattern, and contain 17 test cases.
+
+  **File structure:**
+  ```cpp
+  /**
+   * @file       test_elm.cpp
+   * @brief      Unit tests for Phase 7 ELM classes
+   * @date       2026-07-16
+   */
+
+  #include "elm/role_elm.hpp"
+  #include "elm/domain_elm.hpp"
+  #include "elm/specialist_adapter.hpp"
+  #include "elm/grounding_elm.hpp"
+  #include "elm/tool_support_elm.hpp"
+  #include "elm/elm_chain_builder.hpp"
+  #include "core/engine/inference_engine.hpp"
+  #include "specialists/i_specialist.hpp"
+  #include "knowledge/knowledge_retrieval.hpp"
+  #include "knowledge/context_injection.hpp"
+  #include "knowledge/fact_validation.hpp"
+  #include <gtest/gtest.h>
+  #include <memory>
+
+  using namespace sgns::neoswarm;
+
+  namespace {
+      // MockEngine — copy verbatim from test_grammar_specialist.cpp:17-46
+      class MockEngine : public core::InferenceEngine { ... };
+
+      // FailingMockEngine — copy verbatim from test_grammar_specialist.cpp:48-72
+      class FailingMockEngine : public core::InferenceEngine { ... };
+
+      // MockSpecialist — implements ISpecialist for adapter tests
+      class MockSpecialist : public specialists::ISpecialist {
+      public:
+          std::string GetName() const override { return "MockSpecialist"; }
+          bool IsLoaded() const override { return m_loaded; }
+          outcome::result<void> Load(const std::string&) override { m_loaded = true; return outcome::success(); }
+          outcome::result<std::string> Process(const std::string& input) override {
+              m_lastConf = 0.9f;
+              return outcome::success(input + " [specialized]");
+          }
+          float GetConfidence() const override { return m_lastConf; }
+      private:
+          bool m_loaded = false;
+          float m_lastConf = 0.0f;
+      };
+
+      // MockKnowledgeRetrieval — for GroundingELM tests
+      class MockKnowledgeRetrieval : public knowledge::KnowledgeRetrieval {
+      public:
+          outcome::result<std::vector<KnowledgeFact>> Retrieve(const std::string&) const override {
+              KnowledgeFact fact;
+              fact.m_source = "test";
+              fact.m_content = "test fact content";
+              fact.m_relevanceScore = 0.9f;
+              return std::vector<KnowledgeFact>{ fact };
+          }
+          bool IsLoaded() const override { return true; }
+      };
+  } // namespace
+  ```
+
+  **Test cases — 17 tests total:**
+
+  RoleELM (5 tests):
+  1. `TEST(RoleELM, Process_LoadedEngine_ReturnsResponse)` — MockEngine, Load("dummy"), Process("test", ctx), assert output contains "test", GetConfidence() > 0.0f
+  2. `TEST(RoleELM, Process_NotLoaded_ReturnsInputUnchanged)` — MockEngine, no Load(), Process("hello", ctx) → returns "hello" unchanged, GetConfidence() == 0.0f
+  3. `TEST(RoleELM, GetName_ReturnsCorrectName)` — RoleELM(Verifier, engine) → GetName() == "Verifier"
+  4. `TEST(RoleELM, GetRole_ReturnsConfiguredRole)` — RoleELM(Planner, engine) → GetRole() == ELMRole::Planner
+  5. `TEST(RoleELM, IsLoaded_InitiallyFalse)` — constructor → IsLoaded() == false
+
+  DomainELM (3 tests):
+  6. `TEST(DomainELM, Process_SharedBackbone_ReturnsResponse)` — DomainELM(Code, MockEngine), Load(""), Process("code", ctx) → output present, confidence > 0
+  7. `TEST(DomainELM, Process_NoEngine_ReturnsInputUnchanged)` — DomainELM(Code, nullptr) → Process("test", ctx) → returns "test", confidence == 0.0f
+  8. `TEST(DomainELM, GetRole_ReturnsConfiguredRole)` — DomainELM(Math, engine) → GetRole() == ELMRole::Math
+
+  SpecialistAdapter (2 tests):
+  9. `TEST(SpecialistAdapter, Process_DelegatesToSpecialist)` — MockSpecialist, adapter(ELMRole::Refiner), Process("input", ctx) → output == "input [specialized]"
+  10. `TEST(SpecialistAdapter, GetConfidence_ReflectsSpecialist)` — MockSpecialist, Process("x", ctx), GetConfidence() == 0.9f
+
+  ELMChainBuilder (5 tests — one per trigger priority):
+  11. `TEST(ELMChainBuilder, Build_HighNumericDensity_ReturnsMathChain)` — features.numeric_density_=0.5f, Build() → 2 steps, first step role is Math
+  12. `TEST(ELMChainBuilder, Build_CodeSyntax_ReturnsPlannerCodeChain)` — features.has_code_syntax_=true, Build() → 2 steps, first is Planner, second has domain "code"
+  13. `TEST(ELMChainBuilder, Build_LowComplexity_ReturnsSingleStep)` — features.complexity_=1.0f, no other flags, Build() → 1 step: PrimaryDraft
+  14. `TEST(ELMChainBuilder, Build_HighComplexity_ReturnsFullChain)` — features.complexity_=6.0f, no other flags, Build() → 4 steps, last is Refiner
+  15. `TEST(ELMChainBuilder, Build_Default_ReturnsPrimaryDraft)` — all defaults, Build() → 1 step: PrimaryDraft, reasoning non-empty
+
+  GroundingELM (1 test — uses MockKnowledgeRetrieval):
+  16. `TEST(GroundingELM, Process_KnowledgeLoaded_ReturnsAugmentedOutput)` — MockKnowledgeRetrieval + MockEngine + real ContextInjection + real FactValidation(MockKnowledge), Load(""), Process("test", ctx) → output non-empty, confidence > 0
+
+  ToolSupportELM (2 tests):
+  17. `TEST(ToolSupportELM, Process_ReturnsInputUnchanged_ConfidenceZero)` — default construct, Process("any", ctx) → returns "any", GetConfidence() == 0.0f
+  18. `TEST(ToolSupportELM, IsLoaded_AlwaysFalse)` — default construct → IsLoaded() == false
+
+  **Style:** Each test follows the existing GTest pattern: `ASSERT_TRUE` for preconditions, `EXPECT_*` for assertions. No `sleep_for`, no real model files, no file I/O. Tests must run in < 1 second each. Use `EXPECT_NE(result.value().find("keyword"), std::string::npos)` for string assertions (matching existing patterns). `EXPECT_FLOAT_EQ` for exact float equality (e.g., 0.0f). `EXPECT_GT(value, 0.0f)` for confidence > 0.
+
+  For tests that create an `ELMContext`: initialize all fields (even if empty) — default-constructed `ELMContext` is fine for most tests.
+
+  For ELMChainBuilder tests: create a default `RouteDecision` struct. The `decision.confidence_` doesn't affect chain shape — it's just carried forward.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja test_elm 2>&1 | tail -10 && ./test/test_elm 2>&1 | tail -30</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - File exists: `test/elm/test_elm.cpp`
+    - `grep -c "TEST(" test/elm/test_elm.cpp` returns ≥18 (18 test cases)
+    - `grep -c "MockEngine" test/elm/test_elm.cpp` returns ≥2 (class definition + usage)
+    - `grep -c "FailingMockEngine" test/elm/test_elm.cpp` returns 1 (class definition)
+    - `grep -c "MockSpecialist" test/elm/test_elm.cpp` returns 1 (class definition)
+    - `grep "sleep_for" test/elm/test_elm.cpp` returns 0 (forbidden per CLAUDE.md)
+    - `ninja test_elm` succeeds
+    - `./test/test_elm` — all 18 tests pass (green run)
+  </acceptance_criteria>
+
+  <done>test_elm.cpp compiles. 18 tests pass covering all ELM classes. MockEngine/FailingMockEngine/MockSpecialist mocks used.</done>
+</task>
+
+<task type="auto">
+  <name>task 2: extend test/common/test_types.cpp with ELMRole + ELMContext + ChainStep + ExecutionChain tests</name>
+  <files>test/common/test_types.cpp</files>
+
+  <read_first>
+  - test/common/test_types.cpp (existing test structure — ExecutionMode test at lines 6-11, PromptFeatures test at lines 76-85)
+  - src/common/types.hpp (ELMRole, ELMContext, ChainStep, ExecutionChain, ExecutionMode::Chain)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #16 (test_types.cpp extensions)
+  </read_first>
+
+  <action>
+  Append new test cases to `test/common/test_types.cpp`. Add after the last existing test (after line 93 `TEST(KnowledgeFact, ...)` before end of file).
+
+  **New tests to add:**
+
+  1. `TEST(ELMRole, EnumValues_AreDistinct)` — verify all 10 role values are distinct:
+  ```cpp
+  TEST(ELMRole, EnumValues_AreDistinct)
+  {
+      EXPECT_NE( static_cast<int>( ELMRole::Planner ), static_cast<int>( ELMRole::PrimaryDraft ) );
+      EXPECT_NE( static_cast<int>( ELMRole::Verifier ), static_cast<int>( ELMRole::Arbiter ) );
+      EXPECT_NE( static_cast<int>( ELMRole::Refiner ), static_cast<int>( ELMRole::Grounding ) );
+      EXPECT_NE( static_cast<int>( ELMRole::ToolSupport ), static_cast<int>( ELMRole::Math ) );
+      EXPECT_NE( static_cast<int>( ELMRole::Code ), static_cast<int>( ELMRole::Science ) );
+  }
+  ```
+
+  2. `TEST(ExecutionMode, ChainValue_IsDistinct)` — verify Chain=3 is different from all existing:
+  ```cpp
+  TEST(ExecutionMode, ChainValue_IsDistinct)
+  {
+      EXPECT_NE( static_cast<int>( ExecutionMode::Chain ), static_cast<int>( ExecutionMode::SingleNode ) );
+      EXPECT_NE( static_cast<int>( ExecutionMode::Chain ), static_cast<int>( ExecutionMode::Specialist ) );
+      EXPECT_NE( static_cast<int>( ExecutionMode::Chain ), static_cast<int>( ExecutionMode::Swarm ) );
+  }
+  ```
+
+  3. `TEST(ELMContext, DefaultConstructor_HasReasonableDefaults)`:
+  ```cpp
+  TEST(ELMContext, DefaultConstructor_HasReasonableDefaults)
+  {
+      ELMContext ctx;
+      EXPECT_TRUE( ctx.m_originalTask.empty() );
+      EXPECT_TRUE( ctx.m_lastOutput.empty() );
+      EXPECT_TRUE( ctx.m_stepConfidences.empty() );
+      EXPECT_TRUE( ctx.m_groundingFacts.empty() );
+  }
+  ```
+
+  4. `TEST(ChainStep, DefaultConstructor_HasReasonableDefaults)`:
+  ```cpp
+  TEST(ChainStep, DefaultConstructor_HasReasonableDefaults)
+  {
+      ChainStep step;
+      EXPECT_EQ( step.m_role, ELMRole::PrimaryDraft );
+      EXPECT_FALSE( step.m_domain.has_value() );
+  }
+  ```
+
+  5. `TEST(ExecutionChain, DefaultConstructor_HasReasonableDefaults)`:
+  ```cpp
+  TEST(ExecutionChain, DefaultConstructor_HasReasonableDefaults)
+  {
+      ExecutionChain chain;
+      EXPECT_TRUE( chain.m_steps.empty() );
+      EXPECT_TRUE( chain.m_reasoning.empty() );
+      EXPECT_FLOAT_EQ( chain.m_chainConfidence, 0.0f );
+  }
+  ```
+
+  6. `TEST(PromptFeatures, DefaultConstructor_NewFieldsDefaultFalse)` — extend existing PromptFeatures test at line 76: add assertions for the 2 new fields at the end of the existing test body:
+  ```cpp
+      EXPECT_FALSE( pf.has_grounding_request_ );
+      EXPECT_FALSE( pf.has_formatting_request_ );
+  ```
+  Add these 2 lines inside the existing `TEST(PromptFeatures, DefaultConstructor_AllFalse)` body (after line 84 `pf.has_grammar_request_`).
+
+  **Style:** Follow existing test conventions — `EXPECT_NE` for distinctness, `EXPECT_EQ` for equality, `EXPECT_TRUE`/`EXPECT_FALSE` for booleans, `EXPECT_FLOAT_EQ` for floats. Tests are in `sgns::neoswarm` namespace (already `using namespace` at line 4).
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja test_common_types 2>&1 | tail -5 && ./test/test_common_types 2>&1 | tail -20</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "ELMRole" test/common/test_types.cpp` returns ≥1 (new test added)
+    - `grep -c "ChainValue_IsDistinct" test/common/test_types.cpp` returns 1
+    - `grep -c "has_grounding_request_" test/common/test_types.cpp` returns ≥1 (assertion added to existing test)
+    - `ninja test_common_types` succeeds
+    - `./test/test_common_types` — all existing + new tests pass
+    - Total test count in test_types: ≥15 (existing ~13 + ~5 new)
+  </acceptance_criteria>
+
+  <done>test_types.cpp extended. ELMRole, ELMContext, ChainStep, ExecutionChain, ExecutionMode::Chain, PromptFeatures new fields tested.</done>
+</task>
+
+<task type="auto">
+  <name>task 3: extend test/integration/test_pipeline.cpp with chain mode integration tests</name>
+  <files>test/integration/test_pipeline.cpp</files>
+
+  <read_first>
+  - test/integration/test_pipeline.cpp (existing PipelineTest fixture, existing SingleNode/Math/Grammar tests)
+  - src/api/api_server.hpp (ApiServer::Config — to create stub-mode config for tests)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #17 (test_pipeline.cpp extensions)
+  </read_first>
+
+  <action>
+  Append 2 new test cases to `test/integration/test_pipeline.cpp`, using the existing `PipelineTest` fixture (which sets up an ApiServer in stub mode with no model files).
+
+  **Test 1: `TEST_F(PipelineTest, ChainMode_BasicExecution)`**
+  ```cpp
+  TEST_F( PipelineTest, ChainMode_BasicExecution )
+  {
+      Task task;
+      task.m_prompt = "Solve this complex problem: what is 847 * 963 + 42?";
+      task.m_mode = ExecutionMode::Chain;
+      task.m_maxTokens = 64;
+
+      auto res = server_->Process( task );
+      ASSERT_TRUE( res.has_value() );
+      EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::Chain );
+      EXPECT_FALSE( res.value().m_taskId.empty() );
+      // In stub mode, chain execution still succeeds (falls back to single-node
+      // for some steps since no real model is loaded)
+      EXPECT_TRUE( res.value().m_success );
+  }
+  ```
+
+  **Test 2: `TEST_F(PipelineTest, ChainMode_GeneralPrompt_SingleStep)`**
+  ```cpp
+  TEST_F( PipelineTest, ChainMode_GeneralPrompt_SingleStep )
+  {
+      Task task;
+      task.m_prompt = "Tell me a short story.";
+      task.m_mode = ExecutionMode::Chain;
+      task.m_maxTokens = 32;
+
+      auto res = server_->Process( task );
+      ASSERT_TRUE( res.has_value() );
+      EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::Chain );
+  }
+  ```
+
+  Both tests verify that:
+  - ApiServer::Process() dispatches to the Chain path when mode is `ExecutionMode::Chain`
+  - The chain executor doesn't crash or throw exceptions
+  - Responses have `m_modeUsed == ExecutionMode::Chain`
+
+  Since the `PipelineTest` fixture uses stub mode (no real MNN model loaded), the actual chain output is the stub response `"[stub response — no model loaded]"`. This is acceptable — the test verifies the control flow through the chain executor, not output quality.
+
+  **Style:** Follow existing `PipelineTest` test patterns — `server_->Process(task)`, `ASSERT_TRUE(res.has_value())`, `EXPECT_EQ` on response fields. Add tests after the last existing `TEST_F` in the file.
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && ninja test_pipeline 2>&1 | tail -5 && ./test/test_pipeline --gtest_filter="*Chain*" 2>&1 | tail -15</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "ChainMode" test/integration/test_pipeline.cpp` returns ≥2
+    - `ninja test_pipeline` succeeds
+    - `./test/test_pipeline --gtest_filter="*Chain*"` — both ChainMode tests pass
+    - Existing pipeline tests still pass: `./test/test_pipeline --gtest_filter="-*Chain*"` — all green
+    - No crash, no hang, no timeout in chain tests
+  </acceptance_criteria>
+
+  <done>Pipeline integration tests extended. Chain mode control flow verified. Existing tests pass.</done>
+</task>
+
+<task type="auto">
+  <name>task 4: register test_elm target in test/CMakeLists.txt</name>
+  <files>test/CMakeLists.txt</files>
+
+  <read_first>
+  - test/CMakeLists.txt (neoswarm_test macro pattern lines 42-53, existing test registrations lines 55-78)
+  - .planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md pattern #18 (CMakeLists.txt test registration)
+  </read_first>
+
+  <action>
+  Add ONE line to `test/CMakeLists.txt` — after the existing specialist tests (after line 71 `neoswarm_test(test_symbolic_fallback ...)`), add a section comment and the new test target:
+
+  ```cmake
+  # Phase 7 — ELM tests
+  neoswarm_test(test_elm             elm/test_elm.cpp              "neoswarm_elm;neoswarm_core;neoswarm_knowledge;neoswarm_specialists;neoswarm_common")
+  ```
+  The library dependencies are: `neoswarm_elm` (all ELM classes), `neoswarm_core` (InferenceEngine for MockEngine), `neoswarm_knowledge` (KnowledgeRetrieval for MockKnowledge), `neoswarm_specialists` (ISpecialist for MockSpecialist), `neoswarm_common` (types, error).
+  </action>
+
+  <verify>
+    <automated>cd build/OSX/Debug && cmake ../.. -G Ninja -DCMAKE_BUILD_TYPE=Debug 2>&1 | tail -5 && ninja test_elm 2>&1 | tail -10 && ctest -R test_elm --output-on-failure 2>&1 | tail -15</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "test_elm" test/CMakeLists.txt` returns 1
+    - `grep "neoswarm_elm" test/CMakeLists.txt` returns 1 (linked library list)
+    - CMake configure succeeds
+    - `ninja test_elm` succeeds
+    - `ctest -R test_elm` passes (test registered with CTest)
+    - `ctest --output-on-failure` — all tests pass (full suite green)
+  </acceptance_criteria>
+
+  <done>test_elm registered in CMake. Full CTest suite green including all new ELM tests.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| N/A | Tests have no trust boundaries — MockEngine returns controlled responses |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-07-06-01 | N/A | Test code | accept | Test code is not deployed. No security threat from test framework. MockEngine is entirely synthetic — no real model execution, no I/O, no external calls. |
+</threat_model>
+
+<verification>
+- `cd build/OSX/Debug && ninja test_elm test_common_types test_pipeline` — all test targets build
+- `./test/test_elm` — 18 tests pass
+- `./test/test_common_types` — all tests pass (existing + new)
+- `./test/test_pipeline --gtest_filter="*Chain*"` — 2 chain tests pass
+- `./test/test_router` — existing router tests still pass (regression gate)
+- `ctest --output-on-failure` — full suite green
+</verification>
+
+<success_criteria>
+- [ ] `ninja test_elm test_common_types test_pipeline` succeeds
+- [ ] `./test/test_elm` — 18 ELM unit tests pass
+- [ ] `./test/test_common_types` — ELMRole, ELMContext, ChainStep, ExecutionChain, ExecutionMode::Chain tests pass
+- [ ] `./test/test_pipeline --gtest_filter="*Chain*"` — ChainMode integration tests pass
+- [ ] `./test/test_router` — existing router tests still pass (regression: ELM-10)
+- [ ] `ctest --output-on-failure` — full suite green
+- [ ] No `sleep_for` in any test file
+- [ ] No real model dependencies in any test
+- [ ] All MockEngine implementations implement the full InferenceEngine interface (6 virtuals)
+</success_criteria>
+
+<output>
+After completion, create `.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-06-SUMMARY.md`
+</output>

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md
@@ -111,6 +111,7 @@ Deploy 7 role-based ELMs (Planner, Primary Draft, Verifier, Arbiter, Refiner/For
 <deferred>
 ## Deferred Ideas
 
+- PlannerELM → Planner **+ Memory Governor** extension (doc 11 §16.8.1.1 defines the full role as "Planner and Memory Governor Specialist"; the memory-governor half — retrieval prefiltering, Bridge Block selection, temporal resolution — requires GAML) — Phase 8. PlannerELM's Doxygen header must note this extension point so the missing half is not "fixed" prematurely.
 - Multi-domain parallel dispatch + arbiter-mediated synthesis of parallel outputs — Phase 9 (swarm)
 - Learned classifier router — Phase 7.5 / doc 03 §6.3 stage 2
 - Cognitive planner producing full execution graphs — Phase 8+ (needs GAML memory)

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-CONTEXT.md
@@ -1,0 +1,126 @@
+# Phase 7: Expert Language Models + Router - Context
+
+**Gathered:** 2026-07-15
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Deploy 7 role-based ELMs (Planner, Primary Draft, Verifier, Arbiter, Refiner/Formatter, Grounding, Tool-Support) and 3 domain ELMs (Math, Code, Science) behind swappable interfaces, with a rule-based router extended to build and execute sequential specialist chains (e.g. Planner → Domain → Verifier → Refiner). Local-only, stateless. GAML memory is Phase 8, distributed swarm execution is Phase 9, safety profiles and Tool Intermediary are Phase 10.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### ELM backing (what physically runs each role)
+- **D-01:** Hybrid backing. By default every role ELM invokes the already-loaded core MNN model with a role-specific prompt template (shared backbone per doc 03 §5.2.1). No new model files required for Phase 7 to function.
+- **D-02:** If config provides a model path for a role/domain, that ELM loads its own quantized `.mnn` (SGFP4 export from gnus-poc) instead of the shared backbone. Same `IELM` interface either way.
+- **D-03:** Role prompt templates live as named constants/resources in the ELM implementations — not user-editable config in Phase 7.
+- **D-04:** Missing model file for a configured path → `outcome::result` error at load, ELM falls back to shared-backbone mode with a logged warning (graceful degradation pattern from Phase 2).
+
+### Interface design and legacy mapping
+- **D-05:** New `IELM` interface (`I`-prefix convention): `GetName()`, `GetRole()`, `IsLoaded()`, `Load(path)`, `Process(input, ELMContext)`, `GetConfidence()`. `ISpecialist` remains untouched.
+- **D-06:** Legacy mapping per doc 03 §5.2.6: `GrammarSpecialist` is wrapped by the Refiner/Formatter role ELM via adapter; `MathSpecialist` is wrapped as the Math domain ELM via adapter; `SymbolicFallback` stays internal to the Math path (not an ELM).
+- **D-07:** Adapters use composition (has-a `ISpecialist`), not inheritance. Existing specialist tests unchanged.
+- **D-08:** `ELMRole` enum and `ELMContext` struct added to `src/common/types.hpp`.
+
+### Chain representation and routing rules
+- **D-09:** `ExecutionChain` is a flat ordered list of steps; each step = `{ELMRole role, optional domain}`. No parallel edges in Phase 7 — struct designed so a DAG extension can be added later without breaking consumers.
+- **D-10:** Multi-domain parallel dispatch (`Planner → [Math, Code] → Arbiter`) is explicitly deferred to Phase 9 (swarm dispatch concern).
+- **D-11:** Router split: `RuleBasedRouter` keeps producing `RouteDecision` (unchanged responsibilities, existing tests intact); new `ELMChainBuilder` maps `RouteDecision` + `PromptFeatures` to an `ExecutionChain`.
+- **D-12:** MVP chain selection implements doc 03 §6.2 heuristic triggers:
+  - Numeric density → Math domain + Verifier
+  - Code syntax → Code domain path
+  - Grounding-sensitive → Grounding step before draft
+  - Formatting-sensitive → Refiner/Formatter step after draft
+  - Low complexity → Semantic Core only (Primary Draft)
+  - High complexity/uncertainty → Planner → Domain → Verifier → Refiner
+- **D-13:** `ApiServer` gains `RunELMChain(chain, task)` executing steps sequentially; output of each step feeds the next via `ELMContext`.
+
+### Configuration surface
+- **D-14:** ELM configuration is an `elms` section in the existing `--config` JSON file (consistent with Phase 2 D-09). Per-role/domain optional fields: `model` (path), `eager` (bool, default false).
+- **D-15:** No new per-ELM CLI flags. Existing `--model`, `--grammar-model`, `--math-model` flags stay for backward compatibility.
+- **D-16:** Lazy loading by default; `eager: true` per-ELM opt-in loads at `ApiServer::Initialize()`.
+
+### Grounding and Tool-Support boundaries
+- **D-17:** `GroundingELM` wraps the existing `knowledge/` pipeline (`KnowledgeRetrieval`, `ContextInjection`, `FactValidation`) behind `IELM`. No new retrieval implementation, no new model.
+- **D-18:** `ToolSupportELM` is an interface-conforming stub (pass-through with logged not-implemented status). Real tool-call formatting requires Phase 10's Tool Intermediary boundary.
+
+### OpenCode's Discretion
+- Exact `ELMContext` field set (must carry at minimum: original task, accumulated step outputs, per-step confidence)
+- Role prompt template wording
+- Chain-step timeout and confidence-threshold defaults
+- File layout for ELM implementations (suggested: `src/elm/` or extend `src/specialists/`)
+- Whether Science ELM ships as shared-backbone-only in Phase 7 (no trained model exists)
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- Role ELMs must be swappable per doc 03 §5.2.1 — "implementations are swappable" is the phase's core architectural requirement
+- Execution flow: Task → RuleBasedRouter → RouteDecision → ELMChainBuilder → ExecutionChain → ApiServer::RunELMChain
+- Wave-based execution with one PR per wave (established project workflow)
+
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### ELM and Router architecture
+- `../../docs/architecture/03-model-and-router.md` §5.2 — ELM definition, role-based ELMs, domain experts, invocation patterns, legacy specialist mapping
+- `../../docs/architecture/03-model-and-router.md` §6 — Router responsibilities, MVP rule-based triggers (§6.2), evolution path (§6.3)
+- `../../docs/architecture/11-distributed-swarm-thinking-context.md` §16.8 — Specialist taxonomy: role specialist responsibilities in detail
+
+(Paths relative to repo root: `/Volumes/Work/Gnus_ai/GeniusNetwork/GeniusCognitiveSystem/docs/architecture/`)
+
+### Existing contracts this phase builds on
+- `src/router/i_router.hpp` — `IRouter` interface, `RouteDecision`
+- `src/specialists/i_specialist.hpp` — `ISpecialist` interface being adapted
+- `src/core/engine/inference_engine.hpp` — `InferenceEngine` abstraction (shared backbone access)
+- `src/common/types.hpp` — Task, RouteTarget, ExecutionMode types being extended
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `RuleBasedRouter` + `PromptAnalyzer` (`src/router/`): feature extraction (numeric density, code syntax, complexity) already implements most §6.2 trigger inputs
+- `GrammarSpecialist`, `MathSpecialist`, `SymbolicFallback` (`src/specialists/`): become Refiner and Math ELMs via adapters
+- `KnowledgeRetrieval`/`ContextInjection`/`FactValidation` (`src/knowledge/`): backs GroundingELM
+- `MNNInferenceEngine` (`src/core/engine/`): the shared backbone all default ELMs invoke
+- `ApiServer` (`src/api/`): composition root where chain execution integrates
+
+### Established Patterns
+- `outcome::result<T>` error propagation, no exceptions, C++17 ceiling
+- Config struct + constructor, `Initialize()` lifetime, Pimpl for heavy deps
+- Stub/graceful degradation when optional backends missing
+- `I`-prefix interfaces, `m_` members, snake_case files, `neoswarm_` CMake libs
+
+### Integration Points
+- `ApiServer::Process()` currently branches to `RunSingleNode/RunSpecialist/RunSwarm` — `RunELMChain` becomes the fourth path (or subsumes RunSpecialist)
+- JSON config parsing in `main.cpp` gains `elms` section
+- `test/` structure: `test/router/`, `test/specialists/`, `test/integration/` get ELM test targets
+
+</code_context>
+
+<deferred>
+## Deferred Ideas
+
+- Multi-domain parallel dispatch + arbiter-mediated synthesis of parallel outputs — Phase 9 (swarm)
+- Learned classifier router — Phase 7.5 / doc 03 §6.3 stage 2
+- Cognitive planner producing full execution graphs — Phase 8+ (needs GAML memory)
+- Real Tool-Support logic — Phase 10 (Tool Intermediary boundary)
+- User-editable role prompt templates — future config enhancement
+- Legal/Compliance, Operations, Customer Support, Finance domain ELMs (doc 03 §5.2.3) — future phases
+
+</deferred>
+
+---
+
+*Phase: 07-expert-language-models-router*
+*Context gathered: 2026-07-15*

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-DISCUSSION-LOG.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-DISCUSSION-LOG.md
@@ -1,0 +1,54 @@
+# Phase 7: Expert Language Models + Router — Discussion Log
+
+**Date:** 2026-07-15
+**Mode:** User-delegated auto-selection ("clearly analyse and choose best all choices")
+**Prior context:** A previous 07-CONTEXT.md (2026-07-13) was deleted by the user as potentially wrong; discussion restarted fresh from architecture docs 03 and 11.
+
+---
+
+## Areas Presented
+
+1. What physically backs each role ELM
+2. ELM interface design & legacy specialist mapping
+3. Chain representation & MVP routing rules
+4. ELM configuration surface
+5. Grounding + Tool-Support boundaries
+
+User selected: all (delegated final choice to OpenCode after options were presented with analysis).
+
+---
+
+## Area 1: ELM backing
+
+**Options presented:**
+- A. Shared backbone + role prompts (zero extra memory, works today)
+- B. Separate model file per role (7 permanent stubs in practice)
+- C. Hybrid — shared backbone default, optional per-role model path
+
+**Selected: C (Hybrid).** Role-specific trained models do not exist yet (gnus-poc trained domain LoRA specialists only). Doc 03 §5.2.1 explicitly sanctions shared-backbone ELMs. C gives B's migration path at A's cost. Eliminates the 8GB memory risk.
+
+## Area 2: Interface design
+
+**Selected: new `IELM` + composition adapters; `ISpecialist` untouched.** Legacy mapping straight from doc 03 §5.2.6: Grammar → Refiner/Formatter, Math → Math domain ELM, SymbolicFallback stays internal. Minimal-change, existing tests intact.
+
+## Area 3: Chain representation
+
+**Selected: flat sequential step list, graph-ready struct; parallel deferred to Phase 9.** Resolves the contradiction in the deleted context (sequential type vs parallel multi-domain pattern). MVP chains implement doc 03 §6.2's six heuristic triggers. Router split: RuleBasedRouter (unchanged) + new ELMChainBuilder.
+
+## Area 4: Configuration surface
+
+**Selected: `elms` section in existing JSON config; no new CLI flags.** Consistent with Phase 2 D-09. Rejected the deleted context's 10 per-ELM CLI flags as unwieldy. Lazy default, per-ELM eager opt-in.
+
+## Area 5: Grounding + Tool-Support
+
+**Selected: GroundingELM wraps existing `knowledge/` pipeline; ToolSupportELM is a stub until Phase 10.** No duplicate retrieval implementation; tool safety belongs to Phase 10's Tool Intermediary.
+
+---
+
+## Deferred Ideas Captured
+
+- Parallel multi-domain dispatch → Phase 9
+- Learned classifier router → Phase 7.5
+- Cognitive planner / execution graphs → Phase 8+
+- Real tool-call logic → Phase 10
+- Additional domain ELMs (Legal, Finance, etc.) → future

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md
@@ -1,0 +1,1329 @@
+# Phase 07: Expert Language Models + Router - Pattern Map
+
+**Mapped:** 2026-07-16
+**Files analyzed:** 18 (11 new, 7 modified)
+**Analogs found:** 18 / 18
+
+## File Classification
+
+| New/Modified File | Role | Data Flow | Closest Analog | Match Quality |
+|-------------------|------|-----------|----------------|---------------|
+| `src/elm/i_elm.hpp` | interface | request-response | `src/specialists/i_specialist.hpp` | exact (I-prefix abstract class, outcome::result signatures) |
+| `src/elm/role_elm.hpp` | service | transform | `src/specialists/grammar_specialist.hpp` | exact (prompt-template + engine→Infer, same member layout) |
+| `src/elm/role_elm.cpp` | service | transform | `src/specialists/grammar_specialist.cpp` | exact (BuildPrompt + Task construction + Infer + confidence) |
+| `src/elm/domain_elm.hpp` | service | transform | `src/specialists/math_specialist.hpp` | exact (optional own engine, configurable model path, same structure) |
+| `src/elm/domain_elm.cpp` | service | transform | `src/specialists/math_specialist.cpp` | exact (Load, BuildPrompt, Process, confidence computation) |
+| `src/elm/grounding_elm.hpp` | service | pipeline-transform | `src/knowledge/knowledge_retrieval.hpp` + `src/api/api_server.hpp:AugmentPrompt` | role-match (composes knowledge/ pipeline + engine) |
+| `src/elm/grounding_elm.cpp` | service | pipeline-transform | `src/api/api_server.cpp:204-217` (AugmentPrompt) + `grammar_specialist.cpp:56-81` (Process) | role-match (Retrieve→Inject→Infer→Validate ordering) |
+| `src/elm/tool_support_elm.hpp` | service | request-response (stub) | `src/specialists/grammar_specialist.hpp` (simplified) | role-match (same interface, no engine, pass-through) |
+| `src/elm/tool_support_elm.cpp` | service | request-response (stub) | `src/specialists/grammar_specialist.cpp:56-63` (not-loaded path) | partial (identical fail-close pattern: return input unchanged, confidence=0) |
+| `src/elm/specialist_adapter.hpp` | adapter | request-response | `src/specialists/i_specialist.hpp` (composition target) + `src/api/api_server.hpp:116-117` (member pattern) | role-match (has-a ISpecialist, maps Process signatures) |
+| `src/elm/specialist_adapter.cpp` | adapter | request-response | `src/specialists/grammar_specialist.cpp:22-25` (constructor DI pattern) | partial (simple delegation — composition of shared_ptr) |
+| `src/elm/elm_chain_builder.hpp` | service | transform | `src/router/rule_based_router.hpp` | role-match (Config struct, constructor, single public method, private helpers) |
+| `src/elm/elm_chain_builder.cpp` | service | transform | `src/router/rule_based_router.cpp` | role-match (feature-based decision tree, logging, outcome::result return) |
+| `src/elm/CMakeLists.txt` | config | — | `src/specialists/CMakeLists.txt` | exact (STATIC library, PUBLIC include dirs, PUBLIC link libs) |
+| `src/common/types.hpp` (modify) | model | — | `src/common/types.hpp` (existing structs) | exact (same naming conventions, member layout, doxygen style) |
+| `src/router/prompt_analyzer.hpp` (modify) | service | transform | `src/router/prompt_analyzer.hpp` (existing methods) | exact (add to same class, same method signatures, same naming) |
+| `src/router/prompt_analyzer.cpp` (modify) | service | transform | `src/router/prompt_analyzer.cpp` (existing HasGrammarRequest/HasMathKeywords patterns) | exact (copy keyword-detection pattern for grounding/formatting) |
+| `src/api/api_server.hpp` (modify) | controller | request-response | `src/api/api_server.hpp:116-132` (existing member layout, private method signatures) | exact (same class, add RunELMChain + ELM registry members) |
+| `src/api/api_server.cpp` (modify) | controller | request-response | `src/api/api_server.cpp:280-337` (RunSpecialist pattern) | exact (same class, sequential steps, outcome::result chain, logging) |
+| `src/main.cpp` (modify) | config | file-I/O | `src/main.cpp:89-138` (LoadConfigFile JSON parsing pattern) | exact (nlohmann/json array iteration, args struct extension) |
+| `test/elm/test_elm.cpp` | test | — | `test/specialists/test_grammar_specialist.cpp` | exact (MockEngine class, GTest fixture, happy/unhappy path tests) |
+| `test/common/test_types.cpp` (modify) | test | — | `test/common/test_types.cpp` (existing enum/struct default-constructor tests) | exact (EXPECT_EQ on enum values, EXPECT_TRUE on defaults) |
+| `test/integration/test_pipeline.cpp` (modify) | test | — | `test/integration/test_pipeline.cpp:13-56` (PipelineTest fixture, stub-mode Process tests) | exact (same fixture, add chain-mode test cases) |
+| `test/CMakeLists.txt` (modify) | config | — | `test/CMakeLists.txt:42-53,69-70` (neoswarm_test macro, specialist test registration) | exact (copy macro invocation with neoswarm_elm library) |
+
+## Pattern Assignments
+
+---
+
+### 1. `src/elm/i_elm.hpp` (interface, request-response)
+
+**Analog:** `src/specialists/i_specialist.hpp` (lines 1-54)
+
+**Why:** Both are `I`-prefix abstract interfaces with `outcome::result` signatures and identical semantics. ISpecialist has 5 virtuals (GetName, IsLoaded, Load, Process, GetConfidence); IELM adds `GetRole()` and changes `Process(input)` → `Process(input, ELMContext)`.
+
+**Imports pattern** (lines 10-11):
+```cpp
+#include "common/error.hpp"
+#include <string>
+```
+
+**Include guard pattern** (lines 7-8):
+```cpp
+#ifndef NEOSWARM_SPECIALISTS_ISPECIALIST_HPP
+#define NEOSWARM_SPECIALISTS_ISPECIALIST_HPP
+```
+For IELM, use: `#ifndef NEOSWARM_ELM_IELM_HPP` / `#define NEOSWARM_ELM_IELM_HPP`
+
+**Namespace pattern** (lines 13-14):
+```cpp
+namespace sgns::neoswarm::specialists
+{
+```
+For IELM, use: `namespace sgns::neoswarm::elm`
+
+**Interface class pattern** (lines 20-50):
+```cpp
+class ISpecialist
+{
+    public:
+    virtual ~ISpecialist() = default;
+
+    /// @return Human-readable name of this specialist.
+    virtual std::string GetName() const = 0;
+
+    /// @return True if the specialist model has been loaded.
+    virtual bool IsLoaded() const = 0;
+
+    /**
+     * @brief Load the specialist model from disk.
+     * @param model_path  Path to the model file.
+     * @return            outcome::success or ModelLoadFailed.
+     */
+    virtual outcome::result<void> Load( const std::string& model_path ) = 0;
+
+    /**
+     * @brief Process input (typically Core LLM output) and return refined output.
+     * @param input  Text to process.
+     * @return       Refined text or InferenceFailed.
+     */
+    virtual outcome::result<std::string> Process( const std::string& input ) = 0;
+
+    /**
+     * @brief Confidence in the last Process() call.
+     * @return  Confidence score in [0, 1].
+     */
+    virtual float GetConfidence() const = 0;
+};
+```
+
+**Closing pattern** (lines 52-53):
+```cpp
+} // namespace sgns::neoswarm::specialists
+#endif // NEOSWARM_SPECIALISTS_ISPECIALIST_HPP
+```
+
+**IELM adaptation:** Copy this exact structure but:
+- Add `virtual ELMRole GetRole() const = 0;` between `GetName()` and `IsLoaded()`
+- Change `Process(const std::string& input)` to `Process(const std::string& input, const ELMContext& context)`
+- Forward-declare or include ELMRole and ELMContext from `common/types.hpp`
+
+---
+
+### 2. `src/elm/role_elm.hpp` (service, transform)
+
+**Analog:** `src/specialists/grammar_specialist.hpp` (lines 1-53)
+
+**Why:** RoleELM is a concrete IELM that holds a shared_ptr<InferenceEngine>, has m_loaded + last_confidence_ members, BuildPrompt private method, and a Configurable role template. Exactly the same structural pattern as GrammarSpecialist.
+
+**Imports pattern** (lines 10-12):
+```cpp
+#include "i_elm.hpp"
+#include "core/engine/inference_engine.hpp"
+#include <memory>
+```
+
+**Class declaration pattern** (lines 22-49):
+```cpp
+class GrammarSpecialist : public ISpecialist
+{
+    public:
+    explicit GrammarSpecialist( std::shared_ptr<core::InferenceEngine> engine = nullptr );
+
+    std::string GetName() const override { return "GrammarSpecialist"; }
+    bool IsLoaded() const override { return m_loaded; }
+
+    outcome::result<void> Load( const std::string& model_path ) override;
+    outcome::result<std::string> Process( const std::string& input ) override;
+    float GetConfidence() const override { return last_confidence_; }
+
+    private:
+    std::shared_ptr<core::InferenceEngine> m_engine;
+    bool m_loaded = false;
+    float last_confidence_ = 0.0f;
+
+    std::string BuildPrompt( const std::string& input ) const;
+};
+```
+
+**RoleELM adaptation:** 
+- Inherit from `IELM` not `ISpecialist`
+- Add `ELMRole m_role;` member
+- Add `std::string m_name;` member (constructed from role name)
+- Add constructor `RoleELM(ELMRole role, std::shared_ptr<core::InferenceEngine> engine = nullptr)`
+- `GetName()` returns `m_name`
+- `GetRole()` returns `m_role`
+- `Process()` signature: `outcome::result<std::string> Process( const std::string& input, const ELMContext& context ) override;`
+- `BuildPrompt(const std::string& input, const ELMContext& context) const` (takes context to inject prior outputs)
+
+---
+
+### 3. `src/elm/role_elm.cpp` (service, transform)
+
+**Analog:** `src/specialists/grammar_specialist.cpp` (lines 1-83)
+
+**Why:** The Process() method follows the exact pattern needed: check loaded/engine → BuildPrompt → create Task → Infer → compute confidence → return output or fail-close. Every RoleELM (Planner, PrimaryDraft, Verifier, Arbiter, Refiner) is just this with a different prompt template.
+
+**Logger pattern** (lines 14-19):
+```cpp
+namespace
+{
+    auto GrammarLogger()
+    {
+        return neoswarm::CreateLogger( "GrammarSpecialist" );
+    }
+} // namespace
+```
+For RoleELM: use `neoswarm::CreateLogger("RoleELM/" + roleName)` or similar tagged logger.
+
+**Constructor pattern** (lines 22-25):
+```cpp
+GrammarSpecialist::GrammarSpecialist( std::shared_ptr<core::InferenceEngine> engine )
+    : m_engine( std::move( engine ) )
+{
+}
+```
+
+**Load pattern** (lines 30-40):
+```cpp
+outcome::result<void> GrammarSpecialist::Load( const std::string& model_path )
+{
+    if ( !m_engine )
+    {
+        return outcome::failure( Error::ModelLoadFailed );
+    }
+    BOOST_OUTCOME_TRY( m_engine->LoadModel( model_path ) );
+    m_loaded = true;
+    GrammarLogger()->info( "GrammarSpecialist loaded: {}", model_path );
+    return outcome::success();
+}
+```
+
+**BuildPrompt pattern** (lines 45-51):
+```cpp
+std::string GrammarSpecialist::BuildPrompt( const std::string& input ) const
+{
+    return "[INST] Correct the grammar, spelling, and fluency of the following text. "
+           "Return only the corrected text without explanation.\n\n"
+           "Text: " + input + "\n\nCorrected: [/INST]";
+}
+```
+For RoleELM: Use `[INST] You are a {role_name}. {role instructions}... [/INST]` template format.
+
+**Process pattern** (lines 56-81) — **this is the core pattern to replicate**:
+```cpp
+outcome::result<std::string> GrammarSpecialist::Process( const std::string& input )
+{
+    if ( !m_loaded || !m_engine )
+    {
+        GrammarLogger()->warn( "GrammarSpecialist not loaded — returning input unchanged" );
+        last_confidence_ = 0.0f;
+        return outcome::success( input );
+    }
+
+    Task task;
+    task.m_id = "grammar-" + std::to_string( std::hash<std::string>{}( input ) );
+    task.m_prompt = BuildPrompt( input );
+    task.m_maxTokens = static_cast<uint32_t>( input.size() + 64 );
+    task.m_temperature = 0.1f;
+
+    auto res = m_engine->Infer( task );
+    if ( !res.has_value() )
+    {
+        GrammarLogger()->warn( "GrammarSpecialist inference failed — returning input unchanged" );
+        last_confidence_ = 0.0f;
+        return outcome::success( input );
+    }
+
+    last_confidence_ = 1.0f - std::min( res.value().m_perplexity / 10.0f, 1.0f );
+    return outcome::success( res.value().m_output );
+}
+```
+
+**RoleELM adaptation:**
+- Task ID prefix changes per role: `"planner-"`, `"verifier-"`, etc.
+- `BuildPrompt(input, context)` — uses `context.m_lastOutput` and `context.m_originalTask` in template
+- Same fail-close: return `input` unchanged on not-loaded or inference failure
+
+---
+
+### 4. `src/elm/domain_elm.hpp` + `src/elm/domain_elm.cpp` (service, transform)
+
+**Analog:** `src/specialists/math_specialist.hpp` (lines 1-56) + `math_specialist.cpp` (lines 1-118)
+
+**Why:** Domain ELMs may own a dedicated MNNInferenceEngine instance (separate `.mnn` file) instead of sharing the backbone. MathSpecialist has the same pattern of optional-engine + own model loading + BuildPrompt + Process flow.
+
+**Key structural difference from RoleELM:** DomainELM has TWO engine references:
+- `m_sharedEngine` (shared_ptr) — used when no dedicated model path
+- `m_ownEngine` (unique_ptr) — created when config provides a model path
+
+**Constructor pattern** (math_specialist.cpp:22-25):
+```cpp
+MathSpecialist::MathSpecialist( std::shared_ptr<core::InferenceEngine> engine )
+    : m_engine( std::move( engine ) )
+{
+}
+```
+
+**Load pattern for DomainELM** (Conceptual — extends grammar Load with own-engine creation):
+```cpp
+outcome::result<void> DomainELM::Load( const std::string& model_path )
+{
+    if ( !model_path.empty() )
+    {
+        // Create own engine (unique_ptr) for this domain
+        m_ownEngine = std::make_unique<core::MNNInferenceEngine>(...);
+        BOOST_OUTCOME_TRY( m_ownEngine->LoadModel( model_path ) );
+        m_loaded = true;
+        return outcome::success();
+    }
+    // Fall back to shared backbone
+    if ( !m_sharedEngine )
+    {
+        return outcome::failure( Error::ModelLoadFailed );
+    }
+    m_loaded = true; // Shared engine is already loaded by ApiServer
+    return outcome::success();
+}
+```
+
+**Process pattern for DomainELM** (same as role_elm but uses ownEngine if available):
+```cpp
+auto& engine = m_ownEngine ? m_ownEngine : m_sharedEngine;
+auto res = engine->Infer( task );
+```
+
+---
+
+### 5. `src/elm/grounding_elm.hpp` + `src/elm/grounding_elm.cpp` (service, pipeline-transform)
+
+**Analog:** `src/api/api_server.cpp:204-217` (AugmentPrompt) + `src/specialists/grammar_specialist.cpp:56-81` (Process flow)
+
+**Why:** GroundingELM wraps the existing 3-stage knowledge pipeline (Retrieve → Inject → Infer → Validate) behind the IELM interface. The AugmentPrompt method in ApiServer already does stages 1-2; GrammarSpecialist::Process covers stages 3-4 with confidence.
+
+**Pipeline composition pattern** (api_server.cpp:204-217):
+```cpp
+std::string ApiServer::AugmentPrompt( const std::string& prompt, std::vector<KnowledgeFact>& out_facts ) const
+{
+    if ( !m_knowledge || !m_knowledge->IsLoaded() || !m_contextInj )
+    {
+        return prompt;
+    }
+    auto facts_res = m_knowledge->Retrieve( prompt );
+    if ( !facts_res.has_value() || facts_res.value().empty() )
+    {
+        return prompt;
+    }
+    out_facts = facts_res.value();
+    return m_contextInj->Inject( prompt, out_facts );
+}
+```
+
+**GroundingELM::Process() flow** (replicates stages 1-4 in sequence):
+```
+1. m_knowledge->Retrieve(input) → facts
+2. m_contextInj->Inject(input, facts) → augmented prompt
+3. m_engine->Infer(augmentedPrompt) → output
+4. m_factVal->Validate(output, facts) → validation result
+5. If contradiction: log warning, set low confidence
+6. Return output + confidence
+```
+
+**Members needed:**
+```cpp
+std::shared_ptr<core::InferenceEngine> m_engine;
+std::shared_ptr<knowledge::KnowledgeRetrieval> m_knowledge;
+std::unique_ptr<knowledge::ContextInjection> m_contextInj;
+std::unique_ptr<knowledge::FactValidation> m_factVal;
+```
+
+**Confidence pattern** (grammar_specialist.cpp:79):
+```cpp
+last_confidence_ = 1.0f - std::min( res.value().m_perplexity / 10.0f, 1.0f );
+```
+For GroundingELM: If validation finds contradictions, multiply confidence by (1.0 - contradictionScore).
+
+---
+
+### 6. `src/elm/tool_support_elm.hpp` + `src/elm/tool_support_elm.cpp` (service, request-response stub)
+
+**Analog:** `src/specialists/grammar_specialist.cpp:56-63` (not-loaded fail-close path)
+
+**Why:** ToolSupportELM is a pure stub — every call returns the input unchanged with confidence=0 and logs "not implemented". This is exactly what GrammarSpecialist does when `!m_loaded || !m_engine`.
+
+**Fail-close pattern** (grammar_specialist.cpp:56-63):
+```cpp
+if ( !m_loaded || !m_engine )
+{
+    GrammarLogger()->warn( "GrammarSpecialist not loaded — returning input unchanged" );
+    last_confidence_ = 0.0f;
+    return outcome::success( input );
+}
+```
+
+**ToolSupportELM::Process()** — the entire implementation:
+```cpp
+outcome::result<std::string> ToolSupportELM::Process( const std::string& input, const ELMContext& /*ctx*/ )
+{
+    ToolLogger()->warn( "ToolSupportELM not implemented — returning input unchanged" );
+    m_lastConfidence = 0.0f;
+    return outcome::success( input );
+}
+```
+
+**IsLoaded()** returns `false` always. **Load()** returns `outcome::success()` (no-op).
+
+---
+
+### 7. `src/elm/specialist_adapter.hpp` + `src/elm/specialist_adapter.cpp` (adapter, request-response)
+
+**Analog:** `src/specialists/i_specialist.hpp` (target interface signatures, lines 38-43) + `src/api/api_server.hpp:116-117` (shared_ptr member composition pattern)
+
+**Why:** The adapter maps `IELM::Process(input, ELMContext)` → `ISpecialist::Process(input)`. It drops the ELMContext parameter and delegates directly. Composition via shared_ptr<ISpecialist> member.
+
+**ISpecialist::Process signature** (i_specialist.hpp:43):
+```cpp
+virtual outcome::result<std::string> Process( const std::string& input ) = 0;
+```
+
+**Adapter delegation** — the core mapping:
+```cpp
+outcome::result<std::string> SpecialistAdapter::Process( const std::string& input, const ELMContext& /*ctx*/ )
+{
+    return m_specialist->Process( input );
+}
+```
+
+**Construction with dependency injection** (copy grammar_specialist.cpp:22-25 DI pattern):
+```cpp
+SpecialistAdapter::SpecialistAdapter( std::shared_ptr<ISpecialist> specialist, ELMRole role, const std::string& name )
+    : m_specialist( std::move( specialist ) )
+    , m_role( role )
+    , m_name( name )
+{
+}
+```
+
+**Member layout** (copy api_server.hpp:116-117 shared_ptr member pattern):
+```cpp
+private:
+    std::shared_ptr<specialists::ISpecialist> m_specialist;
+    ELMRole m_role;
+    std::string m_name;
+    float m_lastConfidence = 0.0f;
+```
+
+**Delegated methods** (simply forward):
+```cpp
+std::string GetName() const override { return m_name; }
+ELMRole GetRole() const override { return m_role; }
+bool IsLoaded() const override { return m_specialist && m_specialist->IsLoaded(); }
+float GetConfidence() const override { return m_lastConfidence; }
+outcome::result<void> Load( const std::string& model_path ) override {
+    return m_specialist->Load( model_path );
+}
+```
+
+---
+
+### 8. `src/elm/elm_chain_builder.hpp` + `src/elm/elm_chain_builder.cpp` (service, transform)
+
+**Analog:** `src/router/rule_based_router.hpp` (lines 1-59) + `src/router/rule_based_router.cpp` (lines 1-102)
+
+**Why:** Both are stateless decision-tree classes that take input features and produce structured output. RuleBasedRouter has a Config struct, constructor overloads, a single public method, and private helper methods. ELMChainBuilder follows the exact same pattern, just mapping RouteDecision + PromptFeatures → ExecutionChain instead of Task → RouteDecision.
+
+**Header pattern** (rule_based_router.hpp:24-55):
+```cpp
+class RuleBasedRouter : public IRouter
+{
+    public:
+    struct Config
+    {
+        float numeric_density_threshold_ = 0.30f;
+        float complexity_swarm_threshold_ = 5.0f;
+        bool enable_swarm_m_mode = true;
+    };
+
+    RuleBasedRouter();
+    explicit RuleBasedRouter( Config cfg );
+
+    outcome::result<RouteDecision> Route( const Task& task ) override;
+
+    private:
+    Config m_cfg;
+    PromptAnalyzer m_analyzer;
+
+    ExecutionMode SelectMode( const PromptFeatures& features, ExecutionMode requested ) const;
+};
+```
+
+**ELMChainBuilder adaptation:**
+```cpp
+class ELMChainBuilder
+{
+    public:
+    struct Config
+    {
+        float numeric_density_threshold_ = 0.30f;
+        float complexity_high_threshold_ = 5.0f;
+        float complexity_low_threshold_ = 2.0f;
+        float confidence_threshold_ = 0.6f;
+    };
+
+    ELMChainBuilder();
+    explicit ELMChainBuilder( Config cfg );
+
+    outcome::result<ExecutionChain> Build( const RouteDecision& decision, const PromptFeatures& features );
+
+    private:
+    Config m_cfg;
+};
+```
+
+**Implementation pattern** (rule_based_router.cpp:1-102):
+- Anonymous namespace logger: `CreateLogger("ELMChainBuilder")`
+- Two constructors (default + Config)
+- `Route()` → `Build()` — decision-tree logic with if/else chains
+- Logging at end: `Logger()->debug(...)` with format args
+
+**Decision tree for Build()** (replicates rule_based_router.cpp:63-99 heuristic pattern):
+```cpp
+outcome::result<ExecutionChain> ELMChainBuilder::Build( const RouteDecision& decision, const PromptFeatures& features )
+{
+    ExecutionChain chain;
+
+    if ( features.numeric_density_ > m_cfg.numeric_density_threshold_ )
+    {
+        chain.m_steps.push_back( { ELMRole::Math, "math" } );
+        chain.m_steps.push_back( { ELMRole::Verifier } );
+        chain.m_reasoning = "High numeric density — routing to Math + Verifier";
+    }
+    else if ( features.has_code_syntax_ )
+    {
+        chain.m_steps.push_back( { ELMRole::Planner } );
+        chain.m_steps.push_back( { ELMRole::Code, "code" } );
+        chain.m_reasoning = "Code syntax detected — Planner → Code domain";
+    }
+    else if ( features.has_grounding_request_ )
+    {
+        chain.m_steps.push_back( { ELMRole::Grounding } );
+        chain.m_steps.push_back( { ELMRole::PrimaryDraft } );
+        chain.m_steps.push_back( { ELMRole::Verifier } );
+        chain.m_reasoning = "Grounding-sensitive — Grounding → Draft → Verify";
+    }
+    else if ( features.has_formatting_request_ )
+    {
+        chain.m_steps.push_back( { ELMRole::PrimaryDraft } );
+        chain.m_steps.push_back( { ELMRole::Refiner } );
+        chain.m_reasoning = "Formatting-sensitive — Draft → Refiner";
+    }
+    else if ( features.complexity_ < m_cfg.complexity_low_threshold_ )
+    {
+        chain.m_steps.push_back( { ELMRole::PrimaryDraft } );
+        chain.m_reasoning = "Low complexity — single-step draft";
+    }
+    else if ( features.complexity_ >= m_cfg.complexity_high_threshold_ )
+    {
+        chain.m_steps.push_back( { ELMRole::Planner } );
+        // domain determined from other features, default to PrimaryDraft for general
+        chain.m_steps.push_back( { ELMRole::PrimaryDraft } );
+        chain.m_steps.push_back( { ELMRole::Verifier } );
+        chain.m_steps.push_back( { ELMRole::Refiner } );
+        chain.m_reasoning = "High complexity — Planner → Draft → Verify → Refine";
+    }
+    else
+    {
+        chain.m_steps.push_back( { ELMRole::PrimaryDraft } );
+        chain.m_reasoning = "Default — single-step draft";
+    }
+
+    chain.m_chainConfidence = decision.confidence_;
+    BuilderLogger()->debug( "Chain: {} steps, reason='{}'", chain.m_steps.size(), chain.m_reasoning );
+    return outcome::success( std::move( chain ) );
+}
+```
+
+---
+
+### 9. `src/elm/CMakeLists.txt` (config)
+
+**Analog:** `src/specialists/CMakeLists.txt` (lines 1-12)
+
+**Why:** Exact same pattern — STATIC library, PUBLIC include dirs, PUBLIC link deps. ELM library depends on neoswarm_common, neoswarm_core, neoswarm_knowledge.
+
+**Template to copy:**
+```cmake
+add_library(neoswarm_elm STATIC
+    role_elm.cpp
+    domain_elm.cpp
+    grounding_elm.cpp
+    tool_support_elm.cpp
+    specialist_adapter.cpp
+    elm_chain_builder.cpp
+)
+
+target_include_directories(neoswarm_elm PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_ROOT}/src>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(neoswarm_elm PUBLIC neoswarm_common neoswarm_core neoswarm_knowledge neoswarm_specialists)
+```
+
+**src/CMakeLists.txt addition** (copy line 9 pattern):
+```cmake
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/elm ${CMAKE_CURRENT_BINARY_DIR}/elm)
+```
+
+---
+
+### 10. `src/common/types.hpp` (MODIFY — add ELMRole, ELMContext, ExecutionChain)
+
+**Analog:** `src/common/types.hpp` itself (lines 20-25 for enum, 41-49 for Task struct, 82-90 for PromptFeatures struct)
+
+**Why:** The file already contains Enums (ExecutionMode, RouteTarget) and structs (Task, InferenceResponse, RouteDecision, PromptFeatures) with the exact conventions to follow.
+
+**Enum pattern** (lines 20-25):
+```cpp
+enum class ExecutionMode : uint8_t
+{
+    SingleNode = 0, ///< Mode 1 — Core LLM only, fast
+    Specialist = 1, ///< Mode 2 — Core + Grammar/Math, sequential
+    Swarm = 2       ///< Mode 3 — Multiple nodes, weighted consensus
+};
+```
+
+**New ELMRole enum** (add after RouteTarget enum, before Task struct):
+```cpp
+// -----------------------------------------------------------------------
+// ELM roles (doc 03 §5.2.1)
+// -----------------------------------------------------------------------
+enum class ELMRole : uint8_t
+{
+    Planner = 0,      ///< Analyses task, determines execution plan
+    PrimaryDraft = 1, ///< Core draft generation (shared backbone)
+    Verifier = 2,     ///< Reviews outputs for correctness
+    Arbiter = 3,      ///< Resolves conflicts between outputs
+    Refiner = 4,      ///< Polishes formatting, style, grammar
+    Grounding = 5,    ///< Fact-checks against knowledge base
+    ToolSupport = 6,  ///< Tool-call formatting (stub in Phase 7)
+    Math = 7,         ///< Domain ELM — math
+    Code = 8,         ///< Domain ELM — code
+    Science = 9       ///< Domain ELM — science (shared-backbone only in Phase 7)
+};
+```
+
+**Add Chain to ExecutionMode** (line 23, after `Swarm = 2`):
+```cpp
+    Swarm = 2,  ///< Mode 3 — Multiple nodes, weighted consensus
+    Chain = 3   ///< Mode 4 — Multi-step ELM chain (Phase 7+)
+```
+
+**Struct pattern** (lines 41-49 for Task):
+```cpp
+struct Task
+{
+    std::string m_id;
+    std::string m_prompt;
+    ExecutionMode m_mode = ExecutionMode::SingleNode;
+    uint32_t m_maxTokens = 512;
+    float m_temperature = 0.7f;
+    std::string m_nodeId; ///< originating node
+};
+```
+
+**New ELMContext struct** (add after PromptFeatures struct):
+```cpp
+// -----------------------------------------------------------------------
+// ELM execution context (doc 03 §5.2.1)
+// -----------------------------------------------------------------------
+struct ELMContext
+{
+    std::string m_originalTask;                                   ///< the user's original prompt
+    std::string m_lastOutput;                                     ///< output of the immediately prior step
+    std::vector<std::pair<ELMRole, float>> m_stepConfidences;     ///< (role, confidence) per completed step
+    std::vector<KnowledgeFact> m_groundingFacts;                  ///< facts from GroundingELM, if any
+};
+```
+
+**New ChainStep + ExecutionChain structs** (add after ELMContext):
+```cpp
+// -----------------------------------------------------------------------
+// Chain step and execution chain (doc 03 §6.2)
+// -----------------------------------------------------------------------
+struct ChainStep
+{
+    ELMRole m_role = ELMRole::PrimaryDraft;
+    std::optional<std::string> m_domain; ///< e.g. "math", "code" — for domain ELMs
+};
+
+struct ExecutionChain
+{
+    std::vector<ChainStep> m_steps;
+    std::string m_reasoning;          ///< why this chain was chosen
+    float m_chainConfidence = 0.0f;   ///< builder's confidence in this chain
+};
+```
+
+**New features** (add to PromptFeatures struct, lines 89-90):
+```cpp
+    bool has_grounding_request_ = false;    ///< factual verification request detected
+    bool has_formatting_request_ = false;   ///< structure/style formatting request detected
+```
+
+**Include needed:** Add `#include <optional>` — already present at line 10.
+
+---
+
+### 11. `src/router/prompt_analyzer.hpp` + `prompt_analyzer.cpp` (MODIFY)
+
+**Analog:** `src/router/prompt_analyzer.hpp:57-62` (HasGrammarRequest private method) — copy this pattern for new detectors
+
+**Why:** Two new feature detectors needed (`HasGroundingRequest`, `HasFormattingRequest`). The existing `HasGrammarRequest` method (lines 57-62) shows the exact keyword-detection pattern.
+
+**Header additions** (copy HasGrammarRequest pattern at lines 57-62):
+```cpp
+/**
+ * @brief Check for grounding/factuality verification requests.
+ * @param prompt  Input string.
+ * @return        True if grounding keywords are present.
+ */
+bool HasGroundingRequest( const std::string& prompt ) const;
+
+/**
+ * @brief Check for formatting/structure/style requests.
+ * @param prompt  Input string.
+ * @return        True if formatting keywords are present.
+ */
+bool HasFormattingRequest( const std::string& prompt ) const;
+```
+
+**Implementation pattern** — replicate HasGrammarRequest keyword-detection logic from `prompt_analyzer.cpp`:
+
+For `HasGroundingRequest`: Look for keywords: "is it true", "verify", "according to", "fact check", "factual", "evidence", "source", "citation", "is this correct"
+
+For `HasFormattingRequest`: Look for keywords: "format as", "make this look", "structure this", "organize", "write as", "rewrite in", "convert to", "summarize", "bullet", "outline", "markdown", "json format"
+
+**Analyze() update** — add the two new feature extractions after existing features (lines in prompt_analyzer.cpp):
+```cpp
+features.has_grounding_request_ = HasGroundingRequest( prompt );
+features.has_formatting_request_ = HasFormattingRequest( prompt );
+```
+
+---
+
+### 12. `src/api/api_server.hpp` (MODIFY — add RunELMChain + ELM registry)
+
+**Analog:** `src/api/api_server.hpp:116-132` (existing member and method layout)
+
+**Why:** The ApiServer already has private methods RunSingleNode/RunSpecialist/RunSwarm (lines 130-132) and member variables for specialists (lines 116-117). Add RunELMChain alongside them, following the same conventions.
+
+**New members** — add after m_sgClient (line 128):
+```cpp
+// ELM registry (Phase 7+)
+std::unordered_map<ELMRole, std::shared_ptr<elm::IELM>> m_elmRegistry;
+std::unique_ptr<elm::ELMChainBuilder> m_chainBuilder;
+```
+
+**New private method** — add after RunSwarm (line 133):
+```cpp
+outcome::result<InferenceResponse> RunELMChain( const Task& task, const RouteDecision& route );
+```
+
+**New include** — add after router include (line 22):
+```cpp
+#include "elm/i_elm.hpp"
+#include "elm/elm_chain_builder.hpp"
+```
+
+**Config struct extension** (add to Config struct, lines 50-66):
+```cpp
+struct ElmEntry
+{
+    std::string role;     ///< e.g. "planner", "verifier", "math"
+    std::string model;    ///< optional dedicated model path
+    bool eager = false;   ///< load at Initialize() vs lazy
+};
+std::vector<ElmEntry> m_elmConfigs;
+```
+
+---
+
+### 13. `src/api/api_server.cpp` (MODIFY — RunELMChain, Initialize ELMs, Process switch)
+
+**Analog:** `src/api/api_server.cpp:280-337` (RunSpecialist pattern) — **the primary pattern to replicate**
+
+**Why:** RunELMChain is the sequential chain version of RunSpecialist. Same structure: timing, AugmentPrompt, step-by-step execution, error handling, fact validation, response construction.
+
+**RunELMChain pattern** (conceptual, based on RunSpecialist + sequential loop):
+```cpp
+outcome::result<InferenceResponse> ApiServer::RunELMChain( const Task& task, const RouteDecision& route )
+{
+    auto t0 = std::chrono::steady_clock::now();
+
+    std::vector<KnowledgeFact> facts;
+    Task aug_task = task;
+    aug_task.m_prompt = AugmentPrompt( task.m_prompt, facts );
+
+    ELMContext context;
+    context.m_originalTask = task.m_prompt;
+    context.m_stepConfidences.reserve( 8 );
+
+    std::string currentOutput = aug_task.m_prompt;
+    float aggregateConfidence = 1.0f;
+
+    auto chainResult = m_chainBuilder->Build( route, /* features */ );
+    if ( !chainResult.has_value() )
+    {
+        return outcome::failure( chainResult.error() );
+    }
+
+    for ( const auto& step : chainResult.value().m_steps )
+    {
+        context.m_lastOutput = currentOutput;
+        context.m_groundingFacts = facts;
+
+        auto it = m_elmRegistry.find( step.m_role );
+        if ( it == m_elmRegistry.end() || !it->second )
+        {
+            ServerLogger()->warn( "ELM not found for role {}", static_cast<int>( step.m_role ) );
+            continue;
+        }
+
+        auto elm = it->second;
+        if ( !elm->IsLoaded() )
+        {
+            ServerLogger()->warn( "ELM {} not loaded — skipping step", elm->GetName() );
+            continue;
+        }
+
+        auto stepRes = elm->Process( currentOutput, context );
+        if ( !stepRes.has_value() )
+        {
+            ServerLogger()->warn( "ELM {} failed — stopping chain", elm->GetName() );
+            break;
+        }
+
+        currentOutput = stepRes.value();
+        float stepConf = elm->GetConfidence();
+        context.m_stepConfidences.push_back( { step.m_role, stepConf } );
+        aggregateConfidence = std::min( aggregateConfidence, stepConf );
+
+        ServerLogger()->debug( "Chain step {} completed (confidence={:.2f})", elm->GetName(), stepConf );
+    }
+
+    auto t1 = std::chrono::steady_clock::now();
+    double total_ms = std::chrono::duration<double, std::milli>( t1 - t0 ).count();
+
+    // Fact validation (copy from RunSpecialist.cpp:314-325)
+    if ( m_factVal && m_factVal->IsAvailable() )
+    {
+        // ... same validation pattern as RunSpecialist
+    }
+
+    InferenceResponse resp;
+    resp.m_output = currentOutput;
+    resp.m_taskId = task.m_id;
+    resp.m_modeUsed = ExecutionMode::Chain;
+    resp.m_routeUsed = route.m_target;
+    resp.m_totalLatencyMs = total_ms;
+    resp.m_success = true;
+    resp.m_perplexity = 1.0f - aggregateConfidence; // invert: low conf = high perplexity
+
+    return outcome::success( std::move( resp ) );
+}
+```
+
+**Process() switch addition** (api_server.cpp:448-456, add case for Chain):
+```cpp
+    case ExecutionMode::Chain:
+        return RunELMChain( t, route );
+```
+
+**Initialize() ELM setup** (add after specialist init, around lines 80-95):
+```cpp
+// ELM registry (Phase 7+)
+m_chainBuilder = std::make_unique<elm::ELMChainBuilder>();
+
+// Register role ELMs with shared backbone
+m_elmRegistry[ELMRole::Planner] = std::make_shared<elm::RoleELM>( ELMRole::Planner, m_coreEngine );
+m_elmRegistry[ELMRole::PrimaryDraft] = std::make_shared<elm::RoleELM>( ELMRole::PrimaryDraft, m_coreEngine );
+m_elmRegistry[ELMRole::Verifier] = std::make_shared<elm::RoleELM>( ELMRole::Verifier, m_coreEngine );
+m_elmRegistry[ELMRole::Arbiter] = std::make_shared<elm::RoleELM>( ELMRole::Arbiter, m_coreEngine );
+m_elmRegistry[ELMRole::Refiner] = std::make_shared<elm::SpecialistAdapter>(
+    m_grammarSpec, ELMRole::Refiner, "Refiner/Formatter" );
+m_elmRegistry[ELMRole::Math] = std::make_shared<elm::SpecialistAdapter>(
+    m_mathSpec, ELMRole::Math, "Math" );
+
+// Domain ELMs
+m_elmRegistry[ELMRole::Code] = std::make_shared<elm::DomainELM>( ELMRole::Code, m_coreEngine );
+m_elmRegistry[ELMRole::Science] = std::make_shared<elm::RoleELM>( ELMRole::Science, m_coreEngine );
+
+// Grounding ELM
+if ( m_enableKnowledge )
+{
+    m_elmRegistry[ELMRole::Grounding] = std::make_shared<elm::GroundingELM>(
+        m_coreEngine, m_knowledge, std::make_unique<knowledge::ContextInjection>(),
+        std::make_unique<knowledge::FactValidation>( m_knowledge ) );
+}
+
+// Tool-Support stub
+m_elmRegistry[ELMRole::ToolSupport] = std::make_shared<elm::ToolSupportELM>();
+
+// Load eager ELMs from config
+for ( const auto& cfg : m_cfg.m_elmConfigs )
+{
+    if ( cfg.eager && !cfg.model.empty() )
+    {
+        auto role = ParseRole( cfg.role );
+        auto it = m_elmRegistry.find( role );
+        if ( it != m_elmRegistry.end() )
+        {
+            (void)it->second->Load( cfg.model );
+        }
+    }
+}
+```
+
+**new includes needed in api_server.cpp:**
+```cpp
+#include "elm/role_elm.hpp"
+#include "elm/domain_elm.hpp"
+#include "elm/grounding_elm.hpp"
+#include "elm/tool_support_elm.hpp"
+#include "elm/specialist_adapter.hpp"
+```
+
+---
+
+### 14. `src/main.cpp` (MODIFY — parse `elms` JSON config section)
+
+**Analog:** `src/main.cpp:89-138` (LoadConfigFile pattern — nlohmann/json key existence checks, args struct defaults)
+
+**Why:** Extend the existing `LoadConfigFile()` function to parse an `elms` JSON array. Uses the same `j.contains("key")` pattern, same `args.*` fallback pattern.
+
+**Config struct extension** (copy existing args member pattern from lines 41-60):
+Add to `Args` struct:
+```cpp
+struct ElmConfigEntry
+{
+    std::string role;
+    std::string model;
+    bool eager = false;
+};
+std::vector<ElmConfigEntry> m_elmConfigs;
+```
+
+**JSON parsing addition** (add after line 135, before the `std::cout << "Loaded config..."` line 137):
+```cpp
+// Parse ELM config section (Phase 7+)
+if ( j.contains( "elms" ) && j["elms"].is_array() )
+{
+    for ( const auto& e : j["elms"] )
+    {
+        ElmConfigEntry entry;
+        if ( e.contains( "role" ) )
+        {
+            entry.role = e["role"].get<std::string>();
+        }
+        if ( e.contains( "model" ) )
+        {
+            entry.model = e["model"].get<std::string>();
+        }
+        if ( e.contains( "eager" ) )
+        {
+            entry.eager = e["eager"].get<bool>();
+        }
+        if ( !entry.role.empty() )
+        {
+            args.m_elmConfigs.push_back( std::move( entry ) );
+        }
+    }
+}
+```
+
+**ApiServer::Config population** — map from Args → Config (in ApiServer construction, around line 260-290 of main.cpp):
+```cpp
+for ( const auto& entry : args.m_elmConfigs )
+{
+    api::ApiServer::ElmEntry cfgEntry;
+    cfgEntry.role = entry.role;
+    cfgEntry.model = entry.model;
+    cfgEntry.eager = entry.eager;
+    serverCfg.m_elmConfigs.push_back( std::move( cfgEntry ) );
+}
+```
+
+---
+
+### 15. `test/elm/test_elm.cpp` (NEW — ELM unit tests)
+
+**Analog:** `test/specialists/test_grammar_specialist.cpp` (lines 1-139)
+
+**Why:** Exact same test pattern — MockEngine for happy path, FailingMockEngine for unhappy path, GTest TEST macros, ASSERT_TRUE/EXPECT_EQ/EXPECT_FLOAT_EQ assertions.
+
+**MockEngine pattern** (lines 17-46) — **reuse verbatim in test_elm.cpp**:
+```cpp
+class MockEngine : public core::InferenceEngine
+{
+public:
+    outcome::result<InferenceResponse> Infer( const Task& task ) override
+    {
+        InferenceResponse resp;
+        resp.m_output = task.m_prompt + " [response]";
+        resp.m_perplexity = 1.0f;
+        resp.m_success = true;
+        resp.m_taskId = task.m_id;
+        return outcome::success( resp );
+    }
+    outcome::result<void> StreamInfer( const Task&,
+                                        std::function<void( const std::string& )> ) override
+    {
+        return outcome::success();
+    }
+    outcome::result<void> LoadModel( const std::string& ) override
+    {
+        return outcome::success();
+    }
+    bool IsLoaded() const override { return true; }
+    std::string BackendName() const override { return "mock"; }
+};
+```
+
+**FailingMockEngine pattern** (lines 48-72 in test_grammar_specialist.cpp) — reuse verbatim.
+
+**Test case patterns** (copy structure from lines 78-139):
+
+Happy path test (lines 79-90):
+```cpp
+TEST( RoleELM, Process_LoadedEngine_ReturnsResponse )
+{
+    auto engine = std::make_shared<MockEngine>();
+    elm::RoleELM elm( ELMRole::Verifier, engine );
+    ASSERT_TRUE( elm.Load( "dummy" ).has_value() );
+    ASSERT_TRUE( elm.IsLoaded() );
+
+    ELMContext ctx;
+    ctx.m_originalTask = "test task";
+    auto result = elm.Process( "input text", ctx );
+    ASSERT_TRUE( result.has_value() );
+    EXPECT_NE( result.value().find( "input" ), std::string::npos );
+    EXPECT_GT( elm.GetConfidence(), 0.0f );
+}
+```
+
+Unhappy path — fail-close (lines 114-123):
+```cpp
+TEST( RoleELM, Process_NotLoaded_ReturnsInputUnchanged )
+{
+    auto engine = std::make_shared<MockEngine>();
+    elm::RoleELM elm( ELMRole::Verifier, engine );
+
+    ELMContext ctx;
+    auto result = elm.Process( "hello world", ctx );
+    ASSERT_TRUE( result.has_value() );
+    EXPECT_EQ( result.value(), "hello world" );
+    EXPECT_FLOAT_EQ( elm.GetConfidence(), 0.0f );
+}
+```
+
+**Test targets to create in test_elm.cpp:**
+1. `RoleELM_Process_LoadedEngine_ReturnsResponse` (happy)
+2. `RoleELM_Process_NotLoaded_ReturnsInputUnchanged` (fail-close)
+3. `RoleELM_GetName_ReturnsCorrectName`
+4. `RoleELM_GetRole_ReturnsConfiguredRole`
+5. `RoleELM_IsLoaded_InitiallyFalse`
+6. `DomainELM_Process_SharedBackbone_ReturnsResponse` (happy)
+7. `DomainELM_Process_NoEngine_ReturnsInputUnchanged` (fail-close)
+8. `SpecialistAdapter_Process_DelegatesToSpecialist` (happy)
+9. `SpecialistAdapter_GetConfidence_ReflectsSpecialist`
+10. `ELMChainBuilder_Build_HighNumericDensity_ReturnsMathChain`
+11. `ELMChainBuilder_Build_CodeSyntax_ReturnsPlannerCodeChain`
+12. `ELMChainBuilder_Build_LowComplexity_ReturnsSingleStep`
+13. `ELMChainBuilder_Build_HighComplexity_ReturnsFullChain`
+14. `GroundingELM_Process_KnowledgeLoaded_ReturnsAugmentedOutput`
+15. `GroundingELM_Process_NoKnowledge_ReturnsInputUnchanged`
+16. `ToolSupportELM_Process_ReturnsInputUnchanged_ConfidenceZero`
+17. `ToolSupportELM_IsLoaded_AlwaysFalse`
+
+---
+
+### 16. `test/common/test_types.cpp` (MODIFY — extend with ELMRole/ELMContext)
+
+**Analog:** `test/common/test_types.cpp:6-11` (ExecutionMode enum test pattern) + lines 76-85 (PromptFeatures default test pattern)
+
+**Why:** Add tests for new ELMRole enum values and ELMContext/ExecutionChain default initialization. Follows the exact same test structures.
+
+**ELMRole enum test** (copy ExecutionMode pattern, lines 6-11):
+```cpp
+TEST(ELMRole, EnumValues_AreDistinct)
+{
+    EXPECT_NE( static_cast<int>( ELMRole::Planner ), static_cast<int>( ELMRole::PrimaryDraft ) );
+    EXPECT_NE( static_cast<int>( ELMRole::Verifier ), static_cast<int>( ELMRole::Arbiter ) );
+    EXPECT_NE( static_cast<int>( ELMRole::Refiner ), static_cast<int>( ELMRole::Grounding ) );
+    EXPECT_NE( static_cast<int>( ELMRole::Math ), static_cast<int>( ELMRole::Code ) );
+    EXPECT_NE( static_cast<int>( ELMRole::Science ), static_cast<int>( ELMRole::ToolSupport ) );
+}
+```
+
+**ELMContext default test** (copy PromptFeatures pattern, lines 76-85):
+```cpp
+TEST(ELMContext, DefaultConstructor_HasReasonableDefaults)
+{
+    ELMContext ctx;
+    EXPECT_TRUE( ctx.m_originalTask.empty() );
+    EXPECT_TRUE( ctx.m_lastOutput.empty() );
+    EXPECT_TRUE( ctx.m_stepConfidences.empty() );
+    EXPECT_TRUE( ctx.m_groundingFacts.empty() );
+}
+```
+
+**ExecutionChain default test:**
+```cpp
+TEST(ExecutionChain, DefaultConstructor_HasReasonableDefaults)
+{
+    ExecutionChain chain;
+    EXPECT_TRUE( chain.m_steps.empty() );
+    EXPECT_TRUE( chain.m_reasoning.empty() );
+    EXPECT_FLOAT_EQ( chain.m_chainConfidence, 0.0f );
+}
+```
+
+**ChainStep default test:**
+```cpp
+TEST(ChainStep, DefaultConstructor_HasReasonableDefaults)
+{
+    ChainStep step;
+    EXPECT_EQ( step.m_role, ELMRole::PrimaryDraft );
+    EXPECT_FALSE( step.m_domain.has_value() );
+}
+```
+
+**ExecutionMode Chain value test** — extend existing test (lines 6-11):
+```cpp
+TEST(ExecutionMode, ChainValue_IsDistinct)
+{
+    EXPECT_NE( static_cast<int>( ExecutionMode::Chain ), static_cast<int>( ExecutionMode::SingleNode ) );
+    EXPECT_NE( static_cast<int>( ExecutionMode::Chain ), static_cast<int>( ExecutionMode::Specialist ) );
+    EXPECT_NE( static_cast<int>( ExecutionMode::Chain ), static_cast<int>( ExecutionMode::Swarm ) );
+}
+```
+
+---
+
+### 17. `test/integration/test_pipeline.cpp` (MODIFY — chain execution integration tests)
+
+**Analog:** `test/integration/test_pipeline.cpp:13-56` (PipelineTest fixture + SingleNode/Math/Grammar tests)
+
+**Why:** Add chain-mode integration tests using the same PipelineTest fixture, same stub-mode config, same Process() call pattern.
+
+**New test cases** (copy PipelineTest fixture from lines 13-30, reuse):
+```cpp
+TEST_F( PipelineTest, ChainMode_BasicExecution )
+{
+    Task task;
+    task.m_prompt = "Solve this complex problem: what is 847 * 963 + 42?";
+    task.m_mode = ExecutionMode::Chain;
+    task.m_maxTokens = 64;
+
+    auto res = server_->Process( task );
+    ASSERT_TRUE( res.has_value() );
+    EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::Chain );
+    EXPECT_FALSE( res.value().m_taskId.empty() );
+}
+
+TEST_F( PipelineTest, ChainMode_GeneralPrompt_SingleStep )
+{
+    Task task;
+    task.m_prompt = "Tell me a short story.";
+    task.m_mode = ExecutionMode::Chain;
+    task.m_maxTokens = 32;
+
+    auto res = server_->Process( task );
+    ASSERT_TRUE( res.has_value() );
+    EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::Chain );
+}
+```
+
+---
+
+### 18. `test/CMakeLists.txt` (MODIFY — add ELM test targets)
+
+**Analog:** `test/CMakeLists.txt:69-70` (specialist test registration pattern)
+
+**Why:** Copy the exact `neoswarm_test` macro invocation, linking against `neoswarm_elm`.
+
+**New test registrations:**
+```cmake
+# Phase 7 — ELM tests
+neoswarm_test(test_elm             elm/test_elm.cpp              "neoswarm_elm;neoswarm_core;neoswarm_common")
+```
+
+**Add `test/elm/` directory** — test_elm.cpp lives there.
+
+---
+
+## Shared Patterns
+
+### Authentication
+**Source:** N/A — not applicable for Phase 7 (local-only, no auth gating on ELM calls)
+
+### Error Handling (used by ALL new files)
+**Source:** `src/common/error.hpp` (lines 1-51)
+
+**Error propagation:**
+```cpp
+namespace sgns::neoswarm
+{
+    namespace outcome = libp2p::outcome;
+}
+```
+
+**All ELM interfaces use:**
+```cpp
+outcome::result<T>     // return type (T = void for Load, string for Process)
+outcome::success(val)  // return success with value
+outcome::failure(Error::SomeError) // return failure with error code
+BOOST_OUTCOME_TRY(var) // propagate error from called function
+```
+
+**Fail-close pattern** — all ELM Process() methods MUST return input unchanged on failure:
+```cpp
+if ( !m_loaded || !m_engine )
+{
+    Logger()->warn( "Not loaded — returning input unchanged" );
+    m_lastConfidence = 0.0f;
+    return outcome::success( input );
+}
+```
+
+**No exceptions** — the codebase uses `outcome::result` exclusively. No `try/catch` in hot paths. Only `try/catch` for JSON parsing in main.cpp (nlohmann/json throws on bad input).
+
+### Logging (used by ALL new .cpp files)
+**Source:** `src/common/logging.hpp` (lines 1-40) + grammar_specialist.cpp:14-19 (logger creation pattern)
+
+**Logger creation pattern:**
+```cpp
+namespace
+{
+    auto ElmLogger()
+    {
+        return neoswarm::CreateLogger( "ELM/TagName" );
+    }
+} // namespace
+```
+
+**Logging calls:**
+```cpp
+ElmLogger()->info( "Loaded: {}", model_path );
+ElmLogger()->warn( "Inference failed" );
+ElmLogger()->debug( "Confidence: {:.2f}", confidence );
+```
+
+### Validation (used by GroundingELM, Chain execution)
+**Source:** `src/knowledge/fact_validation.hpp:27-33` (ValidationResult struct) + api_server.cpp:314-325 (validation pattern)
+
+**Validation pattern:**
+```cpp
+if ( m_factVal && m_factVal->IsAvailable() )
+{
+    auto val_result = m_factVal->Validate( output, facts );
+    if ( !val_result.passed_ )
+    {
+        Logger()->warn( "Fact validation failed: {}", val_result.suggestion_ );
+        // Adjust confidence/perplexity based on contradiction score
+    }
+}
+```
+
+### CMake Registration (used by src/elm/CMakeLists.txt, test/CMakeLists.txt, src/CMakeLists.txt)
+**Source:** `src/specialists/CMakeLists.txt` (lines 1-12) + `test/CMakeLists.txt:42-53,69-70`
+
+**Library pattern:**
+```cmake
+add_library(neoswarm_<module> STATIC
+    file1.cpp
+    file2.cpp
+)
+target_include_directories(neoswarm_<module> PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_ROOT}/src>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(neoswarm_<module> PUBLIC neoswarm_common neoswarm_core ...)
+```
+
+**Test target pattern:**
+```cmake
+neoswarm_test(test_<name> <dir>/test_<name>.cpp "<libs>")
+```
+
+**Subdirectory pattern:**
+```cmake
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/<module> ${CMAKE_CURRENT_BINARY_DIR}/<module>)
+```
+
+### Doxygen Headers (used by ALL new .hpp files)
+**Source:** `src/specialists/i_specialist.hpp:1-5`
+
+**File header pattern:**
+```cpp
+/**
+ * @file       i_elm.hpp
+ * @brief      Abstract interface for Expert Language Models (doc 03 §5.2)
+ * @date       2026-07-16
+ */
+```
+
+**Method documentation pattern:**
+```cpp
+/**
+ * @brief Process input through this ELM and return refined output.
+ * @param input    Text to process (typically output of previous chain step).
+ * @param context  ELM execution context (original task, prior outputs, confidences).
+ * @return         Refined text or InferenceFailed.
+ */
+virtual outcome::result<std::string> Process( const std::string& input, const ELMContext& context ) = 0;
+```
+
+### Naming Conventions (ALL files)
+**Source:** CLAUDE.md SuperGenius Naming Convention Overrides section
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Member variables | `m_` prefix + camelCase | `m_engine`, `m_loaded`, `m_lastConfidence` |
+| Function arguments | camelCase (no prefix) | `model_path`, `input`, `context` |
+| File names | snake_case | `role_elm.cpp`, `i_elm.hpp` |
+| Directory names | snake_case lowercase | `src/elm/`, `test/elm/` |
+| Accessors | `Get` prefix, `Set` prefix, `Is` for bool | `GetName()`, `IsLoaded()`, `GetRole()` |
+| Constants (compile-time) | `k` prefix + PascalCase | `kConfidenceThreshold` |
+| Library names (CMake) | `neoswarm_` prefix + snake_case | `neoswarm_elm` |
+| Interfaces | `I` prefix + PascalCase | `IELM` |
+
+### Namespace Convention (ALL files)
+**Source:** `src/specialists/i_specialist.hpp:13,52`
+
+**New ELM namespace:**
+```cpp
+namespace sgns::neoswarm::elm
+{
+    // class declarations
+} // namespace sgns::neoswarm::elm
+```
+
+---
+
+## No Analog Found
+
+| File | Role | Data Flow | Reason |
+|------|------|-----------|--------|
+| *(none)* | — | — | All 18 files have close analogs in the existing codebase |
+
+---
+
+## Metadata
+
+**Analog search scope:** `src/specialists/`, `src/router/`, `src/api/`, `src/common/`, `src/knowledge/`, `src/core/engine/`, `test/`, `src/main.cpp`
+**Files scanned:** 22 (source files + test files + CMake files)
+**Pattern extraction date:** 2026-07-16
+**Research reference:** `.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md`

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-PATTERNS.md
@@ -617,7 +617,7 @@ enum class ELMRole : uint8_t
 **Add Chain to ExecutionMode** (line 23, after `Swarm = 2`):
 ```cpp
     Swarm = 2,  ///< Mode 3 — Multiple nodes, weighted consensus
-    Chain = 3   ///< Mode 4 — Multi-step ELM chain (Phase 7+)
+    ElmAssisted = 3   ///< Mode 2 (doc 07 §9.2) — ELM-assisted sequential chain (Phase 7+)
 ```
 
 **Struct pattern** (lines 41-49 for Task):
@@ -825,7 +825,7 @@ outcome::result<InferenceResponse> ApiServer::RunELMChain( const Task& task, con
     InferenceResponse resp;
     resp.m_output = currentOutput;
     resp.m_taskId = task.m_id;
-    resp.m_modeUsed = ExecutionMode::Chain;
+    resp.m_modeUsed = ExecutionMode::ElmAssisted;
     resp.m_routeUsed = route.m_target;
     resp.m_totalLatencyMs = total_ms;
     resp.m_success = true;
@@ -837,7 +837,7 @@ outcome::result<InferenceResponse> ApiServer::RunELMChain( const Task& task, con
 
 **Process() switch addition** (api_server.cpp:448-456, add case for Chain):
 ```cpp
-    case ExecutionMode::Chain:
+    case ExecutionMode::ElmAssisted:
         return RunELMChain( t, route );
 ```
 
@@ -1104,9 +1104,9 @@ TEST(ChainStep, DefaultConstructor_HasReasonableDefaults)
 ```cpp
 TEST(ExecutionMode, ChainValue_IsDistinct)
 {
-    EXPECT_NE( static_cast<int>( ExecutionMode::Chain ), static_cast<int>( ExecutionMode::SingleNode ) );
-    EXPECT_NE( static_cast<int>( ExecutionMode::Chain ), static_cast<int>( ExecutionMode::Specialist ) );
-    EXPECT_NE( static_cast<int>( ExecutionMode::Chain ), static_cast<int>( ExecutionMode::Swarm ) );
+    EXPECT_NE( static_cast<int>( ExecutionMode::ElmAssisted ), static_cast<int>( ExecutionMode::SingleNode ) );
+    EXPECT_NE( static_cast<int>( ExecutionMode::ElmAssisted ), static_cast<int>( ExecutionMode::Specialist ) );
+    EXPECT_NE( static_cast<int>( ExecutionMode::ElmAssisted ), static_cast<int>( ExecutionMode::Swarm ) );
 }
 ```
 
@@ -1124,12 +1124,12 @@ TEST_F( PipelineTest, ChainMode_BasicExecution )
 {
     Task task;
     task.m_prompt = "Solve this complex problem: what is 847 * 963 + 42?";
-    task.m_mode = ExecutionMode::Chain;
+    task.m_mode = ExecutionMode::ElmAssisted;
     task.m_maxTokens = 64;
 
     auto res = server_->Process( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::Chain );
+    EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::ElmAssisted );
     EXPECT_FALSE( res.value().m_taskId.empty() );
 }
 
@@ -1137,12 +1137,12 @@ TEST_F( PipelineTest, ChainMode_GeneralPrompt_SingleStep )
 {
     Task task;
     task.m_prompt = "Tell me a short story.";
-    task.m_mode = ExecutionMode::Chain;
+    task.m_mode = ExecutionMode::ElmAssisted;
     task.m_maxTokens = 32;
 
     auto res = server_->Process( task );
     ASSERT_TRUE( res.has_value() );
-    EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::Chain );
+    EXPECT_EQ( res.value().m_modeUsed, ExecutionMode::ElmAssisted );
 }
 ```
 

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md
@@ -1,0 +1,726 @@
+# Phase 07: Expert Language Models + Router — Research
+
+**Researched:** 2026-07-16
+**Domain:** ELM orchestration, rule-based router extension, sequential execution chains
+**Confidence:** HIGH — all key findings verified against the existing codebase
+
+## Summary
+
+This phase deploys 10 ELMs (7 role-based, 3 domain) behind a new `IELM` interface, extends the rule-based router with six heuristic chain-building triggers, and integrates sequential `ExecutionChain` execution into `ApiServer`. The existing codebase already contains all the primitives: `InferenceEngine::Infer()` for shared-backbone prompt-in/text-out, `ISpecialist` with a near-identical interface to `IELM`, `RuleBasedRouter` + `PromptAnalyzer` covering 4 of 6 triggers, the full knowledge pipeline for `GroundingELM`, and a `MockEngine` test pattern.
+
+**Primary recommendation:** Extend what exists, do not rebuild. `GrammarSpecialist`/`MathSpecialist` are already proto-ELMs — wrap them with adapter classes. `PromptAnalyzer` needs 2 new feature detectors, not a rewrite. `RuleBasedRouter` keeps its current responsibilities; a new `ELMChainBuilder` translates route decisions into chains. The threading risk is low (ApiServer is synchronous, sequential chain execution is trivially safe at the MNN engine level).
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|-------------|----------------|-----------|
+| Prompt classification & feature extraction | API / Backend | — | `PromptAnalyzer` runs in-process before any model invocation |
+| Route decision (SingleNode / Specialist / Chain) | API / Backend | — | `RuleBasedRouter` owns mode selection and target specialist |
+| Chain construction (decision → ordered steps) | API / Backend | — | New `ELMChainBuilder` converts route + features to `ExecutionChain` |
+| Shared-backbone inference (role ELMs) | API / Backend | — | All role ELMs call the same `InferenceEngine::Infer()` with role-specific prompt templates |
+| Per-ELM model inference (domain ELMs) | API / Backend | — | Domain ELMs may own a dedicated `MNNInferenceEngine` instance with own `.mnn` file |
+| Legacy specialist execution (Grammar/Math) | API / Backend | — | Adapters delegate to existing `ISpecialist` instances via composition |
+| Knowledge retrieval & fact validation | API / Backend | — | `GroundingELM` wraps the existing `knowledge/` pipeline (no new dependencies) |
+| JSON config loading (`elms` section) | API / Backend | — | `main.cpp` `LoadConfigFile()` — same nlohmann/json pattern as existing keys |
+
+## Standard Stack
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| `outcome::result<T>` | libp2p outcome | Error propagation for all ELM interfaces | Project-wide standard; `BOOST_OUTCOME_TRY` macro in all existing code [VERIFIED: src/common/error.hpp] |
+| Google Test | (thirdparty) | Unit/integration tests | Existing 15 test files all use GTest [VERIFIED: test/CMakeLists.txt] |
+| `nlohmann/json` | (thirdparty) | JSON config parsing for `elms` section | Already used in `main.cpp` for config file parsing [VERIFIED: src/main.cpp:98-137] |
+| spdlog | (header-only) | Component logging | `CreateLogger("tag")` pattern in all modules [VERIFIED: src/common/logging.hpp] |
+| MNN (inference) | (thirdparty) | Core model execution | `MNNInferenceEngine` is the only InferenceEngine implementation [VERIFIED: src/core/engine/] |
+
+### Supporting
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| `<boost/asio/io_context.hpp>` | Boost.Asio | Async I/O for SGProcessing path | Already linked; ELMs don't need it (sequential, synchronous) |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| New `IELM` interface from scratch | Extending `ISpecialist` with role/context params | Decision D-05 locks `IELM` as new interface — `ISpecialist` stays untouched for backward compatibility |
+
+**Installation:**
+```bash
+# No new third-party dependencies. Phase 7 uses only already-linked libraries.
+```
+
+## Architecture Patterns
+
+### System Architecture Diagram
+
+```
+User Task
+    │
+    ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  ApiServer::Process()                                            │
+│                                                                   │
+│  1. m_router->Route(task) ──► RouteDecision                       │
+│       │                                                           │
+│       ▼                                                           │
+│  2. (new) m_chainBuilder->Build(decision, features) ──► ExecutionChain
+│       │                                                           │
+│       ▼                                                           │
+│  3. (new) RunELMChain(chain, task)                                │
+│       │                                                           │
+│       │  ExecutionChain steps:                                     │
+│       │  [Planner] → [Domain ELM] → [Verifier] → [Refiner]        │
+│       │      │            │              │             │           │
+│       │      ▼            ▼              ▼             ▼           │
+│       │  ┌────────┐  ┌────────┐    ┌────────┐   ┌────────┐       │
+│       │  │IELM    │  │IELM    │    │IELM    │   │IELM    │       │
+│       │  │(shared │  │(own    │    │(shared │   │(adapter│       │
+│       │  │backbone│  │engine) │    │backbone│   │wraps   │       │
+│       │  │+prompt │  │        │    │+prompt │   │Grammar │       │
+│       │  │template│  │        │    │template│   │Spec)   │       │
+│       │  └────────┘  └────────┘    └────────┘   └────────┘       │
+│       │       │            │              │             │          │
+│       │       ▼            ▼              ▼             ▼          │
+│       │  output₁ ───► output₂ ──────► output₃ ───► final_output   │
+│       │  (via ELMContext accumulated state)                        │
+└─────────────────────────────────────────────────────────────────┘
+    │
+    ▼
+InferenceResponse
+```
+
+### Recommended Project Structure
+```
+src/
+├── api/
+│   └── api_server.{hpp,cpp}        # Gain: RunELMChain(), ELM registry
+├── common/
+│   └── types.hpp                   # Gain: ELMRole enum, ELMContext struct, ExecutionChain
+├── elm/                            # NEW directory
+│   ├── i_elm.hpp                   # IELM interface
+│   ├── role_elm.hpp                # Shared-backbone role ELM (Planner, Verifier, etc.)
+│   ├── role_elm.cpp
+│   ├── domain_elm.hpp              # Domain ELM with optional own model
+│   ├── domain_elm.cpp
+│   ├── grounding_elm.hpp           # Wraps knowledge/ pipeline
+│   ├── grounding_elm.cpp
+│   ├── tool_support_elm.hpp        # Stub (pass-through)
+│   ├── tool_support_elm.cpp
+│   ├── specialist_adapter.hpp      # Wraps ISpecialist as IELM
+│   ├── specialist_adapter.cpp
+│   ├── elm_chain_builder.hpp       # RuleDecision + Features → ExecutionChain
+│   ├── elm_chain_builder.cpp
+│   └── CMakeLists.txt              # neoswarm_elm library target
+├── router/
+│   ├── prompt_analyzer.{hpp,cpp}   # Gain: has_grounding_request, has_formatting_request
+│   └── rule_based_router.{hpp,cpp} # Unchanged (Route remains same)
+└── main.cpp                        # Gain: "elms" JSON config section parsing
+```
+
+### Pattern 1: Shared-Backbone Role ELM
+**What:** A concrete `IELM` that constructs a role-specific prompt template (e.g., `"[INST] You are a Verifier. Check the following..."`) and calls `m_engine->Infer()` on the shared `InferenceEngine`. Identical pattern to how `GrammarSpecialist::BuildPrompt()` + `m_engine->Infer()` works today [VERIFIED: src/specialists/grammar_specialist.cpp:45-80].
+
+**When to use:** Every role ELM (Planner, PrimaryDraft, Verifier, Arbiter, Refiner) when no dedicated model path is configured.
+
+**Example (conceptual, based on existing GrammarSpecialist pattern):**
+```cpp
+// Source pattern: src/specialists/grammar_specialist.cpp:56-81
+outcome::result<std::string> RoleELM::Process(const std::string& input, const ELMContext& ctx)
+{
+    if (!m_loaded || !m_engine)
+    {
+        m_lastConfidence = 0.0f;
+        return outcome::success(input);  // graceful degradation
+    }
+
+    Task task;
+    task.m_id = /* role-specific ID */;
+    task.m_prompt = BuildPrompt(input, ctx);  // role template
+    task.m_maxTokens = 512;
+    task.m_temperature = 0.1f;  // low temp for deterministic roles
+
+    auto res = m_engine->Infer(task);
+    if (!res.has_value())
+    {
+        m_lastConfidence = 0.0f;
+        return outcome::success(input);  // fail-close: return input unchanged
+    }
+
+    m_lastConfidence = 1.0f - std::min(res.value().m_perplexity / 10.0f, 1.0f);
+    return outcome::success(res.value().m_output);
+}
+```
+
+### Pattern 2: Adapter (ISpecialist → IELM)
+**What:** Composition-based wrapper. Holds `std::shared_ptr<ISpecialist>` (or `std::unique_ptr`), maps `IELM::Process(input, ELMContext)` → `ISpecialist::Process(input)`. The `ELMContext` is logged but not passed through (ISpecialist doesn't accept it). Decision D-06/D-07 lock this pattern.
+
+**When to use:** Refiner/Formatter wrapping GrammarSpecialist; Math domain wrapping MathSpecialist.
+
+```cpp
+// Conceptual — maps to ISpecialist::Process(std::string) signature
+// Source: src/specialists/i_specialist.hpp:38-43
+outcome::result<std::string> SpecialistAdapter::Process(const std::string& input, const ELMContext& /*ctx*/)
+{
+    return m_specialist->Process(input);  // ISpecialist only takes string
+}
+```
+
+### Pattern 3: ELMChainBuilder (RouteDecision → ExecutionChain)
+**What:** Stateless function/class that takes `RouteDecision` + `PromptFeatures` and produces an `ExecutionChain` — a flat `vector<ChainStep>` where each step is `{ELMRole, optional domain}`. Implements the six heuristic triggers from doc 03 §6.2.
+
+**When to use:** Called by `ApiServer::Process()` after routing, before execution.
+
+**Trigger mapping:**
+| Trigger | Condition | Chain |
+|---------|-----------|-------|
+| Numeric density | `numeric_density_ > threshold` | Math → Verifier |
+| Code syntax | `has_code_syntax_ == true` | Planner → Code |
+| Grounding-sensitive | `has_grounding_request_` (NEW) | Grounding → PrimaryDraft → Verifier |
+| Formatting-sensitive | `has_formatting_request_` (NEW) | PrimaryDraft → Refiner |
+| Low complexity | `complexity_ < lowThreshold` | PrimaryDraft only |
+| High complexity | `complexity_ > highThreshold` | Planner → Domain → Verifier → Refiner |
+
+### Pattern 4: Sequential Chain Execution
+**What:** `ApiServer::RunELMChain()` iterates through `ExecutionChain` steps. For each step: looks up the ELM by role/domain from the ELM registry, calls `elm->Process(accumulatedText, context)`, feeds output into the next step via `ELMContext`.
+
+**When to use:** The new fourth execution path in `ApiServer::Process()`.
+
+### Anti-Patterns to Avoid
+- **Multiple MNNInferenceEngine instances sharing the same model file:** Each engine loads independently. For shared-backbone ELMs, all must share a single engine. Create per-ELM engines only when `model_path` is explicitly set.
+- **Parallel ELM execution in Phase 7:** Deferred to Phase 9. ExecutionChain is flat and sequential.
+- **Modifying ISpecialist interface:** D-05 explicitly keeps ISpecialist untouched. Adapt via composition.
+- **Using `std::this_thread::sleep_for` in tests:** Project standard forbids this. But ELM chain execution is synchronous; no wait conditions needed.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Prompt template construction | Custom formatting library | `std::string` concatenation / `fmt::format` | Existing specialists already do this; keep it simple [VERIFIED: grammar_specialist.cpp:45-51] |
+| JSON config parsing | Hand-written parser | `nlohmann/json` (already linked) | `LoadConfigFile()` in main.cpp already uses it [VERIFIED: main.cpp:98-137] |
+| Role/domain string → enum mapping | If-else chains | Static `std::unordered_map<std::string, ELMRole>` | Performant, declarative, easy to test |
+| ELM registry (role → ELM instance) | Custom container | `std::unordered_map<ELMRole, std::shared_ptr<IELM>>` | Standard C++17, sufficient for sequential lookup |
+| Confidence aggregation across chain | Custom math | Product of per-step confidences or min confidence | Per-step confidence already computed by each ELM::Process() |
+
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+- D-01/02: Hybrid ELM backing — shared backbone (core MNN model + role prompt template) by default, optional per-role model path. [VERIFIED: feasible — `RoleELM` holds `shared_ptr<InferenceEngine>`, `DomainELM` may own its own `unique_ptr<MNNInferenceEngine>`]
+- D-05..08: New `IELM` interface; adapters wrap GrammarSpecialist/MathSpecialist via composition; `ELMRole` enum + `ELMContext` struct in `common/types.hpp`.
+- D-09..13: Flat sequential `ExecutionChain`; `ELMChainBuilder` separate from `RuleBasedRouter`; `ApiServer::RunELMChain`.
+- D-14..16: `elms` JSON config section, lazy loading default.
+- D-17/18: `GroundingELM` wraps knowledge/ pipeline; `ToolSupportELM` is a stub.
+
+### OpenCode's Discretion
+- Exact `ELMContext` field set (must carry: original task, accumulated step outputs, per-step confidence)
+- Role prompt template wording
+- Chain-step timeout and confidence-threshold defaults
+- File layout for ELM implementations (recommendation: `src/elm/` as new directory)
+- Whether Science ELM ships as shared-backbone-only in Phase 7 (no trained model exists)
+
+### Deferred Ideas (OUT OF SCOPE)
+- Multi-domain parallel dispatch + arbiter-mediated synthesis — Phase 9
+- Learned classifier router — Phase 7.5 / doc 03 §6.3 stage 2
+- Cognitive planner producing full execution graphs — Phase 8+ (needs GAML memory)
+- Real Tool-Support logic — Phase 10
+- User-editable role prompt templates — future
+- Legal/Compliance, Operations, Customer Support, Finance domain ELMs — future
+
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| ELM-01 | Deploy 7 role-based ELMs behind IELM interface | Shared-backbone `RoleELM` class + role prompt templates; verified against existing GrammarSpecialist pattern |
+| ELM-02 | Deploy 3 domain ELMs (Math, Code, Science) | Math ELM via `SpecialistAdapter<MathSpecialist>`; Code/Science via `DomainELM` (shared backbone for Science, optional model for Code) |
+| ELM-03 | ELMRole enum + ELMContext in common/types.hpp | New enum added to existing types.hpp alongside existing ExecutionMode/RouteTarget enums |
+| ELM-04 | Adapters wrap GrammarSpecialist → Refiner, MathSpecialist → Math domain | `SpecialistAdapter` class — composition of `ISpecialist`, verified against i_specialist.hpp signatures |
+| ELM-05 | ELMChainBuilder produces ExecutionChain from RouteDecision + PromptFeatures | New class consuming existing `PromptFeatures` + `RouteDecision` structs; 6 trigger rules from doc 03 §6.2 |
+| ELM-06 | ApiServer::RunELMChain executes chains sequentially | New private method alongside existing RunSingleNode/RunSpecialist/RunSwarm; verified against Process() switch in api_server.cpp:448-456 |
+| ELM-07 | GroundingELM wraps knowledge/ pipeline | Wraps `KnowledgeRetrieval::Retrieve()` + `ContextInjection::Inject()` + engine Infer + `FactValidation::Validate()` |
+| ELM-08 | ToolSupportELM is a pass-through stub | Returns input unchanged, logs "not implemented", confidence=0.0 |
+| ELM-09 | elms JSON config section with lazy loading | Extends `LoadConfigFile()` in main.cpp:89-138 with per-role `model` and `eager` fields |
+| ELM-10 | Router unchanged; new chain builder is separate | RuleBasedRouter keeps producing RouteDecision; ELMChainBuilder is new class |
+
+## Existing Code Analysis
+
+### Q1: Core MNN Model Invocation API (for shared-backbone ELMs)
+
+**File:** `src/core/engine/inference_engine.hpp` [VERIFIED]
+**Interface:** `InferenceEngine::Infer(const Task&) → outcome::result<InferenceResponse>`
+
+```cpp
+// Exact signatures (from inference_engine.hpp:30-37)
+virtual outcome::result<void> LoadModel(const std::string& model_path) = 0;
+virtual outcome::result<InferenceResponse> Infer(const Task& task) = 0;
+virtual bool IsLoaded() const = 0;
+```
+
+**Task struct** (from `common/types.hpp:41-49`):
+```cpp
+struct Task {
+    std::string m_id;
+    std::string m_prompt;
+    ExecutionMode m_mode = ExecutionMode::SingleNode;
+    uint32_t m_maxTokens = 512;
+    float m_temperature = 0.7f;
+    std::string m_nodeId;
+};
+```
+
+**InferenceResponse** (from `common/types.hpp:54-66`):
+```cpp
+struct InferenceResponse {
+    std::string m_output;
+    std::string m_taskId;
+    ExecutionMode m_modeUsed;
+    RouteTarget m_routeUsed;
+    double m_totalLatencyMs = 0.0;
+    float m_perplexity = 1.0f;
+    double m_latencyMs = 0.0;
+    std::string m_nodeId;
+    bool m_success = true;
+    std::string m_errorMessage;
+};
+```
+
+**Existing pattern for role-specific prompts** (from `grammar_specialist.cpp:45-51, 56-81`):
+1. Construct role prompt via `BuildPrompt(input)` 
+2. Create `Task` with the prompt
+3. Call `engine->Infer(task)`
+4. Compute confidence from perplexity
+5. Return output on success, input unchanged on failure (graceful degradation)
+
+This is exactly the pattern every shared-backbone RoleELM will follow.
+
+### Q2: ApiServer::Process() Branching — Where RunELMChain Integrates
+
+**File:** `src/api/api_server.cpp` [VERIFIED]
+
+Current `Process()` flow (lines 425-458):
+```
+Process(task)
+  → m_router->Route(t)
+  → switch(route.m_mode):
+      SingleNode → RunSingleNode(t, route)
+      Specialist → RunSpecialist(t, route)      // Core → Grammar OR Core → Math
+      Swarm      → RunSwarm(t, route)
+```
+
+**Integration plan:** Add a new `ExecutionMode::Chain` value. The ELM chain path replaces the single-specialist path for multi-step routing. The switch becomes:
+```cpp
+case ExecutionMode::Chain:
+    return RunELMChain(t, route);
+```
+
+Alternatively, keep `ExecutionMode::Specialist` for single-step (backward compat), and add `ExecutionMode::Chain` for multi-step. Decision D-09..13 says `RunELMChain` is a new method. The `ExecutionMode` enum in `common/types.hpp:20-25` needs a new value.
+
+### Q3: What RuleBasedRouter + PromptAnalyzer Already Extract
+
+**File:** `src/router/prompt_analyzer.cpp` [VERIFIED]
+
+Current `PromptFeatures` struct (from `common/types.hpp:82-90`):
+```cpp
+struct PromptFeatures {
+    float numeric_density_ = 0.0f;   // ratio of numeric tokens
+    bool has_code_syntax_ = false;
+    float complexity_ = 0.0f;        // log(token_count) × vocab_diversity
+    size_t token_count_ = 0;
+    bool has_math_keywords_ = false;
+    bool has_grammar_request_ = false;
+};
+```
+
+**Six doc 03 §6.2 triggers — coverage analysis:**
+
+| # | Trigger | Covered? | Code |
+|---|---------|----------|------|
+| 1 | Numeric density → Math | ✅ YES | `ComputeNumericDensity()` (prompt_analyzer.cpp:45-74), threshold at 0.30 |
+| 2 | Code syntax → Code | ✅ YES | `DetectCodeSyntax()` (prompt_analyzer.cpp:79-85) — regex-based detection |
+| 3 | Grounding-sensitive → Grounding | ❌ NO | No grounding/factuality detector exists |
+| 4 | Formatting-sensitive → Refiner | ⚠️ PARTIAL | `HasGrammarRequest()` (prompt_analyzer.cpp:142-161) — detects grammar/spelling requests but not general formatting |
+| 5 | Low complexity → Core only | ✅ YES | `EstimateComplexity()` (prompt_analyzer.cpp:90-111) — log(token)×diversity |
+| 6 | High complexity → multi-stage | ⚠️ PARTIAL | Complexity > swarm threshold triggers swarm mode, not multi-stage chain |
+
+**New features needed:**
+- `PromptFeatures::has_grounding_request_` — detects factual claims, "is it true", "verify", "according to", "fact check" keywords
+- `PromptFeatures::has_formatting_request_` — detects structure/style requests beyond grammar: "format as", "make this look", "structure this", "organize", output schema keywords
+
+**RuleBasedRouter::Route()** (from `rule_based_router.cpp:63-100`):
+- Currently produces `RouteDecision` with lower-confidence code routing (`CoreOnly` for code, not `CorePlusCode`)
+- `SelectMode()` (lines 32-58) decides `ExecutionMode`
+- ELMChainBuilder uses the same `PromptFeatures` but produces `ExecutionChain` instead of `RouteDecision`
+
+### Q4: Exact ISpecialist Signatures (for Adapters)
+
+**File:** `src/specialists/i_specialist.hpp` [VERIFIED, lines 20-50]
+
+```cpp
+class ISpecialist {
+public:
+    virtual ~ISpecialist() = default;
+    virtual std::string GetName() const = 0;
+    virtual bool IsLoaded() const = 0;
+    virtual outcome::result<void> Load(const std::string& model_path) = 0;
+    virtual outcome::result<std::string> Process(const std::string& input) = 0;
+    virtual float GetConfidence() const = 0;
+};
+```
+
+**Key difference from IELM (D-05):** `ISpecialist::Process(input)` takes just a `std::string`; `IELM::Process(input, ELMContext)` takes both. The adapter must drop `ELMContext` when forwarding to `ISpecialist::Process()`.
+
+**Concrete specialists to adapt:**
+- `GrammarSpecialist` (grammar_specialist.hpp:22-49) — `GetName()` returns "GrammarSpecialist"
+- `MathSpecialist` (math_specialist.hpp:24-55) — includes `SymbolicFallback`; `GetName()` returns "MathSpecialist"
+
+Both take `shared_ptr<InferenceEngine>` in constructor, call `engine->Infer(Task)` in `Process()`, return input unchanged on failure.
+
+### Q5: Knowledge Pipeline API (for GroundingELM)
+
+**3-stage pipeline** [VERIFIED: src/knowledge/]:
+
+1. **KnowledgeRetrieval::Retrieve(query)** (knowledge_retrieval.hpp:57)
+   ```cpp
+   outcome::result<std::vector<KnowledgeFact>> Retrieve(const std::string& query) const;
+   ```
+   Returns top-k `KnowledgeFact` structs (source, content, relevanceScore). TF-IDF stub [VERIFIED: knowledge_retrieval.cpp:107-136].
+
+2. **ContextInjection::Inject(prompt, facts)** (context_injection.hpp:37)
+   ```cpp
+   std::string Inject(const std::string& prompt, const std::vector<KnowledgeFact>& facts) const;
+   ```
+   Prepends Grokipedia facts to the prompt. Already used in `ApiServer::AugmentPrompt()` [VERIFIED: api_server.cpp:204-217].
+
+3. **FactValidation::Validate(output, facts)** (fact_validation.hpp:47)
+   ```cpp
+   ValidationResult Validate(const std::string& output, const std::vector<KnowledgeFact>& grounding_facts) const;
+   ```
+   Checks claims against facts, returns `ValidationResult { passed_, contradictionScore, contradictions, suggestion_ }`.
+
+**GroundingELM::Process() flow:**
+```
+1. Retrieve(query) → facts
+2. Inject(task + facts) → augmented prompt
+3. engine->Infer(augmented_prompt) → output
+4. FactValidation::Validate(output, facts) → validation result
+5. If contradicting → log warning, set low confidence
+6. Return output
+```
+
+All three components already exist and are wired in `ApiServer`. `GroundingELM` composes them identically.
+
+### Q6: JSON Config Parsing — Where the `elms` Section Hooks In
+
+**File:** `src/main.cpp` [VERIFIED, lines 89-138, 264-288]
+
+Current `LoadConfigFile()` pattern:
+```cpp
+// Pattern for each key: check exists, only set if default value
+if (j.contains("model") && args.m_modelPath.empty())
+    args.m_modelPath = j["model"].get<std::string>();
+```
+
+Config flows into `api::ApiServer::Config` (api_server.hpp:50-66):
+```cpp
+struct Config {
+    std::string m_modelPath;
+    std::string m_grammarModelPath;
+    std::string m_mathModelPath;
+    std::string m_reputationDbPath;
+    bool m_enableNetwork = false;
+    // ... etc
+};
+```
+
+**Integration for `elms` section:**
+
+Add to `ApiServer::Config`:
+```cpp
+struct ElmEntry {
+    std::string role;     // e.g. "planner", "verifier", "math"
+    std::string model;    // optional model path
+    bool eager = false;   // load at Initialize() vs lazy
+};
+std::vector<ElmEntry> m_elmConfigs;
+```
+
+In `LoadConfigFile()`, iterate `j["elms"]` array (if present):
+```cpp
+if (j.contains("elms") && j["elms"].is_array()) {
+    for (const auto& e : j["elms"]) {
+        ElmEntry entry;
+        if (e.contains("role")) entry.role = e["role"].get<std::string>();
+        if (e.contains("model")) entry.model = e["model"].get<std::string>();
+        if (e.contains("eager")) entry.eager = e["eager"].get<bool>();
+        cfg.m_elmConfigs.push_back(std::move(entry));
+    }
+}
+```
+
+### Q7: Existing Test Patterns
+
+**Pattern 1 — MockEngine (synchronous, no wait conditions):**
+From `test/specialists/test_grammar_specialist.cpp:17-46` [VERIFIED]:
+```cpp
+class MockEngine : public core::InferenceEngine {
+    outcome::result<InferenceResponse> Infer(const Task& task) override {
+        InferenceResponse resp;
+        resp.m_output = task.m_prompt + " [corrected]";
+        resp.m_perplexity = 1.0f;
+        return outcome::success(resp);
+    }
+    // ... other virtuals stubbed
+};
+```
+This pattern is directly reusable for ELM tests. Each ELM test creates a MockEngine, constructs the ELM with it, calls `Process()`, and checks output/confidence.
+
+**Pattern 2 — Integration tests with ApiServer stub mode:**
+From `test/integration/test_pipeline.cpp:13-30` [VERIFIED]:
+```cpp
+class PipelineTest : public ::testing::Test {
+    void SetUp() override {
+        ApiServer::Config cfg;
+        cfg.m_modelPath = "";  // stub mode
+        // ...
+        server_ = std::make_unique<ApiServer>(cfg);
+        ASSERT_TRUE(server_->Initialize().has_value());
+    }
+};
+```
+Reusable for chain execution integration tests.
+
+**Pattern 3 — CMake test registration:**
+From `test/CMakeLists.txt:42-53` [VERIFIED]:
+```cmake
+neoswarm_test(test_router router/test_router.cpp "neoswarm_router;neoswarm_common")
+```
+New tests will use `neoswarm_test(test_elm elm/test_elm.cpp "neoswarm_elm;neoswarm_common")`.
+
+### Q8: Threading, Memory, and Pitfalls
+
+**Threading model of ApiServer:** Synchronous throughout. `ApiServer::Process()` is called sequentially per request (interactive REPL mode in main.cpp:228). No thread pool, no concurrent Process() calls. Every internal operation is synchronous. [VERIFIED: api_server.cpp — no threads, no async, no mutex on Process()]
+
+**MNN engine thread safety:** Not thread-safe at the model level. `MNNInferenceEngine` has single `mnn_llm_` pointer, single `m_session`, single `m_interpreter` (mnn_inference_engine.hpp:146-150). Concurrent calls to `Infer()` on the same instance would race on internal MNN state. This is NOT a concern for Phase 7 because:
+- Chain execution is sequential (D-09: "flat ordered list of steps")
+- Each `Infer()` call completes before the next step begins
+- No concurrent ELM execution
+
+**Memory when loading a second model:** Each `MNNInferenceEngine` instance owns its model. `RoleELM` with shared backbone uses `shared_ptr<InferenceEngine>` (no second model). `DomainELM` with its own `.mnn` path creates a new `MNNInferenceEngine` instance → separate model in memory. Acceptable for Phase 7 (local-only, consumer hardware). Memory pressure becomes a concern for Phase 9+ (many concurrent models).
+
+**Stub/graceful degradation:** `MNNInferenceEngine::Infer()` returns `"[stub response — no model loaded]"` when uninitialized (mnn_inference_engine.cpp:250-257). `GrammarSpecialist::Process()` returns input unchanged when not loaded (grammar_specialist.cpp:60-63). ELMs must follow the same fail-close pattern.
+
+**ExecutionMode enum collision risk:** Adding `Chain = 3` to `ExecutionMode` (types.hpp:20-25) is backward-safe — existing switch statements in Process() will hit the `default` case if a chain mode arrives before the handler is added. The planner must ensure `RunELMChain` is added before `Chain` mode is produced by the router.
+
+## Environment Availability
+
+Step 2.6: AUDITED — all dependencies are code-only (no new external tools, services, or runtimes). Phase 7 uses only already-linked libraries (MNN, Boost.Asio, nlohmann/json, spdlog, Google Test). No new environment dependencies to verify.
+
+**Skip condition met:** No new external dependencies identified. All required libraries are already linked in the existing CMake build.
+
+## Validation Architecture
+
+**nyquist_validation: true** (from config.json)
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | Google Test (thirdparty) |
+| Config file | `test/CMakeLists.txt` |
+| Quick run command | `cd build/OSX/Debug && ninja test_router && ./test_router` |
+| Full suite command | `cd build/OSX/Debug && ctest` |
+
+### Phase Requirements → Test Map
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| ELM-01 | RoleELM::Process with MockEngine returns template-augmented output | unit | `ninja test_elm && ./test_elm --gtest_filter="*RoleELM*"` | ❌ Wave 0 |
+| ELM-02 | DomainELM::Process with shared backbone / per-ELM engine | unit | `ninja test_elm && ./test_elm --gtest_filter="*DomainELM*"` | ❌ Wave 0 |
+| ELM-03 | ELMRole enum values, ELMContext carries accumulated outputs | unit | `ninja test_common_types && ./test_common_types` | ❌ (extend existing) |
+| ELM-04 | SpecialistAdapter delegates to ISpecialist correctly | unit | `ninja test_elm && ./test_elm --gtest_filter="*Adapter*"` | ❌ Wave 0 |
+| ELM-05 | ELMChainBuilder produces correct chain for each of 6 triggers | unit | `ninja test_elm && ./test_elm --gtest_filter="*ChainBuilder*"` | ❌ Wave 0 |
+| ELM-06 | ApiServer::RunELMChain processes 3-step chain end-to-end | integration | `ninja test_pipeline && ./test_pipeline --gtest_filter="*Chain*"` | ❌ (extend existing) |
+| ELM-07 | GroundingELM calls knowledge pipeline in order | unit | `ninja test_elm && ./test_elm --gtest_filter="*Grounding*"` | ❌ Wave 0 |
+| ELM-08 | ToolSupportELM returns input unchanged with confidence=0 | unit | `ninja test_elm && ./test_elm --gtest_filter="*ToolSupport*"` | ❌ Wave 0 |
+| ELM-09 | elms JSON config parses correctly; eager ELMs load at init | integration | `ninja test_pipeline && ./test_pipeline` | ❌ (extend existing) |
+| ELM-10 | RuleBasedRouter tests still pass unchanged after chain builder added | regression | `ninja test_router && ./test_router` | ✅ exists |
+
+### Sampling Rate
+- **Per task commit:** `ninja test_elm && ./test_elm`
+- **Per wave merge:** `ctest` (full suite)
+- **Phase gate:** All ELM tests + existing tests green before `/gsd-verify-work`
+
+### Wave 0 Gaps
+- [ ] `test/elm/test_elm.cpp` — covers RoleELM, DomainELM, SpecialistAdapter, ELMChainBuilder, GroundingELM, ToolSupportELM
+- [ ] Extend `test/common/test_types.cpp` — ELMRole enum, ELMContext struct validation
+- [ ] Extend `test/integration/test_pipeline.cpp` — ApiServer chain execution, ELM config loading
+- [ ] Framework: `test/elm/` directory + CMakeLists entry
+
+## Common Pitfalls
+
+### Pitfall 1: ExecutionMode Enum Collision
+**What goes wrong:** Adding `ExecutionMode::Chain = 3` before the `Process()` switch handles it crashes or silently falls through to `InternalError` return.
+**Why it happens:** `ExecuteMode::Chain` could be produced by the router before `RunELMChain` is implemented.
+**How to avoid:** Add the `case ExecutionMode::Chain:` branch in Process() FIRST, then update the router/chain builder to produce chain mode. Or use a temporary route: during Wave 1, chain builder produces single-step chains that use the existing `Specialist` mode path.
+**Warning signs:** `InternalError` responses when chain mode is auto-selected.
+
+### Pitfall 2: Shared MNNInferenceEngine State Races (Does Not Apply)
+**What goes wrong:** N/A for Phase 7. Sequential chain execution means only one ELM calls `Infer()` at a time.
+**Why it doesn't happen:** Decision D-09 (flat ordered list, no parallel edges) guarantees sequential execution.
+**How to handle in future:** Phase 9 (parallel dispatch) will need per-ELM engines or an inference queue.
+
+### Pitfall 3: ELMContext Accumulation Causing Prompt Bloat
+**What goes wrong:** Each chain step receives all prior outputs in `ELMContext`. For a 5-step chain, step 5 sees step 1-4 outputs concatenated → prompt exceeds model's context window.
+**Why it happens:** Naive concatenation doubles or triples prompt size per step.
+**How to avoid:** Each ELM's prompt template should select only the immediately prior output, not the full history. `ELMContext` carries `m_lastOutput` (short) + `m_originalTask` (reference). Intermediate steps reference outputs, not concatenate all.
+
+### Pitfall 4: Confidence Degradation in Long Chains
+**What goes wrong:** Each step has confidence < 1.0. A 4-step chain where each step has 0.8 confidence gives 0.8⁴ = 0.41 final confidence — potentially below any useful threshold.
+**Why it happens:** Perplexity-based confidence is conservative by design.
+**How to avoid:** Use max-per-step or min-per-step confidence, not product. Report per-step confidence in `ELMContext` for debugging. Don't fail chains based on aggregate confidence in Phase 7 (leave threshold tuning for Phase 10).
+
+### Pitfall 5: PromptAnalyzer Clean Extension
+**What goes wrong:** Adding `has_grounding_request_` and `has_formatting_request_` to `PromptFeatures` breaks existing serialization/deserialization if any exists.
+**Why it happens:** Struct layout changes when fields are added at the end.
+**How to avoid:** `PromptFeatures` is a plain struct with no serialization. Adding fields at the end is safe. Existing test assertions checking specific field values may need updates but existing tests use EXPECT_GT/EXPECT_LT not exact values.
+
+## Code Examples
+
+### Role Prompt Template (Planner)
+```cpp
+// Source pattern: grammar_specialist.cpp:45-51 — BuildPrompt() convention
+std::string PlannerELM::BuildPrompt(const std::string& input, const ELMContext& ctx)
+{
+    return "[INST] You are a Planner. Analyze the following task and determine:\n"
+           "1. The primary domain (Math/Code/Science/General)\n"
+           "2. Estimated complexity (Low/Medium/High)\n"
+           "3. Recommended execution steps\n\n"
+           "Task: " + input + "\n\n"
+           "Analysis: [/INST]";
+}
+```
+
+### ExecutionChain Struct
+```cpp
+// Based on D-09: flat ordered list, designed for future DAG extension
+struct ChainStep {
+    ELMRole m_role = ELMRole::PrimaryDraft;
+    std::optional<std::string> m_domain;  // e.g. "math", "code" — for domain ELMs
+};
+
+struct ExecutionChain {
+    std::vector<ChainStep> m_steps;
+    std::string m_reasoning;              // why this chain was chosen
+    float m_chainConfidence = 0.0f;       // builder's confidence in this chain
+};
+```
+
+### ELMContext
+```cpp
+// OpenCode's discretion — minimum field set (D-05 requires: task, outputs, confidence)
+struct ELMContext {
+    std::string m_originalTask;            // the user's original prompt
+    std::string m_lastOutput;              // output of the immediately prior step
+    std::vector<std::pair<ELMRole, float>> m_stepConfidences;  // (role, confidence) per completed step
+    std::vector<KnowledgeFact> m_groundingFacts;  // facts from GroundingELM, if any
+};
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| RouteDecision with single target | ExecutionChain with ordered steps | Phase 7 (this phase) | Router still produces RouteDecision; ChainBuilder adds the chain |
+| Hardcoded specialist dispatch in RunSpecialist() | ELM registry + RunELMChain | Phase 7 (this phase) | New ELMs added via config + registry, not code edits |
+
+**Deprecated/outdated:**
+- `RouteTarget::CorePlusGrammar` — becomes an internal detail of the Refiner adapter, not a top-level routing target (Phase 10+ cleanup, not Phase 7)
+- `RouteTarget::CorePlusCode` (marked "Future") — Code ELM will be a full chain step, not a CorePlus mode
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | `MNNInferenceEngine::mnn_llm_->response()` is safe for sequential calls on the same instance (no internal state corruption between calls) | Q8 Threading | Chain execution would produce garbled output or crash. Mitigation: MockEngine for tests; monitoring in integration tests |
+| A2 | Adding `ExecutionMode::Chain = 3` to the enum does not break binary compatibility with existing compiled tests | Q2 Integration | Test binaries would need recompilation. Mitigation: enum already has 3 values; adding a 4th is standard C++ and wire-safe for this local-only project |
+| A3 | Science ELM ships as shared-backbone-only (no trained model exists per gnus-poc scope boundary) | ELM-02 Domain ELMs | If a Science model appears, config already supports per-ELM model paths — just add to `elms` JSON |
+| A4 | `PromptFeatures` struct has no external serialization dependencies — adding fields is backward-safe | Q3 PromptAnalyzer | Risk is minimal; `PromptFeatures` is a plain struct used only in-memory within the router pipeline |
+
+## Open Questions (RESOLVED)
+
+1. **Should Chain execution replace Specialist mode entirely, or coexist?**
+   - What we know: D-09 says `RunELMChain` is new. Current `RunSpecialist` is a 2-step hardcoded path (Core → Specialist). A chain `[PrimaryDraft, Specialist]` achieves the same result via the chain executor.
+   - What's unclear: Whether to remove `RunSpecialist` or keep as optimization shortcut for single-specialist chains.
+   - Recommendation: Keep `ExecutionMode::Specialist` for backward compat in Phase 7; route single-specialist tasks through it. Use `ExecutionMode::Chain` only for multi-step (3+) chains. Deprecate `Specialist` mode in Phase 10.
+
+2. **Per-step timeout: what default value?**
+   - What we know: D-05/D-11 reference chain-step timeout as OpenCode's discretion. No existing chain timeout infrastructure.
+   - What's unclear: MNN inference is synchronous and blocking — adding timeout requires `std::future` or `boost::asio` wrapping.
+   - Recommendation: Defer per-step timeout to Phase 10 (along with safety profiles). Phase 7 uses synchronous blocking calls; the MNN engine's token-generation loop is the natural timeout (maxTokens-based).
+
+3. **How are role prompt templates versioned?**
+   - What we know: D-03 says templates live as "named constants/resources in the ELM implementations — not user-editable config." But templates shape ELM behavior significantly — changing them is a behavioral change.
+   - What's unclear: Whether template changes require version bumps or just code review.
+   - Recommendation: Document each template as a `static const char*` in the ELM class header (not cpp). Add a version comment. Not a blocking question for Phase 7.
+
+## Security Domain
+
+**security_enforcement: true** (from config.json — absent, treated as enabled)
+
+### Applicable ASVS Categories
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|-----------------|
+| V2 Authentication | No | Phase 1 already handles NodeIdentity |
+| V3 Session Management | No | Stateless inference |
+| V4 Access Control | No | Phase 10 (Tool Intermediary) |
+| V5 Input Validation | Yes | Prompt sanitization before injection into role templates — avoid prompt injection via user input appearing in [INST] blocks |
+| V6 Cryptography | No | No new crypto in this phase |
+
+### Known Threat Patterns for C++ Inference Engine
+
+| Pattern | STRIDE | Standard Mitigation |
+|---------|--------|---------------------|
+| Prompt injection via user input in role template | Spoofing | Role prompt templates use structural delimiters (`[INST]...[/INST]`); user input is always placed AFTER the role instruction, never inline. Input is treated as data, not instruction. |
+| ELM output used directly as next ELM input without sanitization | Elevation | D-09 chain is designed for trusted ELM-to-ELM handoff. For Phase 7 (local, single-user), this is acceptable. Sanitization gates added in Phase 10. |
+| Malformed JSON config crashing the parser | Denial of Service | `nlohmann/json` exceptions caught by existing `try/catch` in `LoadConfigFile()` [VERIFIED: main.cpp:99-107] |
+
+## Sources
+
+### Primary (HIGH confidence)
+- `src/core/engine/inference_engine.hpp` — InferenceEngine interface, Infer() signature
+- `src/core/engine/mnn_inference_engine.{hpp,cpp}` — MNNInferenceEngine implementation, stub mode, InferViaMnnLlm path
+- `src/api/api_server.{hpp,cpp}` — Process() switch, RunSingleNode/RunSpecialist/RunSwarm, Initialize flow
+- `src/router/i_router.hpp` — IRouter interface, RouteDecision
+- `src/router/rule_based_router.{hpp,cpp}` — RuleBasedRouter::Route(), SelectMode()
+- `src/router/prompt_analyzer.{hpp,cpp}` — PromptFeatures extraction, all 5 analyzers
+- `src/specialists/i_specialist.hpp` — ISpecialist interface (exact signatures)
+- `src/specialists/grammar_specialist.{hpp,cpp}` — BuildPrompt pattern, Process flow, graceful degradation
+- `src/specialists/math_specialist.{hpp,cpp}` — SymbolicFallback integration, confidence computation
+- `src/specialists/symbolic_fallback.hpp` — kConfidenceThreshold constant
+- `src/knowledge/knowledge_retrieval.{hpp,cpp}` — Retrieve() API, TF-IDF stub
+- `src/knowledge/context_injection.hpp` — Inject() API
+- `src/knowledge/fact_validation.hpp` — Validate() API, ValidationResult struct
+- `src/common/types.hpp` — Task, InferenceResponse, RouteDecision, PromptFeatures, ExecutionMode, RouteTarget
+- `src/common/error.hpp` — Error enum, outcome namespace
+- `src/common/logging.hpp` — CreateLogger pattern
+- `src/main.cpp` — LoadConfigFile pattern, CLI→config flow, Args struct
+- `test/router/test_router.cpp` — Router test patterns
+- `test/specialists/test_grammar_specialist.cpp` — MockEngine pattern, ELM test patterns
+- `test/integration/test_pipeline.cpp` — Full pipeline test pattern
+- `test/CMakeLists.txt` — neoswarm_test macro, library linking
+- `.planning/workstreams/neoswarm/config.json` — nyquist_validation: true
+- `../../docs/architecture/03-model-and-router.md` — ELM definition, router design, 6 triggers
+- `../../docs/architecture/11-distributed-swarm-thinking-context.md` — §16.8 specialist taxonomy
+
+### Secondary (MEDIUM confidence)
+- None — all findings verified against primary sources
+
+### Tertiary (LOW confidence)
+- None — no unverified websearch findings
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — no new dependencies; all libraries already linked
+- Architecture: HIGH — all integration points verified against live source code with exact file:line references
+- Pitfalls: HIGH — pitfalls derived from code analysis (enum collision risk, prompt bloat from context accumulation)
+- Test patterns: HIGH — MockEngine and integration test patterns directly reusable
+
+**Research date:** 2026-07-16
+**Valid until:** 2026-08-16

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-RESEARCH.md
@@ -305,13 +305,13 @@ Process(task)
       Swarm      → RunSwarm(t, route)
 ```
 
-**Integration plan:** Add a new `ExecutionMode::Chain` value. The ELM chain path replaces the single-specialist path for multi-step routing. The switch becomes:
+**Integration plan:** Add a new `ExecutionMode::ElmAssisted` value. The ELM chain path replaces the single-specialist path for multi-step routing. The switch becomes:
 ```cpp
-case ExecutionMode::Chain:
+case ExecutionMode::ElmAssisted:
     return RunELMChain(t, route);
 ```
 
-Alternatively, keep `ExecutionMode::Specialist` for single-step (backward compat), and add `ExecutionMode::Chain` for multi-step. Decision D-09..13 says `RunELMChain` is a new method. The `ExecutionMode` enum in `common/types.hpp:20-25` needs a new value.
+Alternatively, keep `ExecutionMode::Specialist` for single-step (backward compat), and add `ExecutionMode::ElmAssisted` for multi-step. Decision D-09..13 says `RunELMChain` is a new method. The `ExecutionMode` enum in `common/types.hpp:20-25` needs a new value.
 
 ### Q3: What RuleBasedRouter + PromptAnalyzer Already Extract
 
@@ -507,7 +507,7 @@ New tests will use `neoswarm_test(test_elm elm/test_elm.cpp "neoswarm_elm;neoswa
 
 **Stub/graceful degradation:** `MNNInferenceEngine::Infer()` returns `"[stub response — no model loaded]"` when uninitialized (mnn_inference_engine.cpp:250-257). `GrammarSpecialist::Process()` returns input unchanged when not loaded (grammar_specialist.cpp:60-63). ELMs must follow the same fail-close pattern.
 
-**ExecutionMode enum collision risk:** Adding `Chain = 3` to `ExecutionMode` (types.hpp:20-25) is backward-safe — existing switch statements in Process() will hit the `default` case if a chain mode arrives before the handler is added. The planner must ensure `RunELMChain` is added before `Chain` mode is produced by the router.
+**ExecutionMode enum collision risk:** Adding `ElmAssisted = 3` to `ExecutionMode` (types.hpp:20-25) is backward-safe — existing switch statements in Process() will hit the `default` case if a chain mode arrives before the handler is added. The planner must ensure `RunELMChain` is added before `Chain` mode is produced by the router.
 
 ## Environment Availability
 
@@ -555,9 +555,9 @@ Step 2.6: AUDITED — all dependencies are code-only (no new external tools, ser
 ## Common Pitfalls
 
 ### Pitfall 1: ExecutionMode Enum Collision
-**What goes wrong:** Adding `ExecutionMode::Chain = 3` before the `Process()` switch handles it crashes or silently falls through to `InternalError` return.
+**What goes wrong:** Adding `ExecutionMode::ElmAssisted = 3` before the `Process()` switch handles it crashes or silently falls through to `InternalError` return.
 **Why it happens:** `ExecuteMode::Chain` could be produced by the router before `RunELMChain` is implemented.
-**How to avoid:** Add the `case ExecutionMode::Chain:` branch in Process() FIRST, then update the router/chain builder to produce chain mode. Or use a temporary route: during Wave 1, chain builder produces single-step chains that use the existing `Specialist` mode path.
+**How to avoid:** Add the `case ExecutionMode::ElmAssisted:` branch in Process() FIRST, then update the router/chain builder to produce chain mode. Or use a temporary route: during Wave 1, chain builder produces single-step chains that use the existing `Specialist` mode path.
 **Warning signs:** `InternalError` responses when chain mode is auto-selected.
 
 ### Pitfall 2: Shared MNNInferenceEngine State Races (Does Not Apply)
@@ -638,7 +638,7 @@ struct ELMContext {
 | # | Claim | Section | Risk if Wrong |
 |---|-------|---------|---------------|
 | A1 | `MNNInferenceEngine::mnn_llm_->response()` is safe for sequential calls on the same instance (no internal state corruption between calls) | Q8 Threading | Chain execution would produce garbled output or crash. Mitigation: MockEngine for tests; monitoring in integration tests |
-| A2 | Adding `ExecutionMode::Chain = 3` to the enum does not break binary compatibility with existing compiled tests | Q2 Integration | Test binaries would need recompilation. Mitigation: enum already has 3 values; adding a 4th is standard C++ and wire-safe for this local-only project |
+| A2 | Adding `ExecutionMode::ElmAssisted = 3` to the enum does not break binary compatibility with existing compiled tests | Q2 Integration | Test binaries would need recompilation. Mitigation: enum already has 3 values; adding a 4th is standard C++ and wire-safe for this local-only project |
 | A3 | Science ELM ships as shared-backbone-only (no trained model exists per gnus-poc scope boundary) | ELM-02 Domain ELMs | If a Science model appears, config already supports per-ELM model paths — just add to `elms` JSON |
 | A4 | `PromptFeatures` struct has no external serialization dependencies — adding fields is backward-safe | Q3 PromptAnalyzer | Risk is minimal; `PromptFeatures` is a plain struct used only in-memory within the router pipeline |
 
@@ -647,7 +647,7 @@ struct ELMContext {
 1. **Should Chain execution replace Specialist mode entirely, or coexist?**
    - What we know: D-09 says `RunELMChain` is new. Current `RunSpecialist` is a 2-step hardcoded path (Core → Specialist). A chain `[PrimaryDraft, Specialist]` achieves the same result via the chain executor.
    - What's unclear: Whether to remove `RunSpecialist` or keep as optimization shortcut for single-specialist chains.
-   - Recommendation: Keep `ExecutionMode::Specialist` for backward compat in Phase 7; route single-specialist tasks through it. Use `ExecutionMode::Chain` only for multi-step (3+) chains. Deprecate `Specialist` mode in Phase 10.
+   - Recommendation: Keep `ExecutionMode::Specialist` for backward compat in Phase 7; route single-specialist tasks through it. Use `ExecutionMode::ElmAssisted` only for multi-step (3+) chains. Deprecate `Specialist` mode in Phase 10.
 
 2. **Per-step timeout: what default value?**
    - What we know: D-05/D-11 reference chain-step timeout as OpenCode's discretion. No existing chain timeout infrastructure.

--- a/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-VALIDATION.md
+++ b/.planning/workstreams/neoswarm/phases/07-expert-language-models-router/07-VALIDATION.md
@@ -1,0 +1,77 @@
+---
+phase: 7
+slug: expert-language-models-router
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-07-15
+---
+
+# Phase 7 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | Google Test (pre-built via thirdparty), CTest runner |
+| **Config file** | `test/CMakeLists.txt` (`neoswarm_test` macro) |
+| **Quick run command** | `cd build/OSX/Debug && ninja <test_target> && ./test/<test_target>` |
+| **Full suite command** | `cd build/OSX/Debug && ninja && ctest --output-on-failure` |
+| **Estimated runtime** | ~60 seconds full suite (140+ existing tests) |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Build + run the test target for the module touched (e.g. `./test/test_elm_chain_builder`)
+- **After every plan wave:** Run `ctest --output-on-failure` (full suite)
+- **Before `/gsd-verify-work`:** Full suite must be green
+- **Max feedback latency:** 120 seconds
+
+---
+
+## Per-task Verification Map
+
+*To be filled by planner — each PLAN.md task maps here. Template rows:*
+
+| task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 07-01-XX | 01 | 1 | ELM-core | — | N/A | unit | `./test/test_elm_types` | ❌ W0 | ⬜ pending |
+| 07-02-XX | 02 | 2 | ELM-roles | — | N/A | unit | `./test/test_role_elms` | ❌ W0 | ⬜ pending |
+| 07-03-XX | 03 | 3 | ELM-router | — | N/A | unit | `./test/test_elm_chain_builder` | ❌ W0 | ⬜ pending |
+| 07-04-XX | 04 | 4 | ELM-orchestration | — | N/A | integration | `./test/test_elm_pipeline` | ❌ W0 | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] New test targets registered in `test/CMakeLists.txt` via existing `neoswarm_test` macro as they are created per wave
+- [ ] MockEngine pattern (from existing specialist tests) reused for ELM unit tests — no model files needed
+- [ ] Existing infrastructure covers framework needs (GTest already linked; no new installs)
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Real-model chain quality | ELM output quality | Requires a real `.mnn` model file on disk | `./neo-swarm --model <path> --prompt "solve 12*37" --verbose` — observe chain trace: Planner → Math → Verifier |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 120s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,5 +7,6 @@ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/reputation ${CMAKE_CURRENT_BINARY_DIR
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/knowledge ${CMAKE_CURRENT_BINARY_DIR}/knowledge)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/router ${CMAKE_CURRENT_BINARY_DIR}/router)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/specialists ${CMAKE_CURRENT_BINARY_DIR}/specialists)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/elm ${CMAKE_CURRENT_BINARY_DIR}/elm)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/network ${CMAKE_CURRENT_BINARY_DIR}/network)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/api ${CMAKE_CURRENT_BINARY_DIR}/api)

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace sgns::neoswarm
@@ -21,7 +22,8 @@ namespace sgns::neoswarm
     {
         SingleNode = 0, ///< Mode 1 — Core LLM only, fast
         Specialist = 1, ///< Mode 2 — Core + Grammar/Math, sequential
-        Swarm = 2       ///< Mode 3 — Multiple nodes, weighted consensus
+        Swarm = 2,      ///< Mode 3 — Multiple nodes, weighted consensus
+        Chain = 3       ///< Mode 4 — Multi-step ELM chain (Phase 7+)
     };
 
     // -----------------------------------------------------------------------
@@ -33,6 +35,23 @@ namespace sgns::neoswarm
         CorePlusMath = 1,
         CorePlusGrammar = 2,
         CorePlusCode = 3 ///< Future
+    };
+
+    // -----------------------------------------------------------------------
+    // ELM roles (doc 03 §5.2.1) — Phase 7
+    // -----------------------------------------------------------------------
+    enum class ELMRole : uint8_t
+    {
+        Planner = 0,      ///< Analyses task, determines execution plan
+        PrimaryDraft = 1, ///< Core draft generation (shared backbone)
+        Verifier = 2,     ///< Reviews outputs for correctness
+        Arbiter = 3,      ///< Resolves conflicts between outputs
+        Refiner = 4,      ///< Polishes formatting, style, grammar
+        Grounding = 5,    ///< Fact-checks against knowledge base
+        ToolSupport = 6,  ///< Tool-call formatting (stub in Phase 7)
+        Math = 7,         ///< Domain ELM — math
+        Code = 8,         ///< Domain ELM — code
+        Science = 9       ///< Domain ELM — science (shared-backbone only)
     };
 
     // -----------------------------------------------------------------------
@@ -87,6 +106,8 @@ namespace sgns::neoswarm
         size_t token_count_ = 0;
         bool has_math_keywords_ = false;
         bool has_grammar_request_ = false;
+        bool has_grounding_request_ = false;    ///< factual verification request detected (Phase 7)
+        bool has_formatting_request_ = false;   ///< structure/style formatting request detected (Phase 7)
     };
 
     // -----------------------------------------------------------------------
@@ -127,6 +148,33 @@ namespace sgns::neoswarm
         std::string m_source;
         std::string m_content;
         float m_relevanceScore = 0.0f;
+    };
+
+    // -----------------------------------------------------------------------
+    // ELM execution context (Phase 7 — doc 03 §5.2.1)
+    // -----------------------------------------------------------------------
+    struct ELMContext
+    {
+        std::string m_originalTask;                                   ///< the user's original prompt
+        std::string m_lastOutput;                                     ///< output of the immediately prior step
+        std::vector<std::pair<ELMRole, float>> m_stepConfidences;     ///< (role, confidence) per completed step
+        std::vector<KnowledgeFact> m_groundingFacts;                  ///< facts from GroundingELM, if any
+    };
+
+    // -----------------------------------------------------------------------
+    // Chain step and execution chain (Phase 7 — doc 03 §6.2)
+    // -----------------------------------------------------------------------
+    struct ChainStep
+    {
+        ELMRole m_role = ELMRole::PrimaryDraft;
+        std::optional<std::string> m_domain; ///< e.g. "math", "code" — for domain ELMs
+    };
+
+    struct ExecutionChain
+    {
+        std::vector<ChainStep> m_steps;
+        std::string m_reasoning;          ///< why this chain was chosen
+        float m_chainConfidence = 0.0f;   ///< builder's confidence in this chain
     };
 
     // -----------------------------------------------------------------------

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -23,7 +23,7 @@ namespace sgns::neoswarm
         SingleNode = 0, ///< Mode 1 — Core LLM only, fast
         Specialist = 1, ///< Mode 2 — Core + Grammar/Math, sequential
         Swarm = 2,      ///< Mode 3 — Multiple nodes, weighted consensus
-        Chain = 3       ///< Mode 4 — Multi-step ELM chain (Phase 7+)
+        ElmAssisted = 3 ///< Mode 2 (doc 07 §9.2) — ELM-assisted sequential chain (Phase 7+)
     };
 
     // -----------------------------------------------------------------------

--- a/src/elm/CMakeLists.txt
+++ b/src/elm/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(neoswarm_elm STATIC
+    # Wave 1 stub — header-only library, this source file exists only because
+    # CMake requires at least one source for STATIC libraries. It also serves
+    # as a compile-time verification that i_elm.hpp is well-formed.
+    # This file will be removed in Wave 2 when real .cpp implementations are added.
+    elm_stub.cpp
+)
+
+target_include_directories(neoswarm_elm PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_ROOT}/src>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(neoswarm_elm PUBLIC neoswarm_common)

--- a/src/elm/elm_stub.cpp
+++ b/src/elm/elm_stub.cpp
@@ -1,0 +1,31 @@
+/**
+ * @file       elm_stub.cpp
+ * @brief      Minimal compilation unit for the neoswarm_elm library (Wave 1).
+ *
+ * The neoswarm_elm library is header-only in Wave 1 (i_elm.hpp, types in common/types.hpp).
+ * This file is present only to satisfy CMake's requirement that STATIC libraries have
+ * at least one source file. It also serves as a compile-time verification that the IELM
+ * interface header is syntactically correct and compiles against its dependencies.
+ *
+ * NOTE: This file will be removed in Wave 2 when real .cpp implementations are added.
+ * @date       2026-07-16
+ */
+
+#include "elm/i_elm.hpp"
+
+// -----------------------------------------------------------------------
+// Compile-time verification stub
+//
+// This ensures IELM, ELMRole, ELMContext, and all outcome::result types
+// resolve correctly. The function is intentionally dead code — it exists
+// only to produce an object file for the static library archive.
+// -----------------------------------------------------------------------
+namespace
+{
+    void elm_stub_compile_check() noexcept
+    {
+        // Force instantiation of the abstract class vtable via a pointer cast.
+        // This verifies all pure virtual signatures are well-formed.
+        static_cast<void>( sizeof( sgns::neoswarm::elm::IELM ) );
+    }
+} // namespace

--- a/src/elm/i_elm.hpp
+++ b/src/elm/i_elm.hpp
@@ -1,0 +1,61 @@
+/**
+ * @file       i_elm.hpp
+ * @brief      Abstract interface for Expert Language Models (doc 03 §5.2)
+ * @date       2026-07-16
+ */
+
+#ifndef NEOSWARM_ELM_IELM_HPP
+#define NEOSWARM_ELM_IELM_HPP
+
+#include "common/error.hpp"
+#include "common/types.hpp"
+
+#include <string>
+
+namespace sgns::neoswarm::elm
+{
+    /**
+     * @brief Abstract interface for Expert Language Models.
+     *
+     * Each ELM provides a specific cognitive role in a multi-step chain.
+     * Implementations are swappable per doc 03 §5.2.1.
+     */
+    class IELM
+    {
+        public:
+        virtual ~IELM() = default;
+
+        /// @return Human-readable name of this ELM.
+        virtual std::string GetName() const = 0;
+
+        /// @return The ELM role this instance fulfills.
+        virtual ELMRole GetRole() const = 0;
+
+        /// @return True if the ELM model has been loaded.
+        virtual bool IsLoaded() const = 0;
+
+        /**
+         * @brief Load the ELM model from disk (if a dedicated model path is configured).
+         * @param model_path  Path to the model file (.mnn or similar).
+         * @return            outcome::success or ModelLoadFailed.
+         */
+        virtual outcome::result<void> Load( const std::string& model_path ) = 0;
+
+        /**
+         * @brief Process input through this ELM and return refined output.
+         * @param input    Text to process (typically output of previous chain step).
+         * @param context  ELM execution context (original task, prior outputs, confidences).
+         * @return         Refined text or InferenceFailed.
+         */
+        virtual outcome::result<std::string> Process( const std::string& input, const ELMContext& context ) = 0;
+
+        /**
+         * @brief Confidence in the last Process() call.
+         * @return  Confidence score in [0, 1].
+         */
+        virtual float GetConfidence() const = 0;
+    };
+
+} // namespace sgns::neoswarm::elm
+
+#endif // NEOSWARM_ELM_IELM_HPP


### PR DESCRIPTION
## Summary

Foundation wave for Phase 7 (Expert Language Models + Router). No behavior change — types, interface, and build target only.

- Add `ELMRole` enum (10 roles: Planner, PrimaryDraft, Verifier, Arbiter, Refiner, Grounding, ToolSupport, Math, Code, Science), `ELMContext`, `ChainStep`, `ExecutionChain`, and `ExecutionMode::Chain` to `src/common/types.hpp`
- Extend `PromptFeatures` with grounding/formatting detection fields (consumed in Wave 4)
- Add `IELM` abstract interface (`src/elm/i_elm.hpp`) — swappable per architecture doc 03 §5.2.1
- Register `neoswarm_elm` static library in CMake

## Architecture

- Doc 03 §5.2 (ELM definition), doc 11 §16.8 (specialist taxonomy)
- Planning docs: `.planning/workstreams/neoswarm/phases/07-expert-language-models-router/` (CONTEXT D-05, D-08, D-09)

## Test plan

- Full build green: 80/80 targets (`build/OSX/Debug`, ninja)
- Behavioral tests for ELM types land in Wave 6 per plan 07-06

## Wave plan

Wave 1 of 6 — next: Wave 2 (RoleELM + DomainELM implementations)