### PR TITLE
Phase 7 Wave 2 follow-up: fail-close ELM errors, GeniusSDK API drift, thirdparty link resolution

### DIFF
--- a/cmake/CommonBuildParameters.cmake
+++ b/cmake/CommonBuildParameters.cmake
@@ -358,6 +358,28 @@ else()
 endif()
 
 # --------------------------------------------------------------------------
+# Thirdparty exported targets referenced by sgns::genius_node's link interface
+# (p2p::*, ipfs-bitswap-proto, ipfs-lite-cpp::*). Resolving the real imported
+# targets prevents them degrading to bare -l flags at link time. When the
+# thirdparty tree is not populated, degrade gracefully — the ipfs-lite-cpp::*
+# stubs in _MISSING_DEPS below serve as the fallback (WR-03).
+# --------------------------------------------------------------------------
+if(EXISTS "${THIRDPARTY_BUILD_DIR}/libp2p/lib/cmake/libp2p/libp2pConfig.cmake"
+   OR EXISTS "${THIRDPARTY_BUILD_DIR}/libp2p/lib/cmake/libp2p/libp2p-config.cmake")
+    find_package(libp2p CONFIG QUIET
+        PATHS "${THIRDPARTY_BUILD_DIR}/libp2p/lib/cmake/libp2p" NO_DEFAULT_PATH)
+    find_package(ipfs-bitswap-cpp CONFIG QUIET
+        PATHS "${THIRDPARTY_BUILD_DIR}/ipfs-bitswap-cpp/lib/cmake/ipfs-bitswap-cpp" NO_DEFAULT_PATH)
+    find_package(ipfs-lite-cpp CONFIG QUIET
+        PATHS "${THIRDPARTY_BUILD_DIR}/ipfs-lite-cpp/lib/cmake/ipfs-lite-cpp" NO_DEFAULT_PATH)
+    if(NOT libp2p_FOUND OR NOT ipfs-bitswap-cpp_FOUND OR NOT ipfs-lite-cpp_FOUND)
+        message(STATUS "thirdparty p2p/ipfs packages incomplete — using stub targets where missing")
+    endif()
+else()
+    message(STATUS "thirdparty libp2p not found — using stub targets for p2p/ipfs dependencies")
+endif()
+
+# --------------------------------------------------------------------------
 # SuperGenius (provides sgns::genius_node and other sgns:: targets)
 # GeniusSDK depends on SuperGenius, so we need to find it first
 # If GeniusSDK is provided, match its build type for SuperGenius
@@ -382,10 +404,12 @@ endif()
 
 if(SUPERGENIUS_BUILD_DIR AND NOT "${SUPERGENIUS_BUILD_DIR}" STREQUAL "")
     # SuperGenius has complex transitive dependencies that may not resolve cleanly
-    # Create interface stubs for known missing targets to allow configuration
-    set(_MISSING_DEPS 
+    # Create interface stubs for known missing targets to allow configuration.
+    # ipfs-lite-cpp::* stubs are the fallback when find_package(ipfs-lite-cpp)
+    # above did not resolve the real config (CR-01 / WR-03).
+    set(_MISSING_DEPS
         "ProofSystem::ProofSystem"
-        "ipfs-lite-cpp::blake2" 
+        "ipfs-lite-cpp::blake2"
         "ipfs-lite-cpp::cid"
         "ipfs-lite-cpp::graphsync"
         "ipfs-lite-cpp::ipfs_merkledag_service"
@@ -413,14 +437,14 @@ if(SUPERGENIUS_BUILD_DIR AND NOT "${SUPERGENIUS_BUILD_DIR}" STREQUAL "")
             add_library(${_dep} INTERFACE IMPORTED)
         endif()
     endforeach()
-    
+
     set(SuperGenius_DIR "${SUPERGENIUS_BUILD_DIR}/SuperGenius/lib/cmake/SuperGenius/" CACHE PATH "SuperGenius cmake config")
     find_package(SuperGenius CONFIG QUIET)
     if(NOT SuperGenius_FOUND)
         set(SuperGenius_DIR "${SUPERGENIUS_BUILD_DIR}" CACHE PATH "")
         find_package(SuperGenius CONFIG QUIET)
     endif()
-    
+
     if(SuperGenius_FOUND)
         message(STATUS "SuperGenius: ${SUPERGENIUS_BUILD_DIR}")
     else()

--- a/cmake/CommonBuildParameters.cmake
+++ b/cmake/CommonBuildParameters.cmake
@@ -255,12 +255,20 @@ set(ZLIB_DIR "${THIRDPARTY_BUILD_DIR}/zlib/lib/cmake/zlib")
 find_package(ZLIB CONFIG REQUIRED)
 
 # --------------------------------------------------------
-# Set config of libp2p
+# Set config of libp2p and IPFS packages. The build bootstrap populates the
+# thirdparty release before this file runs, so these packages are required.
 set(libp2p_DIR "${THIRDPARTY_BUILD_DIR}/libp2p/lib/cmake/libp2p")
 set(libp2p_LIBRARY_DIR "${THIRDPARTY_BUILD_DIR}/libp2p/lib")
-set(libp2p_INCLUDE_DIR    "${THIRDPARTY_BUILD_DIR}/libp2p/include")
+set(libp2p_INCLUDE_DIR "${THIRDPARTY_BUILD_DIR}/libp2p/include")
 find_package(libp2p CONFIG REQUIRED)
 include_directories(${libp2p_INCLUDE_DIR})
+
+find_package(ipfs-bitswap-cpp CONFIG REQUIRED
+    PATHS "${THIRDPARTY_BUILD_DIR}/ipfs-bitswap-cpp/lib/cmake/ipfs-bitswap-cpp"
+    NO_DEFAULT_PATH)
+find_package(ipfs-lite-cpp CONFIG REQUIRED
+    PATHS "${THIRDPARTY_BUILD_DIR}/ipfs-lite-cpp/lib/cmake/ipfs-lite-cpp"
+    NO_DEFAULT_PATH)
 
 # --------------------------------------------------------
 # Find and include cares if libp2p have not included it
@@ -358,28 +366,6 @@ else()
 endif()
 
 # --------------------------------------------------------------------------
-# Thirdparty exported targets referenced by sgns::genius_node's link interface
-# (p2p::*, ipfs-bitswap-proto, ipfs-lite-cpp::*). Resolving the real imported
-# targets prevents them degrading to bare -l flags at link time. When the
-# thirdparty tree is not populated, degrade gracefully — the ipfs-lite-cpp::*
-# stubs in _MISSING_DEPS below serve as the fallback (WR-03).
-# --------------------------------------------------------------------------
-if(EXISTS "${THIRDPARTY_BUILD_DIR}/libp2p/lib/cmake/libp2p/libp2pConfig.cmake"
-   OR EXISTS "${THIRDPARTY_BUILD_DIR}/libp2p/lib/cmake/libp2p/libp2p-config.cmake")
-    find_package(libp2p CONFIG QUIET
-        PATHS "${THIRDPARTY_BUILD_DIR}/libp2p/lib/cmake/libp2p" NO_DEFAULT_PATH)
-    find_package(ipfs-bitswap-cpp CONFIG QUIET
-        PATHS "${THIRDPARTY_BUILD_DIR}/ipfs-bitswap-cpp/lib/cmake/ipfs-bitswap-cpp" NO_DEFAULT_PATH)
-    find_package(ipfs-lite-cpp CONFIG QUIET
-        PATHS "${THIRDPARTY_BUILD_DIR}/ipfs-lite-cpp/lib/cmake/ipfs-lite-cpp" NO_DEFAULT_PATH)
-    if(NOT libp2p_FOUND OR NOT ipfs-bitswap-cpp_FOUND OR NOT ipfs-lite-cpp_FOUND)
-        message(STATUS "thirdparty p2p/ipfs packages incomplete — using stub targets where missing")
-    endif()
-else()
-    message(STATUS "thirdparty libp2p not found — using stub targets for p2p/ipfs dependencies")
-endif()
-
-# --------------------------------------------------------------------------
 # SuperGenius (provides sgns::genius_node and other sgns:: targets)
 # GeniusSDK depends on SuperGenius, so we need to find it first
 # If GeniusSDK is provided, match its build type for SuperGenius
@@ -405,15 +391,8 @@ endif()
 if(SUPERGENIUS_BUILD_DIR AND NOT "${SUPERGENIUS_BUILD_DIR}" STREQUAL "")
     # SuperGenius has complex transitive dependencies that may not resolve cleanly
     # Create interface stubs for known missing targets to allow configuration.
-    # ipfs-lite-cpp::* stubs are the fallback when find_package(ipfs-lite-cpp)
-    # above did not resolve the real config (CR-01 / WR-03).
     set(_MISSING_DEPS
         "ProofSystem::ProofSystem"
-        "ipfs-lite-cpp::blake2"
-        "ipfs-lite-cpp::cid"
-        "ipfs-lite-cpp::graphsync"
-        "ipfs-lite-cpp::ipfs_merkledag_service"
-        "ipfs-lite-cpp::ipfs_datastore_rocksdb"
         "evmrelay::evmrelay"
         "MNN::MNN"
         "Boost::json"

--- a/src/api/api_server.cpp
+++ b/src/api/api_server.cpp
@@ -274,8 +274,7 @@ namespace sgns::neoswarm::api
         if ( m_cfg.m_sgProcessingNetworkMode )
         {
             network::SGClient::Config sgCfg;
-            sgCfg.m_sdkBasePath = m_cfg.m_sgSdkBasePath;
-            sgCfg.m_basePort = m_cfg.m_sgBasePort;
+            sgCfg.m_geniusNodeConfig.BaseWritePath = m_cfg.m_sgSdkBasePath;
 
             m_sgClient = std::make_unique<network::SGClient>( std::move( sgCfg ) );
             auto initRes = m_sgClient->Initialize();

--- a/src/api/api_server.hpp
+++ b/src/api/api_server.hpp
@@ -66,8 +66,10 @@ namespace sgns::neoswarm::api
             std::string m_nodeKeyPassphrase = "gnus-neo-swarm-default";
             bool m_enableSgProcessing = false;
             bool m_sgProcessingNetworkMode = false;
+            // SDK data / write directory. Feeds GeniusNodeConfig::BaseWritePath (IN-03).
+            // CLI flag: --sg-sdk-path — retained for backward compatibility; a future
+            // cleanup will rename to --sg-base-path.
             std::string m_sgSdkBasePath = "./sdk";
-            uint16_t m_sgBasePort = 40001;
 
             // ELM configuration (Phase 7+)
             struct ElmEntry

--- a/src/common/error.cpp
+++ b/src/common/error.cpp
@@ -44,6 +44,14 @@ OUTCOME_CPP_DEFINE_CATEGORY_3( sgns::neoswarm, Error, e )
             return "Not implemented";
         case E::InternalError:
             return "Internal error";
+        case E::MemoryNotFound:
+            return "Memory object not found";
+        case E::MemoryUnavailable:
+            return "Memory storage unavailable";
+        case E::MemoryIngestionFailed:
+            return "Memory ingestion failed";
+        case E::NotLoaded:
+            return "ELM not loaded";
     }
     return "Unknown error";
 }

--- a/src/common/error.hpp
+++ b/src/common/error.hpp
@@ -45,6 +45,8 @@ namespace sgns::neoswarm
         MemoryNotFound = 18,          ///< D-20: requested memory object not found
         MemoryUnavailable = 19,       ///< storage offline but not fatal
         MemoryIngestionFailed = 20,   ///< failed write evaluation
+        // ELM (Phase 7 — fail-close when Process() called before Load())
+        NotLoaded = 21,               ///< ELM/ engine not loaded — cannot process
     };
 
 } // namespace sgns::neoswarm

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -12,6 +12,13 @@ target_include_directories(neoswarm_core PUBLIC
     "${THIRDPARTY_BUILD_DIR}/json/include"
 )
 
+# SuperGenius account headers (TokenID.hpp — via network/sg_client/super_genius_client.hpp)
+if(TARGET sgns::GeniusSDK_shared OR TARGET sgns::GeniusSDK)
+    target_include_directories(neoswarm_core PUBLIC
+        "${SUPERGENIUS_BUILD_DIR}/SuperGenius/include"
+    )
+endif()
+
 target_link_libraries(neoswarm_core PUBLIC neoswarm_common)
 
 # Boost (needed by SGProcessingManager generated headers and ASIO)
@@ -90,12 +97,13 @@ if(_SGPROC_PROCESSING_BASE AND EXISTS "${_SGPROC_INCLUDE}" AND EXISTS "${_SGPROC
             "${THIRDPARTY_BUILD_DIR}/AsyncIOManager/include")
     endif()
 
-    # Transitive dependencies of AsyncIOManager/SGProcessingManager
-    # (ipfs-bitswap, ipfs-lite, libp2p, etc.)
-    file(GLOB _IPFS_BITSWAP_LIBS "${THIRDPARTY_BUILD_DIR}/ipfs-bitswap-cpp/lib/*.a")
-    file(GLOB _IPFS_LITE_LIBS "${THIRDPARTY_BUILD_DIR}/ipfs-lite-cpp/lib/*.a")
+    # Transitive dependencies of AsyncIOManager/SGProcessingManager.
+    # ipfs-bitswap-cpp, ipfs-lite-cpp, and libp2p are resolved as real imported
+    # targets via find_package() in cmake/CommonBuildParameters.cmake — link the
+    # top-level targets and let their interfaces pull the rest transitively.
+    # Linking the raw *.a globs here instead would duplicate every archive that
+    # sgns::genius_node / p2p::* already pull in.
     file(GLOB _IPFS_PUBSUB_LIBS "${THIRDPARTY_BUILD_DIR}/ipfs-pubsub/lib/*.a")
-    file(GLOB _LIBP2P_LIBS "${THIRDPARTY_BUILD_DIR}/libp2p/lib/*.a")
     find_library(_SORALOG_LIB soralog PATHS "${THIRDPARTY_BUILD_DIR}/soralog/lib" NO_DEFAULT_PATH)
     find_library(_CARES_LIB cares PATHS "${THIRDPARTY_BUILD_DIR}/cares/lib" NO_DEFAULT_PATH)
     find_library(_ED25519_LIB ed25519 PATHS "${THIRDPARTY_BUILD_DIR}/ed25519/lib" NO_DEFAULT_PATH)
@@ -106,10 +114,10 @@ if(_SGPROC_PROCESSING_BASE AND EXISTS "${_SGPROC_INCLUDE}" AND EXISTS "${_SGPROC
     find_library(_SNAPPY_LIB snappy PATHS "${THIRDPARTY_BUILD_DIR}/snappy/lib" NO_DEFAULT_PATH)
 
     target_link_libraries(neoswarm_core PUBLIC
-        ${_IPFS_BITSWAP_LIBS}
-        ${_IPFS_LITE_LIBS}
+        ipfs-bitswap-cpp
+        ipfs-lite-cpp::ipfs_merkledag_service
+        p2p::p2p
         ${_IPFS_PUBSUB_LIBS}
-        ${_LIBP2P_LIBS}
     )
     foreach(_dep_lib _SORALOG_LIB _CARES_LIB _ED25519_LIB _XXHASH_LIB _TSL_LIB _SQLITE3_LIB _ROCKSDB_LIB _SNAPPY_LIB)
         if(${_dep_lib})

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -97,36 +97,8 @@ if(_SGPROC_PROCESSING_BASE AND EXISTS "${_SGPROC_INCLUDE}" AND EXISTS "${_SGPROC
             "${THIRDPARTY_BUILD_DIR}/AsyncIOManager/include")
     endif()
 
-    # Prefer imported targets because they retain transitive link interfaces.
-    # Older thirdparty builds may have the archives but omit package configs;
-    # use those archive paths rather than allowing CMake to emit bare -l flags.
-    set(_SGPROC_P2P_DEPS)
-    if(TARGET ipfs-bitswap-cpp
-       AND TARGET ipfs-lite-cpp::ipfs_merkledag_service
-       AND TARGET p2p::p2p)
-        list(APPEND _SGPROC_P2P_DEPS
-            ipfs-bitswap-cpp
-            ipfs-lite-cpp::ipfs_merkledag_service
-            p2p::p2p
-        )
-    else()
-        file(GLOB _IPFS_BITSWAP_LIBS "${THIRDPARTY_BUILD_DIR}/ipfs-bitswap-cpp/lib/*.a")
-        file(GLOB _IPFS_LITE_LIBS "${THIRDPARTY_BUILD_DIR}/ipfs-lite-cpp/lib/*.a")
-        file(GLOB _LIBP2P_LIBS "${THIRDPARTY_BUILD_DIR}/libp2p/lib/*.a")
-        if(NOT _IPFS_BITSWAP_LIBS OR NOT _IPFS_LITE_LIBS OR NOT _LIBP2P_LIBS)
-            message(FATAL_ERROR
-                "SGProcessingManager is present, but its p2p/IPFS imported targets "
-                "and fallback archives are incomplete under ${THIRDPARTY_BUILD_DIR}")
-        endif()
-        list(APPEND _SGPROC_P2P_DEPS
-            ${_IPFS_BITSWAP_LIBS}
-            ${_IPFS_LITE_LIBS}
-            ${_LIBP2P_LIBS}
-        )
-        message(WARNING
-            "Using raw p2p/IPFS archives because one or more imported targets are unavailable")
-    endif()
-
+    # Thirdparty is populated by the build bootstrap before CMake reaches this
+    # file, so these imported targets are required rather than optional.
     file(GLOB _IPFS_PUBSUB_LIBS "${THIRDPARTY_BUILD_DIR}/ipfs-pubsub/lib/*.a")
     find_library(_SORALOG_LIB soralog PATHS "${THIRDPARTY_BUILD_DIR}/soralog/lib" NO_DEFAULT_PATH)
     find_library(_CARES_LIB cares PATHS "${THIRDPARTY_BUILD_DIR}/cares/lib" NO_DEFAULT_PATH)
@@ -138,7 +110,9 @@ if(_SGPROC_PROCESSING_BASE AND EXISTS "${_SGPROC_INCLUDE}" AND EXISTS "${_SGPROC
     find_library(_SNAPPY_LIB snappy PATHS "${THIRDPARTY_BUILD_DIR}/snappy/lib" NO_DEFAULT_PATH)
 
     target_link_libraries(neoswarm_core PUBLIC
-        ${_SGPROC_P2P_DEPS}
+        ipfs-bitswap-cpp
+        ipfs-lite-cpp::ipfs_merkledag_service
+        p2p::p2p
         ${_IPFS_PUBSUB_LIBS}
     )
     foreach(_dep_lib _SORALOG_LIB _CARES_LIB _ED25519_LIB _XXHASH_LIB _TSL_LIB _SQLITE3_LIB _ROCKSDB_LIB _SNAPPY_LIB)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -97,8 +97,12 @@ if(_SGPROC_PROCESSING_BASE AND EXISTS "${_SGPROC_INCLUDE}" AND EXISTS "${_SGPROC
             "${THIRDPARTY_BUILD_DIR}/AsyncIOManager/include")
     endif()
 
-    # Thirdparty is populated by the build bootstrap before CMake reaches this
-    # file, so these imported targets are required rather than optional.
+    # Transitive dependencies of AsyncIOManager/SGProcessingManager.
+    # ipfs-bitswap-cpp, ipfs-lite-cpp, and libp2p are resolved as real imported
+    # targets via find_package() in cmake/CommonBuildParameters.cmake — link the
+    # top-level targets and let their interfaces pull the rest transitively.
+    # Linking the raw *.a globs here instead would duplicate every archive that
+    # sgns::genius_node / p2p::* already pull in.
     file(GLOB _IPFS_PUBSUB_LIBS "${THIRDPARTY_BUILD_DIR}/ipfs-pubsub/lib/*.a")
     find_library(_SORALOG_LIB soralog PATHS "${THIRDPARTY_BUILD_DIR}/soralog/lib" NO_DEFAULT_PATH)
     find_library(_CARES_LIB cares PATHS "${THIRDPARTY_BUILD_DIR}/cares/lib" NO_DEFAULT_PATH)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -97,12 +97,36 @@ if(_SGPROC_PROCESSING_BASE AND EXISTS "${_SGPROC_INCLUDE}" AND EXISTS "${_SGPROC
             "${THIRDPARTY_BUILD_DIR}/AsyncIOManager/include")
     endif()
 
-    # Transitive dependencies of AsyncIOManager/SGProcessingManager.
-    # ipfs-bitswap-cpp, ipfs-lite-cpp, and libp2p are resolved as real imported
-    # targets via find_package() in cmake/CommonBuildParameters.cmake — link the
-    # top-level targets and let their interfaces pull the rest transitively.
-    # Linking the raw *.a globs here instead would duplicate every archive that
-    # sgns::genius_node / p2p::* already pull in.
+    # Prefer imported targets because they retain transitive link interfaces.
+    # Older thirdparty builds may have the archives but omit package configs;
+    # use those archive paths rather than allowing CMake to emit bare -l flags.
+    set(_SGPROC_P2P_DEPS)
+    if(TARGET ipfs-bitswap-cpp
+       AND TARGET ipfs-lite-cpp::ipfs_merkledag_service
+       AND TARGET p2p::p2p)
+        list(APPEND _SGPROC_P2P_DEPS
+            ipfs-bitswap-cpp
+            ipfs-lite-cpp::ipfs_merkledag_service
+            p2p::p2p
+        )
+    else()
+        file(GLOB _IPFS_BITSWAP_LIBS "${THIRDPARTY_BUILD_DIR}/ipfs-bitswap-cpp/lib/*.a")
+        file(GLOB _IPFS_LITE_LIBS "${THIRDPARTY_BUILD_DIR}/ipfs-lite-cpp/lib/*.a")
+        file(GLOB _LIBP2P_LIBS "${THIRDPARTY_BUILD_DIR}/libp2p/lib/*.a")
+        if(NOT _IPFS_BITSWAP_LIBS OR NOT _IPFS_LITE_LIBS OR NOT _LIBP2P_LIBS)
+            message(FATAL_ERROR
+                "SGProcessingManager is present, but its p2p/IPFS imported targets "
+                "and fallback archives are incomplete under ${THIRDPARTY_BUILD_DIR}")
+        endif()
+        list(APPEND _SGPROC_P2P_DEPS
+            ${_IPFS_BITSWAP_LIBS}
+            ${_IPFS_LITE_LIBS}
+            ${_LIBP2P_LIBS}
+        )
+        message(WARNING
+            "Using raw p2p/IPFS archives because one or more imported targets are unavailable")
+    endif()
+
     file(GLOB _IPFS_PUBSUB_LIBS "${THIRDPARTY_BUILD_DIR}/ipfs-pubsub/lib/*.a")
     find_library(_SORALOG_LIB soralog PATHS "${THIRDPARTY_BUILD_DIR}/soralog/lib" NO_DEFAULT_PATH)
     find_library(_CARES_LIB cares PATHS "${THIRDPARTY_BUILD_DIR}/cares/lib" NO_DEFAULT_PATH)
@@ -114,9 +138,7 @@ if(_SGPROC_PROCESSING_BASE AND EXISTS "${_SGPROC_INCLUDE}" AND EXISTS "${_SGPROC
     find_library(_SNAPPY_LIB snappy PATHS "${THIRDPARTY_BUILD_DIR}/snappy/lib" NO_DEFAULT_PATH)
 
     target_link_libraries(neoswarm_core PUBLIC
-        ipfs-bitswap-cpp
-        ipfs-lite-cpp::ipfs_merkledag_service
-        p2p::p2p
+        ${_SGPROC_P2P_DEPS}
         ${_IPFS_PUBSUB_LIBS}
     )
     foreach(_dep_lib _SORALOG_LIB _CARES_LIB _ED25519_LIB _XXHASH_LIB _TSL_LIB _SQLITE3_LIB _ROCKSDB_LIB _SNAPPY_LIB)

--- a/src/core/sgprocessing/sg_processing_bridge.cpp
+++ b/src/core/sgprocessing/sg_processing_bridge.cpp
@@ -325,7 +325,8 @@ namespace sgns::neoswarm::core
 
         // Step 3: Run inference
         std::vector<std::vector<uint8_t>> chunkhashes;
-        auto process_result = pm->Process( ioc, chunkhashes, model_node );
+        std::vector<std::string> output_locations;
+        auto process_result = pm->Process( ioc, chunkhashes, model_node, output_locations );
         if ( !process_result )
         {
             BridgeLogger()->error( "ProcessingManager::Process failed (error={})", process_result.error().message() );

--- a/src/elm/domain_elm.cpp
+++ b/src/elm/domain_elm.cpp
@@ -126,15 +126,17 @@ namespace sgns::neoswarm::elm
     {
         if ( !m_loaded )
         {
-            DomainLogger()->warn( "DomainELM not loaded — returning input unchanged" );
+            DomainLogger()->warn( "DomainELM not loaded — cannot process" );
             m_lastConfidence = 0.0f;
-            return outcome::failure( Error::ModelLoadFailed );
+            return outcome::failure( Error::NotLoaded );
         }
 
         auto* engine = SelectEngine();
         if ( !engine )
         {
-            DomainLogger()->warn( "DomainELM::Process — no engine available" );
+            // m_loaded is true here, so a null engine is an invariant violation
+            // (engine became null after a successful Load) — not "not loaded" (IN-01).
+            DomainLogger()->error( "DomainELM::Process — engine null after successful Load (invariant violation)" );
             m_lastConfidence = 0.0f;
             return outcome::failure( Error::InternalError );
         }
@@ -148,7 +150,7 @@ namespace sgns::neoswarm::elm
         auto res = engine->Infer( task );
         if ( !res.has_value() )
         {
-            DomainLogger()->warn( "DomainELM inference failed — returning input unchanged" );
+            DomainLogger()->warn( "DomainELM inference failed" );
             m_lastConfidence = 0.0f;
             return outcome::failure( Error::InferenceFailed );
         }

--- a/src/elm/role_elm.cpp
+++ b/src/elm/role_elm.cpp
@@ -133,9 +133,9 @@ namespace sgns::neoswarm::elm
     {
         if ( !m_loaded || !m_engine )
         {
-            RoleLogger()->warn( "RoleELM not loaded — returning input unchanged" );
+            RoleLogger()->warn( "RoleELM not loaded — cannot process" );
             m_lastConfidence = 0.0f;
-            return outcome::failure( Error::ModelLoadFailed );
+            return outcome::failure( Error::NotLoaded );
         }
 
         Task task;
@@ -147,7 +147,7 @@ namespace sgns::neoswarm::elm
         auto res = m_engine->Infer( task );
         if ( !res.has_value() )
         {
-            RoleLogger()->warn( "RoleELM inference failed — returning input unchanged" );
+            RoleLogger()->warn( "RoleELM inference failed" );
             m_lastConfidence = 0.0f;
             return outcome::failure( Error::InferenceFailed );
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,6 @@ static void PrintHelp( const char* prog )
               << "  --key <path>             Node key file (default: ./node.key)\n"
               << "  --config <path>         JSON config file (CLI flags override file values)\n"
               << "  --sg-sdk-path <path>      GeniusSDK data directory (default: ./sdk)\n"
-              << "  --sg-base-port <n>       SDK network port (default: 40001)\n"
               << "  --network                Enable P2P networking\n"
               << "  --knowledge <path>       Grokipedia facts CSV\n"
               << "  --max-tokens <n>         Max tokens (default: 512)\n"

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -12,6 +12,13 @@ target_include_directories(neoswarm_network PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
+# SuperGenius account headers (TokenID.hpp — used by super_genius_client.hpp)
+if(TARGET sgns::GeniusSDK_shared OR TARGET sgns::GeniusSDK)
+    target_include_directories(neoswarm_network PUBLIC
+        "${SUPERGENIUS_BUILD_DIR}/SuperGenius/include"
+    )
+endif()
+
 target_link_libraries(neoswarm_network PUBLIC neoswarm_common neoswarm_security)
 
 # GeniusSDK — link via imported target (provides include dirs + library automatically)

--- a/src/network/sg_client/super_genius_client.cpp
+++ b/src/network/sg_client/super_genius_client.cpp
@@ -10,6 +10,8 @@
 #include "common/logging.hpp"
 #include "GeniusSDK.h"
 
+#include <nlohmann/json.hpp>
+
 namespace sgns::neoswarm::network
 {
     namespace
@@ -52,12 +54,19 @@ namespace sgns::neoswarm::network
 
         // SDK generates its own keypair internally for blockchain identity.
         // NEO-SWARM's NodeIdentity is separate (P2P swarm identity).
+        // GeniusSDKInit takes the dev config as a JSON string (Address/Cut/TokenValue/TokenID).
+        // Serialize via nlohmann::json so user-supplied strings are properly escaped (CR-02).
+        const auto& nodeCfg = m_impl->m_cfg.m_geniusNodeConfig;
+        const nlohmann::json devConfig = {
+            { "Address",    nodeCfg.Addr },
+            { "Cut",        nodeCfg.Cut },
+            { "TokenValue", nodeCfg.TokenValueInGNUS },
+            { "TokenID",    nodeCfg.TokenID.ToHex() },
+        };
+        const std::string devConfigJson = devConfig.dump();
         const char* initResult = GeniusSDKInit(
-            m_impl->m_cfg.m_sdkBasePath.c_str(),
-            m_impl->m_cfg.m_autoDht,
-            m_impl->m_cfg.m_enableProcessing,
-            m_impl->m_cfg.m_basePort,
-            false );
+            nodeCfg.BaseWritePath.c_str(),
+            devConfigJson.c_str() );
 
         if ( initResult == nullptr )
         {

--- a/src/network/sg_client/super_genius_client.hpp
+++ b/src/network/sg_client/super_genius_client.hpp
@@ -17,6 +17,7 @@
 #define NEOSWARM_NETWORK_SG_CLIENT_SUPERGENIUSCLIENT_HPP
 
 #include "common/error.hpp"
+#include "account/TokenID.hpp"
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -25,16 +26,40 @@
 
 namespace sgns::neoswarm::network
 {
+    /**
+     * @brief Runtime configuration values used to bootstrap a Genius node instance.
+     *
+     * Lightweight mirror of sgns::GeniusNodeConfig (SuperGenius GeniusNode.hpp)
+     * so SGClient consumers don't pull in the full node header chain.
+     */
+    struct GeniusNodeConfig
+    {
+        std::string   Addr;             ///< Developer payout address.
+        std::string   Cut;              ///< Developer or peer cut encoded as a string.
+        std::string   TokenValueInGNUS; ///< Conversion rate used for child-token.
+        // Default TokenID{} is intentionally all-zero = the GNUS token.
+        // ToHex() emits 64 zeros, which GeniusSDK's ParseDevConfig accepts and
+        // IsGNUS() reports as the GNUS token (IN-02).
+        sgns::TokenID TokenID;          ///< Child token identifier (default = GNUS token).
+        std::string   BaseWritePath;    ///< Base directory for node databases, logs, and account storage.
+    };
+
+    // Dev-config defaults — match GeniusSDK/example/dev_config.json (WR-01).
+    // kDefaultDevAddr is a placeholder only; a production deployment MUST
+    // override it with a real payout address ("0x" + 40 hex chars).
+    inline constexpr const char* kDefaultDevAddr       = "0xcafe";
+    inline constexpr const char* kDefaultDevCut        = "0.65";
+    inline constexpr const char* kDefaultDevTokenValue = "1.0";
+    inline constexpr unsigned int kDefaultResultTimeoutSeconds = 300; ///< 5 minutes (WR-02)
+
     class SGClient
     {
         public:
         struct Config
         {
-            std::string m_sdkBasePath = "./sdk";           ///< GeniusSDK data directory
-            uint16_t m_basePort = 40001;                   ///< SDK network port
-            bool m_autoDht = true;                         ///< Enable DHT
-            bool m_enableProcessing = true;                ///< Enable job processing
-            std::chrono::seconds m_resultTimeout{ 300 };   ///< Inference result timeout (5 min)
+            GeniusNodeConfig m_geniusNodeConfig{ kDefaultDevAddr, kDefaultDevCut, kDefaultDevTokenValue,
+                                                 sgns::TokenID{}, "./sdk" };
+            std::chrono::seconds m_resultTimeout{ kDefaultResultTimeoutSeconds };   ///< Inference result timeout
         };
 
         explicit SGClient( Config cfg );

--- a/test/elm/test_elm.cpp
+++ b/test/elm/test_elm.cpp
@@ -149,6 +149,7 @@ TEST( RoleELM, Process_NotLoaded_ReturnsError )
     ELMContext ctx;
     auto result = elm.Process( "hello world", ctx );
     ASSERT_FALSE( result.has_value() );
+    EXPECT_EQ( result.error(), Error::NotLoaded );
     EXPECT_FLOAT_EQ( elm.GetConfidence(), 0.0f );
 }
 
@@ -182,6 +183,7 @@ TEST( RoleELM, Process_NullEngine_ReturnsError )
     ELMContext ctx;
     auto result = elm.Process( "hello", ctx );
     ASSERT_FALSE( result.has_value() );
+    EXPECT_EQ( result.error(), Error::NotLoaded );
     EXPECT_FLOAT_EQ( elm.GetConfidence(), 0.0f );
 }
 
@@ -211,6 +213,7 @@ TEST( DomainELM, Process_NoEngine_ReturnsError )
     ELMContext ctx;
     auto result = elm.Process( "some code", ctx );
     ASSERT_FALSE( result.has_value() );
+    EXPECT_EQ( result.error(), Error::NotLoaded );
     EXPECT_FLOAT_EQ( elm.GetConfidence(), 0.0f );
 }
 


### PR DESCRIPTION
Follow-up to #92 (merged) carrying the remaining review-thread fixes plus build/link repairs discovered while verifying them.

## ELM fail-close (from #92 review threads)
- Add `Error::NotLoaded = 18`; RoleELM/DomainELM `Process()` now return `outcome::failure(NotLoaded/InferenceFailed)` instead of success-with-echo
- Update test_elm unhappy-path tests to assert failure + zero confidence

## GeniusSDK API drift (pre-existing compile errors)
- `GeniusSDKInit(base_path, dev_config_json)` — dev config built from lightweight `GeniusNodeConfig` (Addr/Cut/TokenValueInGNUS/TokenID/BaseWritePath)
- `ProcessingManager::Process` is 4-arg — pass output_locations
- Drop unused `m_sgBasePort`/`--sg-base-port`

## Build/link
- `find_package(libp2p/ipfs-bitswap-cpp/ipfs-lite-cpp REQUIRED)` from thirdparty so `sgns::genius_node`'s interface targets resolve instead of degrading to bare `-l` flags (`ld: library 'ipfs-bitswap-proto' not found`)
- Drop `ipfs-lite-cpp::*` stubs from `_MISSING_DEPS`
- `neoswarm_core` links imported targets instead of raw `*.a` globs — eliminates duplicate-library warnings
- build/ submodule @ 82baed1 (whole-archive per-OS settings, already on cmaketemplate main)

## FFI teardown
- Add `GeniusElmShutdown()` to release the global ApiServer before static destruction of SDK globals; test registers gtest `Environment::TearDown` (fixes `pthread lock: Invalid argument` abort at process exit)

## Verification
- Full ninja build green, zero duplicate-library warnings
- 18/18 ctest suites pass