### PR TITLE
docs: clarify enum class values MUST use UPPER_CASE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,7 @@ ninja
 - Prefer nullptr to 0 and NULL: type-safe, clearer intent, works with templates, enables function overloading
 - Prefer alias declarations (using) to typedefs: work with templates, more readable, support template aliases
 - Prefer scoped enums to unscoped enums: no implicit conversions, namespace pollution prevention, forward declarable, can specify underlying type
+- **Enum class values MUST use UPPER_CASE** (they are compile-time constants): `MemoryObjectType::BRIDGE_BLOCK`, `TrustClass::UNVERIFIED`, `Error::MODEL_LOAD_FAILED`
 
 ### Special Member Functions (Items 11-17)
 - Prefer deleted functions (= delete) to private undefined ones: better error messages, works with any function (not just members), checked at compile-time


### PR DESCRIPTION
CLAUDE.md line 105 says 'Constants: ALL_CAPS' but line 139 says 'k prefix + PascalCase' for compile-time constants. Enum class values weren't explicitly covered, causing executor agents to pick the wrong convention. This adds an explicit rule: **Enum class values MUST use UPPER_CASE** with examples.