### PR TITLE
fix(quantize): SGFP4 v2 spec conformance + T158 mode-selection fix + reference decoder

### DIFF
--- a/gnus-poc/quantize/__init__.py
+++ b/gnus-poc/quantize/__init__.py
@@ -6,6 +6,7 @@ Provides:
 - LaplacianWeightedError: encode-side Laplacian pyramid error analysis
 - QuadtreeEncoder: adaptive block-size selection via quadtree recursion
 - decode_v1 / decode_v2: independent reference decoder (normative semantics)
+- CodeMode / Layout: scoped wire-format enumerations (sgfp4_format)
 """
 
 from quantize.fp4_exporter import FP4Exporter
@@ -13,6 +14,7 @@ from quantize.laplacian import LaplacianWeightedError
 from quantize.manifest import ManifestBuilder
 from quantize.quadtree import QuadtreeEncoder
 from quantize.sgfp4_decoder import decode_v1, decode_v2
+from quantize.sgfp4_format import CodeMode, Layout
 
 __all__ = [
     "FP4Exporter",
@@ -21,4 +23,6 @@ __all__ = [
     "QuadtreeEncoder",
     "decode_v1",
     "decode_v2",
+    "CodeMode",
+    "Layout",
 ]

--- a/gnus-poc/quantize/__init__.py
+++ b/gnus-poc/quantize/__init__.py
@@ -5,16 +5,20 @@ Provides:
 - ManifestBuilder: provenance manifest generation with SHA256 hashing
 - LaplacianWeightedError: encode-side Laplacian pyramid error analysis
 - QuadtreeEncoder: adaptive block-size selection via quadtree recursion
+- decode_v1 / decode_v2: independent reference decoder (normative semantics)
 """
 
 from quantize.fp4_exporter import FP4Exporter
 from quantize.laplacian import LaplacianWeightedError
 from quantize.manifest import ManifestBuilder
 from quantize.quadtree import QuadtreeEncoder
+from quantize.sgfp4_decoder import decode_v1, decode_v2
 
 __all__ = [
     "FP4Exporter",
     "LaplacianWeightedError",
     "ManifestBuilder",
     "QuadtreeEncoder",
+    "decode_v1",
+    "decode_v2",
 ]

--- a/gnus-poc/quantize/fp4_exporter.py
+++ b/gnus-poc/quantize/fp4_exporter.py
@@ -1,7 +1,7 @@
 """FP4 Ultra binary exporter — SGFP4 v1 (fixed 64x64) and v2 (adaptive quadtree).
 
 Container layout v1: headers[B] | offsets[B] | codes_blob[B*2048]
-Container layout v2: magic[4] | version[1] | num_superblocks[4] |
+Container layout v2: magic[4] | version[1] | num_superblocks[4] | pad[7] |
                      superblock_offsets[B] | superblock_data[0..B-1]
 
 v1 (fixed, backward compatible):
@@ -303,12 +303,17 @@ class FP4Exporter:
     ) -> Tuple[bytes, dict]:
         """SGFP4 v2 adaptive quadtree export.
 
-        Binary format:
-            magic[4] | version[1] | num_superblocks[4] |
+        Binary format (paper Sec 6.1):
+            magic[4] | version[1] | num_superblocks[4] | pad[7] |
             superblock_offsets[B] | superblock_data[0..B-1]
 
-        Each superblock:
-            superblock_header[4] | block_headers[N*4] | payloads[var]
+        Each superblock record (paper Sec 6.2), 16-byte aligned and zero
+        padded to a 16-byte multiple:
+            sb_header[4] | split_map[12] (LAYOUT_MIXED only) |
+            block_headers[N*4] | pad[0-15] | payloads[N] (each 16B-padded)
+
+        Leaf storage order: row-major raster for uniform layouts; pre-order
+        DFS (matching the split map) for LAYOUT_MIXED.
         """
         O, I = weights.shape
         tiles_y = math.ceil(O / MACROBLOCK_SIZE)
@@ -367,6 +372,15 @@ class FP4Exporter:
         current_offset = 0
 
         for idx, (layout, blocks) in enumerate(superblock_layouts):
+            # Leaf storage order (paper Sec 6.2): uniform layouts are stored
+            # in row-major raster order of the tile grid; LAYOUT_MIXED keeps
+            # the pre-order DFS order that matches the split map.
+            if layout == LAYOUT_MIXED:
+                split_map = self._build_split_map(blocks)
+            else:
+                split_map = b""
+                blocks = sorted(blocks, key=lambda b: (b["y"], b["x"]))
+
             # Superblock header: uint32 with layout enum + reserved
             sb_header = np.uint32(layout & 0x7)
 
@@ -385,6 +399,16 @@ class FP4Exporter:
                 bh = np.uint32((int(bh) & 0xFFFFFFF0) | flags)
                 block_headers.append(bh)
 
+            # Header section: sb_header | split_map | block_headers, then
+            # zero pad to a 16-byte boundary so payloads (and therefore all
+            # absolute addresses) stay aligned (paper Sec 6.2)
+            header_section = (
+                sb_header.tobytes()
+                + split_map
+                + b"".join(bh.tobytes() for bh in block_headers)
+            )
+            header_section += b"\x00" * ((-len(header_section)) % ALIGNMENT)
+
             # Per-block payloads with 16-byte alignment per RESEARCH.md Pitfall 3
             payload_chunks = []
             for blk in blocks:
@@ -395,22 +419,22 @@ class FP4Exporter:
                     payload_bytes = payload_bytes + b'\x00' * (aligned_size - len(payload_bytes))
                 payload_chunks.append(payload_bytes)
 
-            # Assemble superblock data
-            sb_data = (
-                sb_header.tobytes()
-                + b"".join(bh.tobytes() for bh in block_headers)
-                + b"".join(payload_chunks)
-            )
+            # Assemble superblock data; pad record to a 16-byte multiple so
+            # every record offset stays 16-byte aligned (paper Sec 6.1)
+            sb_data = header_section + b"".join(payload_chunks)
+            sb_data += b"\x00" * ((-len(sb_data)) % ALIGNMENT)
 
             superblock_offsets[idx] = current_offset
             superblock_data_chunks.append(sb_data)
             current_offset += len(sb_data)
 
-        # Assemble full binary
+        # Assemble full binary: magic | version | B | 7B pad to 16-byte
+        # boundary | offset table | records (paper Sec 6.1)
         binary = (
             SGFP4_MAGIC
             + struct.pack("<B", SGFP4_VERSION_V2)
             + struct.pack("<I", B)
+            + b"\x00" * 7
             + superblock_offsets.tobytes()
             + b"".join(superblock_data_chunks)
         )
@@ -669,6 +693,60 @@ class FP4Exporter:
                 return LAYOUT_FULL_4x4
 
         return LAYOUT_MIXED
+
+    @staticmethod
+    def _build_split_map(blocks: List[dict]) -> bytes:
+        """Serialize the quadtree structure as a 12-byte split bitmap.
+
+        Per paper Sec 6.2: visiting nodes in pre-order DFS with quadrant
+        order TL, TR, BL, BR, one bit per node of size >= 8 records whether
+        that node is split (1) or a leaf (0). Nodes of size 4 cannot split
+        and contribute no bit. Bit k of the map is bit (k mod 32) of word
+        floor(k/32); upper bits are zero.
+
+        Args:
+            blocks: Leaf block dicts (with y, x, size) in pre-order DFS
+                    order, as emitted by QuadtreeEncoder.encode().
+
+        Returns:
+            12 bytes: three little-endian uint32 words.
+        """
+        bits: List[int] = []
+        idx = [0]
+
+        def walk(y: int, x: int, size: int):
+            if size == 4:
+                # 4x4 nodes cannot split and contribute no bit; the leaf
+                # must be here.
+                blk = blocks[idx[0]]
+                assert (blk["y"], blk["x"], blk["size"]) == (y, x, 4), (
+                    f"split-map walk expected 4x4 leaf at ({y},{x}), "
+                    f"got {blk}"
+                )
+                idx[0] += 1
+                return
+            blk = blocks[idx[0]]
+            if (blk["y"], blk["x"], blk["size"]) == (y, x, size):
+                bits.append(0)  # leaf
+                idx[0] += 1
+                return
+            bits.append(1)  # split
+            half = size // 2
+            for dy in (0, half):
+                for dx in (0, half):
+                    walk(y + dy, x + dx, half)
+
+        walk(0, 0, MACROBLOCK_SIZE)
+        assert idx[0] == len(blocks), (
+            f"split map consumed {idx[0]} of {len(blocks)} leaves"
+        )
+        assert len(bits) <= 85, f"split map needs {len(bits)} bits (max 85)"
+
+        words = [0, 0, 0]
+        for k, bit in enumerate(bits):
+            if bit:
+                words[k // 32] |= 1 << (k % 32)
+        return struct.pack("<3I", *words)
 
     # ==================================================================
     # Manifest generation (v2 only)

--- a/gnus-poc/quantize/fp4_exporter.py
+++ b/gnus-poc/quantize/fp4_exporter.py
@@ -32,30 +32,48 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
+from quantize.sgfp4_format import (
+    ALIGNMENT,
+    FP16_MAX,
+    HEADER_CLEAR_FLAGS_MASK,
+    LEAF_MODE_MASK,
+    MACROBLOCK_SIZE,
+    MIN_LEAF_SIZE,
+    OFFSET_FLAG_MASK,
+    PAYLOAD_BYTES,
+    PAYLOAD_U32,
+    SB_HEADER_LAYOUT_MASK,
+    SGFP4_MAGIC,
+    SGFP4_VERSION_V2,
+    SPLIT_MAP_BYTES,
+    SPLIT_MAP_MAX_BITS,
+    SPLIT_MAP_WORDS,
+    UINT32_BITS,
+    V2_HEADER_PAD_BYTES,
+    CodeMode,
+    Layout,
+)
+
 
 # ---------------------------------------------------------------------------
-# Constants
+# Backward-compatible aliases (std. §4.1: scoped enums are the canonical
+# names; plain-int aliases kept for existing callers and tests)
 # ---------------------------------------------------------------------------
 
-MACROBLOCK_SIZE = 64          # Superblock outer size (always 64 in both v1 and v2)
-PAYLOAD_BYTES = 2048          # v1 fixed payload size
-PAYLOAD_U32 = PAYLOAD_BYTES // 4
-ALIGNMENT = 16
+MODE_FP4_AFFINE = CodeMode.FP4_AFFINE
+MODE_T158_AFFINE = CodeMode.T158_AFFINE
 
-MODE_FP4_AFFINE = 0
-MODE_T158_AFFINE = 1
+LAYOUT_UNIFORM_64 = Layout.UNIFORM_64
+LAYOUT_UNIFORM_32 = Layout.UNIFORM_32
+LAYOUT_UNIFORM_16 = Layout.UNIFORM_16
+LAYOUT_UNIFORM_8 = Layout.UNIFORM_8
+LAYOUT_MIXED = Layout.MIXED
+LAYOUT_FULL_4x4 = Layout.FULL_4X4
 
-# v2 magic header bytes
-SGFP4_MAGIC = b'SGF4'
-SGFP4_VERSION_V2 = 0x02
 
-# v2 layout enum constants (D-02)
-LAYOUT_UNIFORM_64 = 0    # one 64x64 block
-LAYOUT_UNIFORM_32 = 1    # four 32x32 blocks
-LAYOUT_UNIFORM_16 = 2    # sixteen 16x16 blocks
-LAYOUT_UNIFORM_8  = 3    # sixty-four 8x8 blocks
-LAYOUT_MIXED      = 4    # mixed quadtree
-LAYOUT_FULL_4x4   = 5    # full 4x4 stamps (256 blocks)
+def _zero_pad(data: bytes, alignment: int = ALIGNMENT) -> bytes:
+    """Append zero bytes until len(data) is a multiple of alignment."""
+    return data + b"\x00" * ((-len(data)) % alignment)
 
 # Default v2 thresholds (per RESEARCH.md Pattern 4 / D-08)
 DEFAULT_V2_THRESHOLDS = {
@@ -252,12 +270,15 @@ class FP4Exporter:
                     mode = MODE_FP4_AFFINE
                     selected = fp4_result
 
-                scale = float(np.clip(selected["scale"], -65504, 65504))
-                bias = float(np.clip(selected["bias"], -65504, 65504))
+                scale = float(np.clip(selected["scale"], -FP16_MAX, FP16_MAX))
+                bias = float(np.clip(selected["bias"], -FP16_MAX, FP16_MAX))
                 headers[block_idx] = self._pack_half2(scale, bias)
 
                 assert current_offset % ALIGNMENT == 0
-                offsets[block_idx] = (current_offset & ~0xF) | (mode & 0xF)
+                offsets[block_idx] = (
+                    (current_offset & ~OFFSET_FLAG_MASK)
+                    | (int(mode) & OFFSET_FLAG_MASK)
+                )
 
                 block_payload = selected["payload"]
                 assert len(block_payload) == PAYLOAD_U32
@@ -375,54 +396,47 @@ class FP4Exporter:
             # Leaf storage order (paper Sec 6.2): uniform layouts are stored
             # in row-major raster order of the tile grid; LAYOUT_MIXED keeps
             # the pre-order DFS order that matches the split map.
-            if layout == LAYOUT_MIXED:
+            if layout == Layout.MIXED:
                 split_map = self._build_split_map(blocks)
             else:
                 split_map = b""
                 blocks = sorted(blocks, key=lambda b: (b["y"], b["x"]))
 
             # Superblock header: uint32 with layout enum + reserved
-            sb_header = np.uint32(layout & 0x7)
+            sb_header = np.uint32(int(layout) & SB_HEADER_LAYOUT_MASK)
 
             # Per-block headers
             block_headers = []
             for blk in blocks:
                 bh = self._pack_half2(
-                    float(np.clip(blk["scale"], -65504, 65504)),
-                    float(np.clip(blk["bias"], -65504, 65504)),
+                    float(np.clip(blk["scale"], -FP16_MAX, FP16_MAX)),
+                    float(np.clip(blk["bias"], -FP16_MAX, FP16_MAX)),
                 )
                 # 4 LSB offset flags per D-06:
                 #   bit 0 = mode (FP4=0, T158=1)
                 #   bit 1 = log mode (reserved=0 per D-05)
                 #   bits 2-3 = reserved (0)
-                flags = (blk["mode"] & 0x1)
-                bh = np.uint32((int(bh) & 0xFFFFFFF0) | flags)
+                flags = int(blk["mode"]) & LEAF_MODE_MASK
+                bh = np.uint32((int(bh) & HEADER_CLEAR_FLAGS_MASK) | flags)
                 block_headers.append(bh)
 
             # Header section: sb_header | split_map | block_headers, then
             # zero pad to a 16-byte boundary so payloads (and therefore all
             # absolute addresses) stay aligned (paper Sec 6.2)
-            header_section = (
+            header_section = _zero_pad(
                 sb_header.tobytes()
                 + split_map
                 + b"".join(bh.tobytes() for bh in block_headers)
             )
-            header_section += b"\x00" * ((-len(header_section)) % ALIGNMENT)
 
             # Per-block payloads with 16-byte alignment per RESEARCH.md Pitfall 3
-            payload_chunks = []
-            for blk in blocks:
-                payload_bytes = blk["payload"].tobytes()
-                # 16-byte alignment
-                aligned_size = (len(payload_bytes) + (ALIGNMENT - 1)) & ~(ALIGNMENT - 1)
-                if aligned_size > len(payload_bytes):
-                    payload_bytes = payload_bytes + b'\x00' * (aligned_size - len(payload_bytes))
-                payload_chunks.append(payload_bytes)
+            payload_chunks = [
+                _zero_pad(blk["payload"].tobytes()) for blk in blocks
+            ]
 
             # Assemble superblock data; pad record to a 16-byte multiple so
             # every record offset stays 16-byte aligned (paper Sec 6.1)
-            sb_data = header_section + b"".join(payload_chunks)
-            sb_data += b"\x00" * ((-len(sb_data)) % ALIGNMENT)
+            sb_data = _zero_pad(header_section + b"".join(payload_chunks))
 
             superblock_offsets[idx] = current_offset
             superblock_data_chunks.append(sb_data)
@@ -434,7 +448,7 @@ class FP4Exporter:
             SGFP4_MAGIC
             + struct.pack("<B", SGFP4_VERSION_V2)
             + struct.pack("<I", B)
-            + b"\x00" * 7
+            + b"\x00" * V2_HEADER_PAD_BYTES
             + superblock_offsets.tobytes()
             + b"".join(superblock_data_chunks)
         )
@@ -662,37 +676,37 @@ class FP4Exporter:
             return n_weights // 16
 
     @staticmethod
-    def _classify_layout(blocks: List[dict]) -> int:
+    def _classify_layout(blocks: List[dict]) -> Layout:
         """Classify superblock layout from quadtree output blocks (D-02).
 
         Args:
             blocks: List of block dicts from QuadtreeEncoder.encode().
 
         Returns:
-            Layout enum value (0-5).
+            Layout enum member.
         """
         sizes = [b["size"] for b in blocks]
         unique_sizes = set(sizes)
 
         if len(unique_sizes) == 1:
             size = sizes[0]
-            expected_count = (64 // size) * (64 // size)
+            expected_count = (MACROBLOCK_SIZE // size) * (MACROBLOCK_SIZE // size)
             if len(blocks) != expected_count:
                 # All same size but wrong count — treat as mixed
-                return LAYOUT_MIXED
+                return Layout.MIXED
 
             if size == 64:
-                return LAYOUT_UNIFORM_64
+                return Layout.UNIFORM_64
             elif size == 32:
-                return LAYOUT_UNIFORM_32
+                return Layout.UNIFORM_32
             elif size == 16:
-                return LAYOUT_UNIFORM_16
+                return Layout.UNIFORM_16
             elif size == 8:
-                return LAYOUT_UNIFORM_8
-            elif size == 4:
-                return LAYOUT_FULL_4x4
+                return Layout.UNIFORM_8
+            elif size == MIN_LEAF_SIZE:
+                return Layout.FULL_4X4
 
-        return LAYOUT_MIXED
+        return Layout.MIXED
 
     @staticmethod
     def _build_split_map(blocks: List[dict]) -> bytes:
@@ -712,23 +726,22 @@ class FP4Exporter:
             12 bytes: three little-endian uint32 words.
         """
         bits: List[int] = []
-        idx = [0]
+        leaf_index = 0
 
-        def walk(y: int, x: int, size: int):
-            if size == 4:
+        def walk(y: int, x: int, size: int) -> None:
+            nonlocal leaf_index
+            blk = blocks[leaf_index]
+            if size == MIN_LEAF_SIZE:
                 # 4x4 nodes cannot split and contribute no bit; the leaf
                 # must be here.
-                blk = blocks[idx[0]]
-                assert (blk["y"], blk["x"], blk["size"]) == (y, x, 4), (
-                    f"split-map walk expected 4x4 leaf at ({y},{x}), "
-                    f"got {blk}"
+                assert (blk["y"], blk["x"], blk["size"]) == (y, x, MIN_LEAF_SIZE), (
+                    f"split-map walk expected 4x4 leaf at ({y},{x}), got {blk}"
                 )
-                idx[0] += 1
+                leaf_index += 1
                 return
-            blk = blocks[idx[0]]
             if (blk["y"], blk["x"], blk["size"]) == (y, x, size):
                 bits.append(0)  # leaf
-                idx[0] += 1
+                leaf_index += 1
                 return
             bits.append(1)  # split
             half = size // 2
@@ -737,15 +750,17 @@ class FP4Exporter:
                     walk(y + dy, x + dx, half)
 
         walk(0, 0, MACROBLOCK_SIZE)
-        assert idx[0] == len(blocks), (
-            f"split map consumed {idx[0]} of {len(blocks)} leaves"
+        assert leaf_index == len(blocks), (
+            f"split map consumed {leaf_index} of {len(blocks)} leaves"
         )
-        assert len(bits) <= 85, f"split map needs {len(bits)} bits (max 85)"
+        assert len(bits) <= SPLIT_MAP_MAX_BITS, (
+            f"split map needs {len(bits)} bits (max {SPLIT_MAP_MAX_BITS})"
+        )
 
-        words = [0, 0, 0]
+        words = [0] * SPLIT_MAP_WORDS
         for k, bit in enumerate(bits):
-            if bit:
-                words[k // 32] |= 1 << (k % 32)
+            if bit != 0:
+                words[k // UINT32_BITS] |= 1 << (k % UINT32_BITS)
         return struct.pack("<3I", *words)
 
     # ==================================================================

--- a/gnus-poc/quantize/quadtree.py
+++ b/gnus-poc/quantize/quadtree.py
@@ -130,9 +130,12 @@ class QuadtreeEncoder:
         fp4_result = self._fit_fp4(region)
         t158_result = self._fit_t158(region)
 
-        # Compute Laplacian-weighted error for both modes
-        fp4_reconstructed = self._reconstruct(region, fp4_result)
-        t158_reconstructed = self._reconstruct(region, t158_result)
+        # Compute Laplacian-weighted error for both modes. Each mode must be
+        # reconstructed with its OWN codebook (FP4 nibble codes vs ternary
+        # thresholding) or the dual-mode decision scores T158 against the
+        # wrong error surface.
+        fp4_reconstructed = self._reconstruct(region, fp4_result, mode=0)
+        t158_reconstructed = self._reconstruct(region, t158_result, mode=1)
 
         fp4_error = self._laplacian.compute(region, fp4_reconstructed, block_size=size)
         t158_error = self._laplacian.compute(region, t158_reconstructed, block_size=size)
@@ -211,14 +214,31 @@ class QuadtreeEncoder:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _reconstruct(region: np.ndarray, result: dict) -> np.ndarray:
-        """Reconstruct a region from encode result for error computation."""
+    def _reconstruct(region: np.ndarray, result: dict, mode: int = 0) -> np.ndarray:
+        """Reconstruct a region from encode result for error computation.
+
+        Args:
+            region: 2D array of original weights.
+            result: Encode result dict with scale/bias.
+            mode: 0 = FP4_AFFINE (round-to-nearest nibble codes),
+                  1 = T158_AFFINE (ternary threshold codes). Using the wrong
+                  mode's codebook here systematically distorts the dual-mode
+                  selection error comparison.
+        """
         flat = region.ravel().astype(np.float32)
-        n = flat.size
         scale = result["scale"]
         bias = result["bias"]
-        # Reconstruct using same method as encode
-        codes = np.clip(np.round((flat - bias) / scale), -8, 7).astype(np.int8)
+        if mode == 1:
+            # T158: threshold at tau = S/2 (matches the ternary encoder and
+            # _t158_has_outlier)
+            centered = flat - bias
+            tau = 0.5 * scale
+            codes = np.zeros(flat.size, dtype=np.int8)
+            codes[centered > tau] = 1
+            codes[centered < -tau] = -1
+        else:
+            # FP4: round-to-nearest, clip to [-8, 7]
+            codes = np.clip(np.round((flat - bias) / scale), -8, 7).astype(np.int8)
         return (scale * codes.astype(np.float32) + bias).reshape(region.shape)
 
     @staticmethod

--- a/gnus-poc/quantize/quadtree.py
+++ b/gnus-poc/quantize/quadtree.py
@@ -23,6 +23,8 @@ from typing import Callable, Dict, List
 
 import numpy as np
 
+from quantize.sgfp4_format import CodeMode
+
 
 # Maximum recursion depth (64 -> 32 -> 16 -> 8 -> 4)
 _kMaxRecursionDepth = 4
@@ -134,8 +136,12 @@ class QuadtreeEncoder:
         # reconstructed with its OWN codebook (FP4 nibble codes vs ternary
         # thresholding) or the dual-mode decision scores T158 against the
         # wrong error surface.
-        fp4_reconstructed = self._reconstruct(region, fp4_result, mode=0)
-        t158_reconstructed = self._reconstruct(region, t158_result, mode=1)
+        fp4_reconstructed = self._reconstruct(
+            region, fp4_result, mode=CodeMode.FP4_AFFINE
+        )
+        t158_reconstructed = self._reconstruct(
+            region, t158_result, mode=CodeMode.T158_AFFINE
+        )
 
         fp4_error = self._laplacian.compute(region, fp4_reconstructed, block_size=size)
         t158_error = self._laplacian.compute(region, t158_reconstructed, block_size=size)
@@ -151,11 +157,11 @@ class QuadtreeEncoder:
         if t158_preferred:
             selected = t158_result
             selected_error = t158_error
-            mode = 1  # MODE_T158_AFFINE
+            mode = CodeMode.T158_AFFINE
         else:
             selected = fp4_result
             selected_error = fp4_error
-            mode = 0  # MODE_FP4_AFFINE
+            mode = CodeMode.FP4_AFFINE
 
         max_mse = threshold.get("max_mse", 0.0005)
 
@@ -214,21 +220,25 @@ class QuadtreeEncoder:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _reconstruct(region: np.ndarray, result: dict, mode: int = 0) -> np.ndarray:
+    def _reconstruct(
+        region: np.ndarray,
+        result: dict,
+        mode: CodeMode = CodeMode.FP4_AFFINE,
+    ) -> np.ndarray:
         """Reconstruct a region from encode result for error computation.
 
         Args:
             region: 2D array of original weights.
             result: Encode result dict with scale/bias.
-            mode: 0 = FP4_AFFINE (round-to-nearest nibble codes),
-                  1 = T158_AFFINE (ternary threshold codes). Using the wrong
-                  mode's codebook here systematically distorts the dual-mode
-                  selection error comparison.
+            mode: CodeMode.FP4_AFFINE (round-to-nearest nibble codes) or
+                  CodeMode.T158_AFFINE (ternary threshold codes). Using the
+                  wrong mode's codebook here systematically distorts the
+                  dual-mode selection error comparison.
         """
         flat = region.ravel().astype(np.float32)
         scale = result["scale"]
         bias = result["bias"]
-        if mode == 1:
+        if mode == CodeMode.T158_AFFINE:
             # T158: threshold at tau = S/2 (matches the ternary encoder and
             # _t158_has_outlier)
             centered = flat - bias

--- a/gnus-poc/quantize/sgfp4_decoder.py
+++ b/gnus-poc/quantize/sgfp4_decoder.py
@@ -15,7 +15,9 @@ implementation (paper Sec 8 conformance-vector use case):
   - Sec 6.2  v2 record: sb_header | split map (MIXED) | block headers |
              pad | 16B-padded payloads; Eq (6) beta flag truncation
 
-Decoders raise SGFP4FormatError on malformed streams.
+All wire-format constants come from quantize.sgfp4_format; this module
+contains decode logic only. Decoders raise SGFP4FormatError on malformed
+streams.
 """
 
 import math
@@ -24,30 +26,51 @@ from typing import List, Tuple
 
 import numpy as np
 
-MACROBLOCK_SIZE = 64
-PAYLOAD_BYTES = 2048
-PAYLOAD_U32 = PAYLOAD_BYTES // 4
-ALIGNMENT = 16
+from quantize.sgfp4_format import (
+    ALIGNMENT,
+    BETA_TRUNC_MASK,
+    FP4_BITS_PER_CODE,
+    FP4_CODE_BIAS,
+    FP4_CODES_PER_WORD,
+    FP4_NIBBLE_MASK,
+    FP4_SIGN_THRESHOLD,
+    HALF_MASK,
+    HALF_SHIFT,
+    LEAF_FLAG_MASK,
+    LEAF_MODE_MASK,
+    LEAF_RESERVED_MASK,
+    MACROBLOCK_SIZE,
+    MIN_LEAF_SIZE,
+    OFFSET_FLAG_MASK,
+    OFFSET_MODE_MASK,
+    OFFSET_RESERVED_MASK,
+    PAYLOAD_BYTES,
+    PAYLOAD_U32,
+    SB_HEADER_LAYOUT_MASK,
+    SB_HEADER_RESERVED_SHIFT,
+    SGFP4_MAGIC,
+    SGFP4_VERSION_V2,
+    SPLIT_MAP_BYTES,
+    SPLIT_MAP_MAX_BITS,
+    T158_BITS_PER_CODE,
+    T158_CODES_PER_WORD,
+    T158_SYMBOL_MASK,
+    T158_SYMBOL_NEG,
+    T158_SYMBOL_POS,
+    UINT32_BITS,
+    V2_FIXED_HEADER_BYTES,
+    V2_HEADER_PAD_BYTES,
+    CodeMode,
+    Layout,
+)
 
-MODE_FP4_AFFINE = 0
-MODE_T158_AFFINE = 1
-
-SGFP4_MAGIC = b"SGF4"
-SGFP4_VERSION_V2 = 0x02
-
-LAYOUT_UNIFORM_64 = 0
-LAYOUT_UNIFORM_32 = 1
-LAYOUT_UNIFORM_16 = 2
-LAYOUT_UNIFORM_8 = 3
-LAYOUT_MIXED = 4
-LAYOUT_FULL_4x4 = 5
-
+# Uniform layouts imply both the leaf geometry and the leaf count
 _LAYOUT_LEAF_SIZE = {
-    LAYOUT_UNIFORM_64: 64,
-    LAYOUT_UNIFORM_32: 32,
-    LAYOUT_UNIFORM_16: 16,
-    LAYOUT_UNIFORM_8: 8,
-    LAYOUT_FULL_4x4: 4,
+    Layout.UNIFORM_64: 64,
+    Layout.UNIFORM_32: 32,
+    Layout.UNIFORM_16: 16,
+    Layout.UNIFORM_8: 8,
+    Layout.FULL_4X4: 4,
 }
 
 
@@ -56,34 +79,38 @@ class SGFP4FormatError(ValueError):
 
 
 def _half_from_bits(bits: int) -> float:
-    return struct.unpack("<e", struct.pack("<H", bits & 0xFFFF))[0]
+    return struct.unpack("<e", struct.pack("<H", bits & HALF_MASK))[0]
 
 
 def int4_to_int(nib: int) -> int:
-    """Two's-complement 4-bit code (paper Listing 1)."""
-    nib &= 0xF
-    return nib if nib < 8 else nib - 16
+    """Two's-complement 4-bit code (paper Sec 4.3, Listing 1)."""
+    nib &= FP4_NIBBLE_MASK
+    return nib if nib < FP4_SIGN_THRESHOLD else nib - FP4_CODE_BIAS
 
 
 def sym2_to_ternary(sym: int) -> int:
     """2-bit ternary symbol map; 11 is reserved and decodes as 0."""
-    sym &= 0x3
-    if sym == 1:
+    sym &= T158_SYMBOL_MASK
+    if sym == T158_SYMBOL_POS:
         return 1
-    if sym == 2:
+    if sym == T158_SYMBOL_NEG:
         return -1
     return 0
 
 
-def _decode_codes(words: np.ndarray, mode: int, n_weights: int) -> np.ndarray:
+def _decode_codes(words: np.ndarray, mode: CodeMode, n_weights: int) -> np.ndarray:
     """Normative code extraction (paper Sec 4.3, Eq. 3 and 4)."""
     codes = np.empty(n_weights, dtype=np.int32)
-    if mode == MODE_FP4_AFFINE:
+    if mode == CodeMode.FP4_AFFINE:
         for i in range(n_weights):
-            codes[i] = int4_to_int(int(words[i >> 3] >> (4 * (i & 7))))
+            word = words[i // FP4_CODES_PER_WORD]
+            shift = FP4_BITS_PER_CODE * (i % FP4_CODES_PER_WORD)
+            codes[i] = int4_to_int(int(word >> shift))
     else:
         for i in range(n_weights):
-            codes[i] = sym2_to_ternary(int(words[i >> 4] >> (2 * (i & 15))))
+            word = words[i // T158_CODES_PER_WORD]
+            shift = T158_BITS_PER_CODE * (i % T158_CODES_PER_WORD)
+            codes[i] = sym2_to_ternary(int(word >> shift))
     return codes
 
 
@@ -92,39 +119,52 @@ def decode_v1(binary: bytes, O: int, I: int) -> np.ndarray:
 
     Args:
         binary: headers[B] | offsets[B] | codes blob (B*2048 bytes).
-        O, I: unpadded tensor shape (carried by the model manifest).
+        O: unpadded output-channel count (carried by the model manifest).
+        I: unpadded input-channel count.
+
+    Returns:
+        Decoded float32 array of shape (O, I).
+
+    Raises:
+        SGFP4FormatError: on size mismatches or reserved-bit violations.
     """
     binary = bytes(binary)
-    ty = math.ceil(O / MACROBLOCK_SIZE)
-    tx = math.ceil(I / MACROBLOCK_SIZE)
-    B = ty * tx
-    if len(binary) != 8 * B + B * PAYLOAD_BYTES:
+    tiles_y = math.ceil(O / MACROBLOCK_SIZE)
+    tiles_x = math.ceil(I / MACROBLOCK_SIZE)
+    B = tiles_y * tiles_x
+    expected_bytes = B * 8 + B * PAYLOAD_BYTES  # headers + offsets + blob
+    if len(binary) != expected_bytes:
         raise SGFP4FormatError(
-            f"v1 stream is {len(binary)} bytes, expected {8 * B + B * PAYLOAD_BYTES}"
+            f"v1 stream is {len(binary)} bytes, expected {expected_bytes}"
         )
 
     headers = np.frombuffer(binary, dtype=np.uint32, count=B, offset=0)
-    offsets = np.frombuffer(binary, dtype=np.uint32, count=B, offset=4 * B)
-    blob = binary[8 * B:]
+    offsets = np.frombuffer(binary, dtype=np.uint32, count=B, offset=B * 4)
+    blob = binary[B * 8:]
 
-    out = np.zeros((ty * MACROBLOCK_SIZE, tx * MACROBLOCK_SIZE), dtype=np.float32)
+    out = np.zeros(
+        (tiles_y * MACROBLOCK_SIZE, tiles_x * MACROBLOCK_SIZE), dtype=np.float32
+    )
     for b in range(B):
-        h = int(headers[b])
-        S = _half_from_bits(h >> 16)
-        beta = _half_from_bits(h & 0xFFFF)
-        off = int(offsets[b])
-        flags = off & 0xF
-        base = off & ~0xF
-        if flags & 0xC:
+        header = int(headers[b])
+        scale = _half_from_bits(header >> HALF_SHIFT)
+        bias = _half_from_bits(header & HALF_MASK)
+
+        offset_word = int(offsets[b])
+        flags = offset_word & OFFSET_FLAG_MASK
+        base = offset_word & ~OFFSET_FLAG_MASK
+        if (flags & OFFSET_RESERVED_MASK) != 0:
             raise SGFP4FormatError(
                 f"block {b}: reserved offset flag bits 2-3 nonzero"
             )
-        mode = flags & 0x1
+        mode = CodeMode(flags & OFFSET_MODE_MASK)
+
         words = np.frombuffer(blob, dtype=np.uint32, count=PAYLOAD_U32, offset=base)
         codes = _decode_codes(words, mode, MACROBLOCK_SIZE * MACROBLOCK_SIZE)
-        by, bx = divmod(b, tx)
+
+        by, bx = divmod(b, tiles_x)
         tile = (
-            np.float32(S) * codes.astype(np.float32) + np.float32(beta)
+            np.float32(scale) * codes.astype(np.float32) + np.float32(bias)
         ).reshape(MACROBLOCK_SIZE, MACROBLOCK_SIZE)
         out[
             by * MACROBLOCK_SIZE:(by + 1) * MACROBLOCK_SIZE,
@@ -137,25 +177,29 @@ def _parse_split_map(buf: bytes) -> List[Tuple[int, int, int]]:
     """Rebuild leaf (y, x, size) list from a 12-byte split bitmap.
 
     Pre-order DFS, quadrant order TL, TR, BL, BR; one bit per node of
-    size >= 8 (1 = split, 0 = leaf); 4x4 nodes contribute no bit.
+    size >= 8 (1 = split, 0 = leaf); 4x4 nodes contribute no bit
+    (paper Sec 6.2).
     """
-    if len(buf) < 12:
+    if len(buf) < SPLIT_MAP_BYTES:
         raise SGFP4FormatError("split map truncated")
-    w0, w1, w2 = struct.unpack_from("<3I", buf, 0)
-    words = (w0, w1, w2)
+    words = struct.unpack_from("<3I", buf, 0)
     leaves: List[Tuple[int, int, int]] = []
-    bitpos = [0]
+    bit_pos = 0
 
-    def walk(y: int, x: int, size: int):
-        if size == 4:
+    def walk(y: int, x: int, size: int) -> None:
+        nonlocal bit_pos
+        if size == MIN_LEAF_SIZE:
             leaves.append((y, x, size))
             return
-        k = bitpos[0]
-        if k >= 85:
-            raise SGFP4FormatError("split map overrun (>85 bits)")
-        bitpos[0] += 1
-        split = (words[k // 32] >> (k % 32)) & 1
-        if split:
+        if bit_pos >= SPLIT_MAP_MAX_BITS:
+            raise SGFP4FormatError(
+                f"split map overrun (>{SPLIT_MAP_MAX_BITS} bits)"
+            )
+        word_index = bit_pos // UINT32_BITS
+        bit_index = bit_pos % UINT32_BITS
+        bit_pos += 1
+        split = (words[word_index] >> bit_index) & 0x1
+        if split != 0:
             half = size // 2
             for dy in (0, half):
                 for dx in (0, half):
@@ -167,12 +211,45 @@ def _parse_split_map(buf: bytes) -> List[Tuple[int, int, int]]:
     return leaves
 
 
+def _record_leaves(
+    binary: bytes, layout: Layout, pos: int
+) -> Tuple[List[Tuple[int, int, int]], int]:
+    """Resolve the leaf list of one v2 record per paper Sec 6.2.
+
+    Uniform layouts imply row-major raster order; LAYOUT_MIXED consumes a
+    12-byte split map and yields leaves in pre-order DFS order.
+
+    Returns:
+        (leaves, new_pos): leaf (y, x, size) list and the offset just past
+        the split map (unchanged for uniform layouts).
+    """
+    if layout == Layout.MIXED:
+        leaves = _parse_split_map(binary[pos:pos + SPLIT_MAP_BYTES])
+        return leaves, pos + SPLIT_MAP_BYTES
+    if layout in _LAYOUT_LEAF_SIZE:
+        leaf_size = _LAYOUT_LEAF_SIZE[layout]
+        leaves = [
+            (ry, rx, leaf_size)
+            for ry in range(0, MACROBLOCK_SIZE, leaf_size)
+            for rx in range(0, MACROBLOCK_SIZE, leaf_size)
+        ]
+        return leaves, pos
+    raise SGFP4FormatError(f"unknown layout {int(layout)}")
+
+
 def decode_v2(binary: bytes, O: int, I: int) -> np.ndarray:
     """Decode a v2 quadtree-adaptive container to a float32 (O, I) tensor.
 
     Args:
         binary: self-framed v2 stream (paper Sec 6.1).
-        O, I: unpadded tensor shape (carried by the model manifest).
+        O: unpadded output-channel count (carried by the model manifest).
+        I: unpadded input-channel count.
+
+    Returns:
+        Decoded float32 array of shape (O, I).
+
+    Raises:
+        SGFP4FormatError: on framing, alignment, or reserved-bit violations.
     """
     binary = bytes(binary)
     if binary[:4] != SGFP4_MAGIC:
@@ -180,17 +257,23 @@ def decode_v2(binary: bytes, O: int, I: int) -> np.ndarray:
     if binary[4] != SGFP4_VERSION_V2:
         raise SGFP4FormatError(f"bad version {binary[4]:#x}")
     B = struct.unpack_from("<I", binary, 5)[0]
-    if binary[9:16] != b"\x00" * 7:
+    pad = binary[9:V2_FIXED_HEADER_BYTES]
+    if pad != b"\x00" * V2_HEADER_PAD_BYTES:
         raise SGFP4FormatError("missing 7-byte header pad (Sec 6.1)")
-    rec_offs = [struct.unpack_from("<I", binary, 16 + 4 * i)[0] for i in range(B)]
-    record_region = 16 + 4 * B
+    rec_offs = [
+        struct.unpack_from("<I", binary, V2_FIXED_HEADER_BYTES + 4 * i)[0]
+        for i in range(B)
+    ]
+    record_region = V2_FIXED_HEADER_BYTES + 4 * B
 
-    ty = math.ceil(O / MACROBLOCK_SIZE)
-    tx = math.ceil(I / MACROBLOCK_SIZE)
-    if ty * tx != B:
-        raise SGFP4FormatError(f"record count {B} != tiling {ty * tx}")
+    tiles_y = math.ceil(O / MACROBLOCK_SIZE)
+    tiles_x = math.ceil(I / MACROBLOCK_SIZE)
+    if tiles_y * tiles_x != B:
+        raise SGFP4FormatError(f"record count {B} != tiling {tiles_y * tiles_x}")
 
-    out = np.zeros((ty * MACROBLOCK_SIZE, tx * MACROBLOCK_SIZE), dtype=np.float32)
+    out = np.zeros(
+        (tiles_y * MACROBLOCK_SIZE, tiles_x * MACROBLOCK_SIZE), dtype=np.float32
+    )
     for b in range(B):
         if rec_offs[b] % ALIGNMENT != 0:
             raise SGFP4FormatError(
@@ -198,52 +281,50 @@ def decode_v2(binary: bytes, O: int, I: int) -> np.ndarray:
             )
         base = record_region + rec_offs[b]
         sb_header = struct.unpack_from("<I", binary, base)[0]
-        layout = sb_header & 0x7
-        if sb_header >> 3:
+        layout = Layout(sb_header & SB_HEADER_LAYOUT_MASK)
+        if (sb_header >> SB_HEADER_RESERVED_SHIFT) != 0:
             raise SGFP4FormatError(f"record {b}: sb_header reserved bits set")
-        pos = base + 4
 
-        if layout == LAYOUT_MIXED:
-            leaves = _parse_split_map(binary[pos:pos + 12])
-            pos += 12
-        elif layout in _LAYOUT_LEAF_SIZE:
-            leaf = _LAYOUT_LEAF_SIZE[layout]
-            # Uniform layouts: leaves in row-major raster order (Sec 6.2)
-            leaves = [
-                (ry, rx, leaf)
-                for ry in range(0, MACROBLOCK_SIZE, leaf)
-                for rx in range(0, MACROBLOCK_SIZE, leaf)
-            ]
-        else:
-            raise SGFP4FormatError(f"record {b}: unknown layout {layout}")
+        leaves, pos = _record_leaves(binary, layout, base + 4)
 
-        N = len(leaves)
-        hdrs = [struct.unpack_from("<I", binary, pos + 4 * i)[0] for i in range(N)]
-        pos += 4 * N
-        hdr_pad = (-(pos - base)) % ALIGNMENT
-        if binary[pos:pos + hdr_pad] != b"\x00" * hdr_pad:
+        block_headers = [
+            struct.unpack_from("<I", binary, pos + 4 * i)[0]
+            for i in range(len(leaves))
+        ]
+        pos += 4 * len(leaves)
+        header_pad = (-(pos - base)) % ALIGNMENT
+        if binary[pos:pos + header_pad] != b"\x00" * header_pad:
             raise SGFP4FormatError(f"record {b}: header pad missing/nonzero")
-        pos += hdr_pad
+        pos += header_pad
 
-        by, bx = divmod(b, tx)
-        for (y, x, size), h in zip(leaves, hdrs):
-            S = _half_from_bits(h >> 16)
-            beta = _half_from_bits(h & 0xFFF0)  # Eq (6): flag truncation
-            flags = h & 0xF
-            if flags & 0xE:
+        by, bx = divmod(b, tiles_x)
+        for (y, x, size), header in zip(leaves, block_headers):
+            scale = _half_from_bits(header >> HALF_SHIFT)
+            bias = _half_from_bits(header & BETA_TRUNC_MASK)  # Eq (6)
+            flags = header & LEAF_FLAG_MASK
+            if (flags & LEAF_RESERVED_MASK) != 0:
                 raise SGFP4FormatError(
                     f"record {b} leaf ({y},{x}): reserved header flag bits set"
                 )
-            mode = flags & 0x1
-            n_w = size * size
-            n_words = n_w // 8 if mode == MODE_FP4_AFFINE else n_w // 16
-            n_bytes = ((n_words * 4 + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT
-            words = np.frombuffer(binary, dtype=np.uint32, count=n_words, offset=pos)
-            codes = _decode_codes(words, mode, n_w)
+            mode = CodeMode(flags & LEAF_MODE_MASK)
+
+            n_weights = size * size
+            if mode == CodeMode.FP4_AFFINE:
+                n_words = n_weights // FP4_CODES_PER_WORD
+            else:
+                n_words = n_weights // T158_CODES_PER_WORD
+            payload_bytes = n_words * 4
+            n_bytes = payload_bytes + (-payload_bytes) % ALIGNMENT
+            words = np.frombuffer(
+                binary, dtype=np.uint32, count=n_words, offset=pos
+            )
+            codes = _decode_codes(words, mode, n_weights)
             tile = (
-                np.float32(S) * codes.astype(np.float32) + np.float32(beta)
+                np.float32(scale) * codes.astype(np.float32) + np.float32(bias)
             ).reshape(size, size)
-            out[by * MACROBLOCK_SIZE + y:by * MACROBLOCK_SIZE + y + size,
-                bx * MACROBLOCK_SIZE + x:bx * MACROBLOCK_SIZE + x + size] = tile
+            out[
+                by * MACROBLOCK_SIZE + y:by * MACROBLOCK_SIZE + y + size,
+                bx * MACROBLOCK_SIZE + x:bx * MACROBLOCK_SIZE + x + size,
+            ] = tile
             pos += n_bytes
     return out[:O, :I]

--- a/gnus-poc/quantize/sgfp4_decoder.py
+++ b/gnus-poc/quantize/sgfp4_decoder.py
@@ -1,0 +1,249 @@
+"""Reference SGFP4 decoder — normative decode semantics.
+
+Implements the closed decode specification of "SGFP4: Adaptive Dual-Mode
+Macroblock Quantization with GPU-Friendly Unpacking and Verifiable Decode
+Semantics" so that containers can be replayed bit-exactly by an independent
+implementation (paper Sec 8 conformance-vector use case):
+
+  - Sec 3.2  affine reconstruction w = S*c + beta; FP16 (S, beta) packed
+             scale-in-high-halfword (packHalf2x16 order)
+  - Sec 4    v1 profile: headers[B] | offsets[B] | 2048-byte payload blob;
+             mode flag in bit 0 of the 16-byte-aligned offsets
+  - Sec 4.3  normative code ordering (nibble i at bit 4*(i mod 8); ternary
+             symbol i at bit 2*(i mod 16); 11 reserved -> 0)
+  - Sec 6.1  v2 framing: 'SGF4' | 0x02 | B(u32) | 7B pad | record_offsets[B]
+  - Sec 6.2  v2 record: sb_header | split map (MIXED) | block headers |
+             pad | 16B-padded payloads; Eq (6) beta flag truncation
+
+Decoders raise SGFP4FormatError on malformed streams.
+"""
+
+import math
+import struct
+from typing import List, Tuple
+
+import numpy as np
+
+MACROBLOCK_SIZE = 64
+PAYLOAD_BYTES = 2048
+PAYLOAD_U32 = PAYLOAD_BYTES // 4
+ALIGNMENT = 16
+
+MODE_FP4_AFFINE = 0
+MODE_T158_AFFINE = 1
+
+SGFP4_MAGIC = b"SGF4"
+SGFP4_VERSION_V2 = 0x02
+
+LAYOUT_UNIFORM_64 = 0
+LAYOUT_UNIFORM_32 = 1
+LAYOUT_UNIFORM_16 = 2
+LAYOUT_UNIFORM_8 = 3
+LAYOUT_MIXED = 4
+LAYOUT_FULL_4x4 = 5
+
+_LAYOUT_LEAF_SIZE = {
+    LAYOUT_UNIFORM_64: 64,
+    LAYOUT_UNIFORM_32: 32,
+    LAYOUT_UNIFORM_16: 16,
+    LAYOUT_UNIFORM_8: 8,
+    LAYOUT_FULL_4x4: 4,
+}
+
+
+class SGFP4FormatError(ValueError):
+    """Raised when a container violates the normative SGFP4 layout."""
+
+
+def _half_from_bits(bits: int) -> float:
+    return struct.unpack("<e", struct.pack("<H", bits & 0xFFFF))[0]
+
+
+def int4_to_int(nib: int) -> int:
+    """Two's-complement 4-bit code (paper Listing 1)."""
+    nib &= 0xF
+    return nib if nib < 8 else nib - 16
+
+
+def sym2_to_ternary(sym: int) -> int:
+    """2-bit ternary symbol map; 11 is reserved and decodes as 0."""
+    sym &= 0x3
+    if sym == 1:
+        return 1
+    if sym == 2:
+        return -1
+    return 0
+
+
+def _decode_codes(words: np.ndarray, mode: int, n_weights: int) -> np.ndarray:
+    """Normative code extraction (paper Sec 4.3, Eq. 3 and 4)."""
+    codes = np.empty(n_weights, dtype=np.int32)
+    if mode == MODE_FP4_AFFINE:
+        for i in range(n_weights):
+            codes[i] = int4_to_int(int(words[i >> 3] >> (4 * (i & 7))))
+    else:
+        for i in range(n_weights):
+            codes[i] = sym2_to_ternary(int(words[i >> 4] >> (2 * (i & 15))))
+    return codes
+
+
+def decode_v1(binary: bytes, O: int, I: int) -> np.ndarray:
+    """Decode a v1 fixed-payload container to a float32 (O, I) tensor.
+
+    Args:
+        binary: headers[B] | offsets[B] | codes blob (B*2048 bytes).
+        O, I: unpadded tensor shape (carried by the model manifest).
+    """
+    binary = bytes(binary)
+    ty = math.ceil(O / MACROBLOCK_SIZE)
+    tx = math.ceil(I / MACROBLOCK_SIZE)
+    B = ty * tx
+    if len(binary) != 8 * B + B * PAYLOAD_BYTES:
+        raise SGFP4FormatError(
+            f"v1 stream is {len(binary)} bytes, expected {8 * B + B * PAYLOAD_BYTES}"
+        )
+
+    headers = np.frombuffer(binary, dtype=np.uint32, count=B, offset=0)
+    offsets = np.frombuffer(binary, dtype=np.uint32, count=B, offset=4 * B)
+    blob = binary[8 * B:]
+
+    out = np.zeros((ty * MACROBLOCK_SIZE, tx * MACROBLOCK_SIZE), dtype=np.float32)
+    for b in range(B):
+        h = int(headers[b])
+        S = _half_from_bits(h >> 16)
+        beta = _half_from_bits(h & 0xFFFF)
+        off = int(offsets[b])
+        flags = off & 0xF
+        base = off & ~0xF
+        if flags & 0xC:
+            raise SGFP4FormatError(
+                f"block {b}: reserved offset flag bits 2-3 nonzero"
+            )
+        mode = flags & 0x1
+        words = np.frombuffer(blob, dtype=np.uint32, count=PAYLOAD_U32, offset=base)
+        codes = _decode_codes(words, mode, MACROBLOCK_SIZE * MACROBLOCK_SIZE)
+        by, bx = divmod(b, tx)
+        tile = (
+            np.float32(S) * codes.astype(np.float32) + np.float32(beta)
+        ).reshape(MACROBLOCK_SIZE, MACROBLOCK_SIZE)
+        out[
+            by * MACROBLOCK_SIZE:(by + 1) * MACROBLOCK_SIZE,
+            bx * MACROBLOCK_SIZE:(bx + 1) * MACROBLOCK_SIZE,
+        ] = tile
+    return out[:O, :I]
+
+
+def _parse_split_map(buf: bytes) -> List[Tuple[int, int, int]]:
+    """Rebuild leaf (y, x, size) list from a 12-byte split bitmap.
+
+    Pre-order DFS, quadrant order TL, TR, BL, BR; one bit per node of
+    size >= 8 (1 = split, 0 = leaf); 4x4 nodes contribute no bit.
+    """
+    if len(buf) < 12:
+        raise SGFP4FormatError("split map truncated")
+    w0, w1, w2 = struct.unpack_from("<3I", buf, 0)
+    words = (w0, w1, w2)
+    leaves: List[Tuple[int, int, int]] = []
+    bitpos = [0]
+
+    def walk(y: int, x: int, size: int):
+        if size == 4:
+            leaves.append((y, x, size))
+            return
+        k = bitpos[0]
+        if k >= 85:
+            raise SGFP4FormatError("split map overrun (>85 bits)")
+        bitpos[0] += 1
+        split = (words[k // 32] >> (k % 32)) & 1
+        if split:
+            half = size // 2
+            for dy in (0, half):
+                for dx in (0, half):
+                    walk(y + dy, x + dx, half)
+        else:
+            leaves.append((y, x, size))
+
+    walk(0, 0, MACROBLOCK_SIZE)
+    return leaves
+
+
+def decode_v2(binary: bytes, O: int, I: int) -> np.ndarray:
+    """Decode a v2 quadtree-adaptive container to a float32 (O, I) tensor.
+
+    Args:
+        binary: self-framed v2 stream (paper Sec 6.1).
+        O, I: unpadded tensor shape (carried by the model manifest).
+    """
+    binary = bytes(binary)
+    if binary[:4] != SGFP4_MAGIC:
+        raise SGFP4FormatError("bad magic")
+    if binary[4] != SGFP4_VERSION_V2:
+        raise SGFP4FormatError(f"bad version {binary[4]:#x}")
+    B = struct.unpack_from("<I", binary, 5)[0]
+    if binary[9:16] != b"\x00" * 7:
+        raise SGFP4FormatError("missing 7-byte header pad (Sec 6.1)")
+    rec_offs = [struct.unpack_from("<I", binary, 16 + 4 * i)[0] for i in range(B)]
+    record_region = 16 + 4 * B
+
+    ty = math.ceil(O / MACROBLOCK_SIZE)
+    tx = math.ceil(I / MACROBLOCK_SIZE)
+    if ty * tx != B:
+        raise SGFP4FormatError(f"record count {B} != tiling {ty * tx}")
+
+    out = np.zeros((ty * MACROBLOCK_SIZE, tx * MACROBLOCK_SIZE), dtype=np.float32)
+    for b in range(B):
+        if rec_offs[b] % ALIGNMENT != 0:
+            raise SGFP4FormatError(
+                f"record {b} offset {rec_offs[b]} not 16-byte aligned"
+            )
+        base = record_region + rec_offs[b]
+        sb_header = struct.unpack_from("<I", binary, base)[0]
+        layout = sb_header & 0x7
+        if sb_header >> 3:
+            raise SGFP4FormatError(f"record {b}: sb_header reserved bits set")
+        pos = base + 4
+
+        if layout == LAYOUT_MIXED:
+            leaves = _parse_split_map(binary[pos:pos + 12])
+            pos += 12
+        elif layout in _LAYOUT_LEAF_SIZE:
+            leaf = _LAYOUT_LEAF_SIZE[layout]
+            # Uniform layouts: leaves in row-major raster order (Sec 6.2)
+            leaves = [
+                (ry, rx, leaf)
+                for ry in range(0, MACROBLOCK_SIZE, leaf)
+                for rx in range(0, MACROBLOCK_SIZE, leaf)
+            ]
+        else:
+            raise SGFP4FormatError(f"record {b}: unknown layout {layout}")
+
+        N = len(leaves)
+        hdrs = [struct.unpack_from("<I", binary, pos + 4 * i)[0] for i in range(N)]
+        pos += 4 * N
+        hdr_pad = (-(pos - base)) % ALIGNMENT
+        if binary[pos:pos + hdr_pad] != b"\x00" * hdr_pad:
+            raise SGFP4FormatError(f"record {b}: header pad missing/nonzero")
+        pos += hdr_pad
+
+        by, bx = divmod(b, tx)
+        for (y, x, size), h in zip(leaves, hdrs):
+            S = _half_from_bits(h >> 16)
+            beta = _half_from_bits(h & 0xFFF0)  # Eq (6): flag truncation
+            flags = h & 0xF
+            if flags & 0xE:
+                raise SGFP4FormatError(
+                    f"record {b} leaf ({y},{x}): reserved header flag bits set"
+                )
+            mode = flags & 0x1
+            n_w = size * size
+            n_words = n_w // 8 if mode == MODE_FP4_AFFINE else n_w // 16
+            n_bytes = ((n_words * 4 + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT
+            words = np.frombuffer(binary, dtype=np.uint32, count=n_words, offset=pos)
+            codes = _decode_codes(words, mode, n_w)
+            tile = (
+                np.float32(S) * codes.astype(np.float32) + np.float32(beta)
+            ).reshape(size, size)
+            out[by * MACROBLOCK_SIZE + y:by * MACROBLOCK_SIZE + y + size,
+                bx * MACROBLOCK_SIZE + x:bx * MACROBLOCK_SIZE + x + size] = tile
+            pos += n_bytes
+    return out[:O, :I]

--- a/gnus-poc/quantize/sgfp4_format.py
+++ b/gnus-poc/quantize/sgfp4_format.py
@@ -1,0 +1,110 @@
+"""SGFP4 wire-format constants — single source of truth.
+
+Every magic number used by the SGFP4 exporter and reference decoder is
+named here exactly once, mirroring the SuperGenius coding standard's rule
+against unnamed constants (std. §4.5). Names follow the Python/PEP 8
+UPPER_CASE convention, which plays the role that k-prefixed compile-time
+constants play in the C++ standard.
+
+All values are normative, taken from "SGFP4: Adaptive Dual-Mode
+Macroblock Quantization with GPU-Friendly Unpacking and Verifiable
+Decode Semantics" (arXiv v2), sections 3.2, 4.2, 4.3, 6.1, 6.2.
+"""
+
+from enum import IntEnum
+
+
+# ---------------------------------------------------------------------------
+# Enumerations (std. §5.9: scoped enums over bare ints)
+# ---------------------------------------------------------------------------
+
+class CodeMode(IntEnum):
+    """Per-block code mode (paper Sec 3.2)."""
+
+    FP4_AFFINE = 0    # 4-bit signed two's-complement codes
+    T158_AFFINE = 1   # ternary {-1, 0, +1} as 2-bit symbols
+
+
+class Layout(IntEnum):
+    """v2 superblock layout enumeration (paper Sec 6.2, Table 3)."""
+
+    UNIFORM_64 = 0    # one 64x64 leaf
+    UNIFORM_32 = 1    # four 32x32 leaves
+    UNIFORM_16 = 2    # sixteen 16x16 leaves
+    UNIFORM_8 = 3     # sixty-four 8x8 leaves
+    MIXED = 4         # variable quadtree leaves; split map present
+    FULL_4X4 = 5      # 256 4x4 leaves
+
+
+# ---------------------------------------------------------------------------
+# Tiling and payload geometry (Sec 3.1, 4.1)
+# ---------------------------------------------------------------------------
+
+MACROBLOCK_SIZE = 64        # external addressing unit, both profiles
+PAYLOAD_BYTES = 2048        # v1 fixed payload per macroblock
+PAYLOAD_U32 = PAYLOAD_BYTES // 4
+ALIGNMENT = 16              # payload/record alignment, both profiles
+UINT32_BYTES = 4
+UINT32_BITS = 32
+
+# ---------------------------------------------------------------------------
+# Normative code packing (Sec 4.3, Eq. 3 and 4)
+# ---------------------------------------------------------------------------
+
+FP4_BITS_PER_CODE = 4
+FP4_CODES_PER_WORD = UINT32_BITS // FP4_BITS_PER_CODE       # 8
+FP4_NIBBLE_MASK = 0xF
+FP4_SIGN_THRESHOLD = 8      # nibbles >= 8 map to code - 16
+FP4_CODE_BIAS = 16          # two's-complement wrap for negative nibbles
+
+T158_BITS_PER_CODE = 2
+T158_CODES_PER_WORD = UINT32_BITS // T158_BITS_PER_CODE     # 16
+T158_SYMBOL_MASK = 0x3
+T158_SYMBOL_POS = 1         # 01 -> +1
+T158_SYMBOL_NEG = 2         # 10 -> -1
+# 00 -> 0; 11 is reserved and decodes as 0
+
+T158_RESERVED_WORD_START = 256   # words 256..511 of a v1 T158 payload are 0
+
+# ---------------------------------------------------------------------------
+# v1 offset-word flags (Sec 4.2)
+# ---------------------------------------------------------------------------
+
+OFFSET_FLAG_MASK = 0xF          # low 4 bits of aligned offsets carry flags
+OFFSET_MODE_MASK = 0x1          # bit 0: mode
+OFFSET_RESERVED_MASK = 0xC      # bits 2-3: reserved, written 0
+
+# ---------------------------------------------------------------------------
+# Affine parameter packing (Sec 3.2) and v2 leaf-header flags (Sec 6.2, Eq. 6)
+# ---------------------------------------------------------------------------
+
+HALF_SHIFT = 16                 # S in upper 16 bits, beta in lower 16
+HALF_MASK = 0xFFFF
+FP16_MAX = 65504.0              # FP16 clip bound at encode time
+
+LEAF_FLAG_MASK = 0xF            # low 4 bits of the packed word carry flags
+LEAF_MODE_MASK = 0x1            # bit 0: mode
+LEAF_RESERVED_MASK = 0xE        # bits 1-3: reserved, written 0
+BETA_TRUNC_MASK = 0xFFF0        # decoder recovers beta = half(h & mask)
+HEADER_CLEAR_FLAGS_MASK = 0xFFFFFFF0
+
+# ---------------------------------------------------------------------------
+# v2 framing (Sec 6.1)
+# ---------------------------------------------------------------------------
+
+SGFP4_MAGIC = b"SGF4"
+SGFP4_VERSION_V2 = 0x02
+V2_FIXED_HEADER_BYTES = 16      # magic(4) + version(1) + B(4) + pad(7)
+V2_HEADER_PAD_BYTES = 7
+
+# ---------------------------------------------------------------------------
+# v2 record header (Sec 6.2)
+# ---------------------------------------------------------------------------
+
+SB_HEADER_LAYOUT_MASK = 0x7     # bits 0-2: layout enum
+SB_HEADER_RESERVED_SHIFT = 3    # bits 3-31: reserved, written 0
+
+SPLIT_MAP_BYTES = 12            # three little-endian uint32 words
+SPLIT_MAP_WORDS = 3
+SPLIT_MAP_MAX_BITS = 85         # 1 + 4 + 16 + 64 nodes of size >= 8
+MIN_LEAF_SIZE = 4               # quadtree recursion floor; no bit below this

--- a/gnus-poc/tests/test_fp4_exporter.py
+++ b/gnus-poc/tests/test_fp4_exporter.py
@@ -290,11 +290,11 @@ class TestFP4ExporterV2:
         exporter = FP4Exporter()
         weights = np.random.randn(128, 128).astype(np.float32) * 0.1
         binary, stats = exporter.export_weights(weights, "test", adaptive=True)
-        # After magic(4) + version(1) + num_sb(4) = 9 bytes
+        # Paper Sec 6.1: magic(4) + version(1) + num_sb(4) + pad(7) = 16 bytes
         num_sb = struct.unpack_from("<I", binary, 5)[0]
         assert num_sb == 4
         # Read offset table
-        offset_base = 9
+        offset_base = 16
         offsets = []
         for i in range(num_sb):
             off = struct.unpack_from("<I", binary, offset_base + i * 4)[0]
@@ -386,3 +386,112 @@ class TestFP4ExporterThreatModel:
             # The superblock header is just layout & 0x7
             sb_header = np.uint32(layout_val & 0x7)
             assert sb_header < 8  # fits in 3 bits
+
+
+# ---------------------------------------------------------------------------
+# Spec conformance tests (paper Sec 6 framing + reference decoder round-trip)
+# ---------------------------------------------------------------------------
+
+class TestV2SpecConformance:
+    """The v2 stream must be decodable by an independent implementation
+    built purely from the paper's normative framing (Sec 6.1/6.2)."""
+
+    def test_v2_header_pad_and_record_alignment(self):
+        """Sec 6.1: 7 zero pad bytes; records 16B-aligned, 16B-multiple size."""
+        exporter = FP4Exporter()
+        rng = np.random.default_rng(0)
+        weights = (rng.standard_normal((128, 128)) * 0.1).astype(np.float32)
+        binary, stats = exporter.export_weights(weights, "test", adaptive=True)
+
+        assert binary[9:16] == b"\x00" * 7
+        B = struct.unpack_from("<I", binary, 5)[0]
+        offsets = [struct.unpack_from("<I", binary, 16 + 4 * i)[0]
+                   for i in range(B)]
+        for off in offsets:
+            assert off % 16 == 0, f"record offset {off} not 16B aligned"
+        record_region = 16 + 4 * B
+        ends = offsets[1:] + [len(binary) - record_region]
+        for off, end in zip(offsets, ends):
+            assert (end - off) % 16 == 0, "record size not a 16B multiple"
+
+    def test_v1_reference_decoder_roundtrip(self):
+        """v1 container decodes via the independent reference decoder."""
+        from quantize.sgfp4_decoder import decode_v1
+        exporter = FP4Exporter()
+        rng = np.random.default_rng(1)
+        weights = (rng.standard_normal((128, 192)) * 2.0).astype(np.float32)
+        binary, _ = exporter.export_weights(weights, "test")
+        decoded = decode_v1(binary, 128, 192)
+        mse = float(np.mean((weights - decoded) ** 2))
+        assert mse < 1.0
+
+    def test_v2_reference_decoder_roundtrip_uniform(self):
+        """v2 uniform-layout container decodes via reference decoder."""
+        from quantize.sgfp4_decoder import decode_v2
+        exporter = FP4Exporter()
+        rng = np.random.default_rng(2)
+        weights = (rng.standard_normal((128, 128)) * 0.05).astype(np.float32)
+        binary, stats = exporter.export_weights(weights, "test", adaptive=True)
+        decoded = decode_v2(binary, 128, 128)
+        mse = float(np.mean((weights - decoded) ** 2))
+        assert mse < 0.01
+
+    def test_v2_uniform_16_raster_order_roundtrip(self):
+        """Uniform-16 leaves must be stored in row-major raster order
+        (Sec 6.2) — verified end-to-end through the reference decoder."""
+        from quantize.sgfp4_decoder import decode_v2
+        from quantize.fp4_exporter import LAYOUT_UNIFORM_16
+        exporter = FP4Exporter()
+        rng = np.random.default_rng(3)
+        weights = (rng.standard_normal((64, 64)) * 2.0).astype(np.float32)
+        binary, stats = exporter.export_weights(
+            weights, "test", adaptive=True,
+            thresholds={64: {"max_mse": 0.0, "max_relative": 0.0},
+                        32: {"max_mse": 0.0, "max_relative": 0.0}},
+            min_block_size=16,
+        )
+        assert stats["layout_distribution"][LAYOUT_UNIFORM_16] == 1
+        decoded = decode_v2(binary, 64, 64)
+        mse = float(np.mean((weights - decoded) ** 2))
+        assert mse < 1.0
+
+    def test_v2_mixed_layout_roundtrip_via_split_map(self):
+        """LAYOUT_MIXED record must carry a split map that lets the
+        reference decoder rebuild the quadtree (Sec 6.2)."""
+        from quantize.sgfp4_decoder import decode_v2
+        from quantize.fp4_exporter import LAYOUT_MIXED
+        exporter = FP4Exporter()
+        rng = np.random.default_rng(4)
+        weights = (rng.standard_normal((64, 64)) * 0.01).astype(np.float32)
+        weights[:32, :32] = rng.standard_normal((32, 32)).astype(np.float32)
+        thresholds = {s: {"max_mse": 1e-4, "max_relative": 1.0}
+                      for s in (64, 32, 16, 8, 4)}
+        binary, stats = exporter.export_weights(
+            weights, "test", adaptive=True, thresholds=thresholds)
+        assert stats["layout_distribution"][LAYOUT_MIXED] == 1
+        decoded = decode_v2(binary, 64, 64)
+        mse = float(np.mean((weights - decoded) ** 2))
+        assert mse < 1.0
+
+    def test_build_split_map_known_tree(self):
+        """Split map for a hand-built tree matches the Sec 6.2 bit rules,
+        and round-trips through the reference parser."""
+        from quantize.sgfp4_decoder import _parse_split_map
+        # Root split; TL/TR/BR are 32x32 leaves; BL splits into four 16x16.
+        blocks = [
+            {"y": 0, "x": 0, "size": 32},
+            {"y": 0, "x": 32, "size": 32},
+            {"y": 32, "x": 0, "size": 16},
+            {"y": 32, "x": 16, "size": 16},
+            {"y": 48, "x": 0, "size": 16},
+            {"y": 48, "x": 16, "size": 16},
+            {"y": 32, "x": 32, "size": 32},
+        ]
+        sm = FP4Exporter._build_split_map(blocks)
+        assert len(sm) == 12
+        word0, word1, word2 = struct.unpack("<3I", sm)
+        # Bits in DFS order: 1(root) 0(TL) 0(TR) 1(BL) 0 0 0 0 0(BR)
+        assert word0 == (1 << 0) | (1 << 3)
+        assert word1 == 0 and word2 == 0
+        leaves = _parse_split_map(sm)
+        assert leaves == [(b["y"], b["x"], b["size"]) for b in blocks]


### PR DESCRIPTION
## Summary

Independent verification of `gnus-poc/quantize` against the SGFP4 arXiv v2 paper (normative decode semantics) found the **v1 profile fully conformant and bit-exact**, but the **v2 stream undecodable by any paper-conformant implementation** — defeating the format's core purpose (cross-implementation bit-exact replay for execution attestation, paper §8). This PR fixes all conformance defects found, adds an independent reference decoder, and applies the [GNUS.AI software-engineering handbook](https://docs.gnus.ai/technical-information/software-engineering-handbook/c%2B%2B-coding-standards/) standards to the new/changed code.

## Defects fixed

| # | Severity | Defect | Paper ref |
|---|----------|--------|-----------|
| 1 | 🔴 | `LAYOUT_MIXED` records carried **no split map** — quadtree leaf geometry unrecoverable from the wire | §6.2 |
| 2 | 🔴 | Missing 7-byte pad after `magic\|version\|B`; offset table sat at byte 9 | §6.1 |
| 3 | 🔴 | Records not padded to 16B multiples; record offsets landed at ≡8 (mod 16) | §6.1 |
| 4 | 🟠 | No alignment pad between block headers and payloads | §6.2 |
| 5 | 🟠 | Uniform-layout leaves serialized in DFS order; paper mandates **row-major raster** (diverges below uniform-32) | §6.2 |
| 6 | 🟠 | `QuadtreeEncoder._reconstruct` scored the T158 candidate with the **FP4 codebook**, underestimating ternary error 4.7–18×; **17.2% of mode decisions flipped** (all wrongly toward T158) in a 400-sample sweep | §6.3 / D-04 |

## Changes

**Spec fixes:**
- **`quantize/fp4_exporter.py`** — 12-byte split map for MIXED (`_build_split_map`); raster-order leaves for uniform layouts; 7B header pad; header-section pad; records padded to 16B multiples
- **`quantize/quadtree.py`** — `_reconstruct` dispatches per mode (ternary threshold codes for T158). Mode-decision flips: **69/400 → 0/400**
- **`quantize/sgfp4_decoder.py`** *(new)* — independent reference decoder (`decode_v1`/`decode_v2`) implementing the paper's closed decode semantics, suitable for §8 conformance vectors and cross-implementation replay checks
- **`tests/test_fp4_exporter.py`** — offset-table test corrected to spec framing (base 16, was 9); new `TestV2SpecConformance` suite: header pad/record alignment, reference-decoder round-trips (v1, v2 uniform, uniform-16 raster order, MIXED-via-split-map), known-tree split-map bit test

**Coding-standards pass** (handbook rules applied to Python, behavior-neutral):

| Handbook rule | Applied as |
|---|---|
| §4.5 no magic numbers | **`quantize/sgfp4_format.py`** *(new)* — every wire-format constant (masks, shifts, pad sizes, split-map geometry, FP16 clip) named exactly once, imported by exporter, decoder, and quadtree |
| §5.9 scoped enums | `CodeMode` / `Layout` `IntEnum`s are canonical; plain-int aliases kept for backward compatibility |
| §5.12 explicit comparisons | all flag/bit tests are explicit `!= 0` |
| §1.1 clarity / simplicity | `nonlocal` replaces list-of-one closure hacks; `_zero_pad` helper deduplicates open-coded padding; `_record_leaves` split out of `decode_v2` |
| §6.5 named temporaries | payload-size math and header parsing use named intermediates |
| §8.4 function length | all functions well under ~100 lines |

## Validation

- **62/62** quantize tests pass (`test_fp4_exporter`, `test_quadtree`, `test_laplacian`, `test_manifest`) — identical results before and after the standards refactor
- An independent paper-only verification harness (decoder written solely from the spec, plus hand-built golden vectors incl. reserved ternary symbol `11→0`) passes **17/17** checks against this branch
- MIXED record (67 leaves, sizes {4,32}) now parses per paper: MSE 0.0013
- Branch contents verified byte-for-byte against the validated local tree after every push
- Pre-existing collection errors in unrelated test modules (`nltk`, `yaml` missing in env) are untouched

## Notes / follow-ups (not in this PR)

- `max_relative` threshold is never read by the quadtree (only `max_mse`)
- v1 `ERROR HINT` offset bit is never set (paper marks it informative)
- `laplacian.py` decimates the residual without per-level Gaussian filtering — not a true Laplacian pyramid; encode-side quality only
- Recommend adding golden conformance vectors to CI once this lands