### PR TITLE
fix(quantize): conform SGFP4 v2 framing to revised specification

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -46,21 +46,28 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: gnus-poc/requirements.txt
+      - name: Set up Python 3.11
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          if ! command -v python3.11 >/dev/null 2>&1; then
+            brew install python@3.11
+          fi
+          python3.11 -m venv .venv
+          .venv/bin/python --version
 
       - name: Install dependencies
+        shell: bash
         run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install -r requirements.txt
+          set -euo pipefail
+          .venv/bin/python -m pip install --upgrade pip setuptools wheel
+          .venv/bin/python -m pip install -r requirements.txt
 
       - name: Run Python tests
+        shell: bash
         run: >-
-          python -m pytest
+          .venv/bin/python -m pytest
           -m "not slow and not integration"
           --strict-markers
           --durations=20

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,66 @@
+name: GNUS POC Python Tests
+
+on:
+  pull_request:
+    branches:
+      - develop
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (gv-OSX-Large)
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      - self-hosted
+      - gv-OSX-Large
+    timeout-minutes: 90
+
+    defaults:
+      run:
+        working-directory: gnus-poc
+
+    env:
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      PYTHONUNBUFFERED: "1"
+      TOKENIZERS_PARALLELISM: "false"
+      HF_HUB_DISABLE_TELEMETRY: "1"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: gnus-poc/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements.txt
+
+      - name: Run Python tests
+        run: >-
+          python -m pytest
+          -m "not slow and not integration"
+          --strict-markers
+          --durations=20

--- a/gnus-poc/quantize/fp4_exporter.py
+++ b/gnus-poc/quantize/fp4_exporter.py
@@ -1,32 +1,23 @@
-"""FP4 Ultra binary exporter — SGFP4 v1 (fixed 64x64) and v2 (adaptive quadtree).
+"""SGFP4 v1 fixed-payload and v2 adaptive-quadtree exporter.
 
-Container layout v1: headers[B] | offsets[B] | codes_blob[B*2048]
-Container layout v2: magic[4] | version[1] | num_superblocks[4] | pad[7] |
-                     superblock_offsets[B] | superblock_data[0..B-1]
+Container layout v1::
 
-v1 (fixed, backward compatible):
-- 64x64 macroblocks
-- Fixed 2048-byte payload per block
-- FP4_AFFINE (mode 0): 4-bit signed codes, 8 per uint32
-- T158_AFFINE (mode 1): ternary as 2-bit symbols, 16 per uint32
+    headers[B] | offsets[B] | codes_blob[B * 2048]
 
-v2 (adaptive, SGFP4 v2):
-- Variable block sizes 4x4..64x64 selected by quadtree + Laplacian error
-- Layout enum per superblock (0-5) identifies block structure
-- Variable payloads scale with block area
-- Dual-mode per-block: FP4_AFFINE vs T158_AFFINE via error comparison
-- 4-byte magic header (b'SGF4') + version byte (0x02) for format detection
-- Superblock offset table for paging
-- 16-byte payload alignment per block
-- Manifest generation via ManifestBuilder
+Container layout v2::
+
+    magic[4] | version[1] | B[4] | pad0[7] | record_offsets[B] |
+    pad1[0..12] | records[0..B-1]
+
+For v2, ``pad1`` aligns the record-region base to 16 bytes. Record offsets
+are relative to that aligned base. Each record and each leaf payload is also
+zero-padded to a 16-byte multiple.
 """
 
 import argparse
 import json
 import math
 import struct
-import sys
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -36,7 +27,6 @@ from quantize.sgfp4_format import (
     ALIGNMENT,
     FP16_MAX,
     HEADER_CLEAR_FLAGS_MASK,
-    LEAF_ERROR_HINT_MASK,
     LEAF_MODE_MASK,
     MACROBLOCK_SIZE,
     MIN_LEAF_SIZE,
@@ -46,7 +36,6 @@ from quantize.sgfp4_format import (
     SB_HEADER_LAYOUT_MASK,
     SGFP4_MAGIC,
     SGFP4_VERSION_V2,
-    SPLIT_MAP_BYTES,
     SPLIT_MAP_MAX_BITS,
     SPLIT_MAP_WORDS,
     UINT32_BITS,
@@ -56,11 +45,7 @@ from quantize.sgfp4_format import (
 )
 
 
-# ---------------------------------------------------------------------------
-# Backward-compatible aliases (std. §4.1: scoped enums are the canonical
-# names; plain-int aliases kept for existing callers and tests)
-# ---------------------------------------------------------------------------
-
+# Backward-compatible aliases used by existing callers and tests.
 MODE_FP4_AFFINE = CodeMode.FP4_AFFINE
 MODE_T158_AFFINE = CodeMode.T158_AFFINE
 
@@ -73,40 +58,29 @@ LAYOUT_FULL_4x4 = Layout.FULL_4X4
 
 
 def _zero_pad(data: bytes, alignment: int = ALIGNMENT) -> bytes:
-    """Append zero bytes until len(data) is a multiple of alignment."""
+    """Append zero bytes until ``len(data)`` is a multiple of alignment."""
+    if alignment <= 0:
+        raise ValueError("alignment must be positive")
     return data + b"\x00" * ((-len(data)) % alignment)
 
-# Default v2 thresholds (per RESEARCH.md Pattern 4 / D-08)
+
 DEFAULT_V2_THRESHOLDS = {
     64: {"max_mse": 0.01, "max_relative": 0.05},
     32: {"max_mse": 0.005, "max_relative": 0.03},
     16: {"max_mse": 0.002, "max_relative": 0.02},
-    8:  {"max_mse": 0.001, "max_relative": 0.01},
-    4:  {"max_mse": 0.0005, "max_relative": 0.005},
+    8: {"max_mse": 0.001, "max_relative": 0.01},
+    4: {"max_mse": 0.0005, "max_relative": 0.005},
 }
 
 
-# ---------------------------------------------------------------------------
-# FP4Exporter
-# ---------------------------------------------------------------------------
-
 class FP4Exporter:
-    """SGFP4 weight exporter with v1 fixed and v2 adaptive modes.
-
-    Constructor args:
-        project_root: Path to the gnus-poc project root. Defaults to parent of
-                      this file if None.
-    """
+    """Export two-dimensional weight tensors to SGFP4 v1 or v2."""
 
     def __init__(self, project_root: Optional[Path] = None):
         if project_root is None:
             project_root = Path(__file__).resolve().parent.parent
         self._root = project_root
         self._artifacts_dir = project_root / "artifacts"
-
-    # ==================================================================
-    # Public API
-    # ==================================================================
 
     def export_weights(
         self,
@@ -119,37 +93,31 @@ class FP4Exporter:
         min_block_size: int = 4,
         laplacian_levels: int = 3,
     ) -> Tuple[bytes, dict]:
-        """Export weight tensor to SGFP4 binary.
+        """Export a two-dimensional float weight tensor.
 
-        Args:
-            weights: 2D float32 numpy array of shape (O, I).
-            niche_name: Specialist niche name (e.g. "code", "medical").
-            prefer_ternary: Prefer T158_AFFINE even in v1 mode.
-            ternary_delta: D-04 delta for T158 preference.
-            adaptive: If True, use SGFP4 v2 adaptive quadtree export.
-                      If False (default), use v1 fixed 64x64 export.
-            thresholds: Per-block-size error thresholds (v2 only).
-            min_block_size: Minimum block edge size for quadtree (v2 only).
-            laplacian_levels: Max Laplacian pyramid levels (v2 only).
-
-        Returns:
-            Tuple of (binary bytes, stats dict).
+        ``adaptive=False`` selects the v1 fixed-payload profile.
+        ``adaptive=True`` selects the v2 quadtree-adaptive profile.
         """
+        if weights.ndim != 2:
+            raise ValueError("weights must be a two-dimensional array")
+
         if adaptive:
             return self._export_v2_adaptive(
-                weights, niche_name,
+                weights,
+                niche_name,
                 prefer_ternary=prefer_ternary,
                 ternary_delta=ternary_delta,
                 thresholds=thresholds,
                 min_block_size=min_block_size,
                 laplacian_levels=laplacian_levels,
             )
-        else:
-            return self._export_v1_fixed(
-                weights, niche_name,
-                prefer_ternary=prefer_ternary,
-                ternary_delta=ternary_delta,
-            )
+
+        return self._export_v1_fixed(
+            weights,
+            niche_name,
+            prefer_ternary=prefer_ternary,
+            ternary_delta=ternary_delta,
+        )
 
     def export_to_file(
         self,
@@ -164,25 +132,10 @@ class FP4Exporter:
         training_metadata: Optional[dict] = None,
         **kwargs,
     ):
-        """Export weights to file, optionally with manifest (v2).
-
-        Args:
-            weights: 2D float32 numpy array.
-            niche_name: Specialist niche name.
-            output_dir: Target directory (default: artifacts/fp4/{niche}).
-            adaptive: Use v2 adaptive export if True.
-            thresholds: Per-block-size error thresholds (v2 only).
-            min_block_size: Minimum block edge size (v2 only).
-            laplacian_levels: Max Laplacian pyramid levels (v2 only).
-            base_model: Base model reference for manifest (v2 only).
-            training_metadata: Training metadata dict for manifest (v2 only).
-            **kwargs: Additional arguments passed to export_weights.
-
-        Returns:
-            Tuple of (bin_path, stats).
-        """
+        """Export weights to disk and write stats and, for v2, a manifest."""
         binary, stats = self.export_weights(
-            weights, niche_name,
+            weights,
+            niche_name,
             adaptive=adaptive,
             thresholds=thresholds,
             min_block_size=min_block_size,
@@ -194,21 +147,13 @@ class FP4Exporter:
             output_dir = self._artifacts_dir / "fp4" / niche_name
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        if adaptive:
-            ext = ".sgfp4"
-        else:
-            ext = ".fp4"
+        extension = ".sgfp4" if adaptive else ".fp4"
+        bin_path = output_dir / f"{niche_name}{extension}"
+        bin_path.write_bytes(binary)
 
-        bin_path = output_dir / f"{niche_name}{ext}"
-        with bin_path.open("wb") as f:
-            f.write(binary)
-
-        # Write stats JSON
         stats_path = output_dir / f"{niche_name}_stats.json"
-        with stats_path.open("w") as f:
-            json.dump(stats, f, indent=2)
+        stats_path.write_text(json.dumps(stats, indent=2))
 
-        # v2: write manifest via ManifestBuilder (D-10)
         if adaptive:
             self._write_manifest(
                 niche_name=niche_name,
@@ -221,9 +166,9 @@ class FP4Exporter:
 
         return bin_path, stats
 
-    # ==================================================================
-    # v1 fixed export (preserved for backward compatibility)
-    # ==================================================================
+    # ------------------------------------------------------------------
+    # v1 fixed-payload profile
+    # ------------------------------------------------------------------
 
     def _export_v1_fixed(
         self,
@@ -232,34 +177,34 @@ class FP4Exporter:
         prefer_ternary: bool = False,
         ternary_delta: float = 0.10,
     ) -> Tuple[bytes, dict]:
-        """v1 fixed 64x64 export — identical to pre-upgrade behavior."""
-        O, I = weights.shape
-        tiles_y = math.ceil(O / MACROBLOCK_SIZE)
-        tiles_x = math.ceil(I / MACROBLOCK_SIZE)
-        B = tiles_y * tiles_x
+        """Export the v1 fixed 64x64 profile."""
+        del niche_name
+        output_count, input_count = weights.shape
+        tiles_y = math.ceil(output_count / MACROBLOCK_SIZE)
+        tiles_x = math.ceil(input_count / MACROBLOCK_SIZE)
+        block_count = tiles_y * tiles_x
 
         padded = np.zeros(
             (tiles_y * MACROBLOCK_SIZE, tiles_x * MACROBLOCK_SIZE),
             dtype=np.float32,
         )
-        padded[:O, :I] = weights.astype(np.float32)
+        padded[:output_count, :input_count] = weights.astype(np.float32)
 
-        headers = np.zeros(B, dtype=np.uint32)
-        offsets = np.zeros(B, dtype=np.uint32)
-        codes_blocks = []
+        headers = np.zeros(block_count, dtype="<u4")
+        offsets = np.zeros(block_count, dtype="<u4")
+        code_blocks = []
 
         current_offset = 0
-        for by in range(tiles_y):
-            for bx in range(tiles_x):
-                block_idx = by * tiles_x + bx
+        for block_y in range(tiles_y):
+            for block_x in range(tiles_x):
+                block_index = block_y * tiles_x + block_x
                 block = padded[
-                    by * 64:(by + 1) * 64,
-                    bx * 64:(bx + 1) * 64,
+                    block_y * MACROBLOCK_SIZE:(block_y + 1) * MACROBLOCK_SIZE,
+                    block_x * MACROBLOCK_SIZE:(block_x + 1) * MACROBLOCK_SIZE,
                 ]
 
                 fp4_result = self._encode_fp4_affine(block)
                 t158_result = self._encode_t158_affine(block)
-
                 if (
                     prefer_ternary
                     and t158_result["l2_error"]
@@ -273,45 +218,39 @@ class FP4Exporter:
 
                 scale = float(np.clip(selected["scale"], -FP16_MAX, FP16_MAX))
                 bias = float(np.clip(selected["bias"], -FP16_MAX, FP16_MAX))
-                headers[block_idx] = self._pack_half2(scale, bias)
+                headers[block_index] = self._pack_half2(scale, bias)
 
-                assert current_offset % ALIGNMENT == 0
-                offsets[block_idx] = (
+                if current_offset % ALIGNMENT != 0:
+                    raise AssertionError("v1 payload offset is not aligned")
+                offsets[block_index] = (
                     (current_offset & ~OFFSET_FLAG_MASK)
                     | (int(mode) & OFFSET_FLAG_MASK)
                 )
 
                 block_payload = selected["payload"]
-                assert len(block_payload) == PAYLOAD_U32
-                codes_blocks.append(block_payload)
+                if len(block_payload) != PAYLOAD_U32:
+                    raise AssertionError("v1 payload has the wrong size")
+                code_blocks.append(block_payload.astype("<u4", copy=False))
                 current_offset += PAYLOAD_BYTES
 
-        codes_blob = b"".join(b.tobytes() for b in codes_blocks)
+        codes_blob = b"".join(block.tobytes() for block in code_blocks)
+        fp4_blocks = sum(1 for word in offsets if (int(word) & 0x1) == 0)
+        t158_blocks = block_count - fp4_blocks
 
         stats = {
-            "shape": [O, I],
-            "num_blocks": B,
+            "shape": [output_count, input_count],
+            "num_blocks": block_count,
             "tiles_y": tiles_y,
             "tiles_x": tiles_x,
-            "total_bytes": len(codes_blob) + B * 4 + B * 4,
-            "fp4_blocks": 0,
-            "t158_blocks": 0,
+            "total_bytes": len(codes_blob) + block_count * 8,
+            "fp4_blocks": fp4_blocks,
+            "t158_blocks": t158_blocks,
         }
+        return headers.tobytes() + offsets.tobytes() + codes_blob, stats
 
-        for b in range(B):
-            if offsets[b] & 0x1:
-                stats["t158_blocks"] += 1
-            else:
-                stats["fp4_blocks"] += 1
-
-        return (
-            headers.tobytes() + offsets.tobytes() + codes_blob,
-            stats,
-        )
-
-    # ==================================================================
-    # v2 adaptive export
-    # ==================================================================
+    # ------------------------------------------------------------------
+    # v2 quadtree-adaptive profile
+    # ------------------------------------------------------------------
 
     def _export_v2_adaptive(
         self,
@@ -323,53 +262,44 @@ class FP4Exporter:
         min_block_size: int = 4,
         laplacian_levels: int = 3,
     ) -> Tuple[bytes, dict]:
-        """SGFP4 v2 adaptive quadtree export.
+        """Export the SGFP4 v2 quadtree-adaptive profile.
 
-        Binary format (paper Sec 6.1):
-            magic[4] | version[1] | num_superblocks[4] | pad[7] |
-            superblock_offsets[B] | superblock_data[0..B-1]
+        The framing is::
 
-        Each superblock record (paper Sec 6.2), 16-byte aligned and zero
-        padded to a 16-byte multiple:
-            sb_header[4] | split_map[12] (LAYOUT_MIXED only) |
-            block_headers[N*4] | pad[0-15] | payloads[N] (each 16B-padded)
+            SGF4 | 0x02 | B | pad0 | offsets[B] | pad1 | records
 
-        Leaf storage order: row-major raster for uniform layouts; pre-order
-        DFS (matching the split map) for LAYOUT_MIXED.
+        ``pad1`` is zero-filled so the record-region base is
+        ``align16(16 + 4*B)``. Offsets remain relative to that base.
         """
-        O, I = weights.shape
-        tiles_y = math.ceil(O / MACROBLOCK_SIZE)
-        tiles_x = math.ceil(I / MACROBLOCK_SIZE)
-        B = tiles_y * tiles_x
+        del niche_name, prefer_ternary, laplacian_levels
+        output_count, input_count = weights.shape
+        tiles_y = math.ceil(output_count / MACROBLOCK_SIZE)
+        tiles_x = math.ceil(input_count / MACROBLOCK_SIZE)
+        block_count = tiles_y * tiles_x
 
         padded = np.zeros(
             (tiles_y * MACROBLOCK_SIZE, tiles_x * MACROBLOCK_SIZE),
             dtype=np.float32,
         )
-        padded[:O, :I] = weights.astype(np.float32)
+        padded[:output_count, :input_count] = weights.astype(np.float32)
 
-        # Use default thresholds if none provided
         if thresholds is None:
             thresholds = DEFAULT_V2_THRESHOLDS
 
-        # Import v2 modules (lazy to avoid circular imports at module level)
         from quantize.laplacian import LaplacianWeightedError
         from quantize.quadtree import QuadtreeEncoder
 
         laplacian = LaplacianWeightedError()
-
-        # Encode each superblock into variable-sized blocks
-        superblock_layouts = []  # List of (layout_enum, blocks)
+        superblock_layouts = []
         total_fp4_blocks = 0
         total_t158_blocks = 0
 
-        for by in range(tiles_y):
-            for bx in range(tiles_x):
+        for block_y in range(tiles_y):
+            for block_x in range(tiles_x):
                 superblock = padded[
-                    by * 64:(by + 1) * 64,
-                    bx * 64:(bx + 1) * 64,
+                    block_y * MACROBLOCK_SIZE:(block_y + 1) * MACROBLOCK_SIZE,
+                    block_x * MACROBLOCK_SIZE:(block_x + 1) * MACROBLOCK_SIZE,
                 ]
-
                 encoder = QuadtreeEncoder(
                     thresholds=thresholds,
                     ternary_delta=ternary_delta,
@@ -382,93 +312,76 @@ class FP4Exporter:
                 layout = self._classify_layout(blocks)
                 superblock_layouts.append((layout, blocks))
 
-                for blk in blocks:
-                    if blk["mode"] == MODE_FP4_AFFINE:
+                for block in blocks:
+                    if block["mode"] == MODE_FP4_AFFINE:
                         total_fp4_blocks += 1
                     else:
                         total_t158_blocks += 1
 
-        # Serialize superblocks
-        superblock_data_chunks = []
-        superblock_offsets = np.zeros(B, dtype=np.uint32)
+        record_chunks = []
+        record_offsets = np.zeros(block_count, dtype="<u4")
         current_offset = 0
 
-        for idx, (layout, blocks) in enumerate(superblock_layouts):
-            # Leaf storage order (paper Sec 6.2): uniform layouts are stored
-            # in row-major raster order of the tile grid; LAYOUT_MIXED keeps
-            # the pre-order DFS order that matches the split map.
+        for index, (layout, blocks) in enumerate(superblock_layouts):
             if layout == Layout.MIXED:
                 split_map = self._build_split_map(blocks)
             else:
                 split_map = b""
-                blocks = sorted(blocks, key=lambda b: (b["y"], b["x"]))
+                blocks = sorted(blocks, key=lambda block: (block["y"], block["x"]))
 
-            # Superblock header: uint32 with layout enum + reserved
-            sb_header = np.uint32(int(layout) & SB_HEADER_LAYOUT_MASK)
-
-            # Per-block headers
-            block_headers = []
-            for blk in blocks:
-                bh = self._pack_half2(
-                    float(np.clip(blk["scale"], -FP16_MAX, FP16_MAX)),
-                    float(np.clip(blk["bias"], -FP16_MAX, FP16_MAX)),
+            sb_header = struct.pack("<I", int(layout) & SB_HEADER_LAYOUT_MASK)
+            leaf_headers = []
+            for block in blocks:
+                packed = self._pack_half2(
+                    float(np.clip(block["scale"], -FP16_MAX, FP16_MAX)),
+                    float(np.clip(block["bias"], -FP16_MAX, FP16_MAX)),
                 )
-                # 4 LSB offset flags:
-                #   bit 0 = mode (FP4=0, T158=1)
-                #   bit 1 = ERROR_HINT (0 = L2-selected, 1 = Pyramid-selected)
-                #   bits 2-3 = reserved (0)
-                flags = int(blk["mode"]) & LEAF_MODE_MASK
-                if blk.get("error_hint", 0):
-                    flags |= LEAF_ERROR_HINT_MASK
-                bh = np.uint32((int(bh) & HEADER_CLEAR_FLAGS_MASK) | flags)
-                block_headers.append(bh)
+                # v2 bit 0 is MODE. Bits 1-3 are reserved and remain zero.
+                flags = int(block["mode"]) & LEAF_MODE_MASK
+                leaf_headers.append(
+                    struct.pack(
+                        "<I",
+                        (int(packed) & HEADER_CLEAR_FLAGS_MASK) | flags,
+                    )
+                )
 
-            # Header section: sb_header | split_map | block_headers, then
-            # zero pad to a 16-byte boundary so payloads (and therefore all
-            # absolute addresses) stay aligned (paper Sec 6.2)
             header_section = _zero_pad(
-                sb_header.tobytes()
-                + split_map
-                + b"".join(bh.tobytes() for bh in block_headers)
+                sb_header + split_map + b"".join(leaf_headers)
             )
-
-            # Per-block payloads with 16-byte alignment per RESEARCH.md Pitfall 3
             payload_chunks = [
-                _zero_pad(blk["payload"].tobytes()) for blk in blocks
+                _zero_pad(
+                    block["payload"].astype("<u4", copy=False).tobytes()
+                )
+                for block in blocks
             ]
+            record = _zero_pad(header_section + b"".join(payload_chunks))
 
-            # Assemble superblock data; pad record to a 16-byte multiple so
-            # every record offset stays 16-byte aligned (paper Sec 6.1)
-            sb_data = _zero_pad(header_section + b"".join(payload_chunks))
+            if current_offset % ALIGNMENT != 0:
+                raise AssertionError("v2 record offset is not aligned")
+            record_offsets[index] = current_offset
+            record_chunks.append(record)
+            current_offset += len(record)
 
-            superblock_offsets[idx] = current_offset
-            superblock_data_chunks.append(sb_data)
-            current_offset += len(sb_data)
-
-        # Assemble full binary: magic | version | B | 7B pad to 16-byte
-        # boundary | offset table | records (paper Sec 6.1)
-        binary = (
+        framing = (
             SGFP4_MAGIC
             + struct.pack("<B", SGFP4_VERSION_V2)
-            + struct.pack("<I", B)
+            + struct.pack("<I", block_count)
             + b"\x00" * V2_HEADER_PAD_BYTES
-            + superblock_offsets.tobytes()
-            + b"".join(superblock_data_chunks)
+            + record_offsets.tobytes()
         )
+        framing = _zero_pad(framing)
+        binary = framing + b"".join(record_chunks)
 
-        # Compute layout distribution
-        layout_distribution = {i: 0 for i in range(6)}
-        for layout, _ in superblock_layouts:
-            layout_distribution[layout] += 1
-
-        # Compute effective bitrate
-        total_weights = int(O * I)
+        total_weights = int(output_count * input_count)
         total_bits = len(binary) * 8
         effective_bpw = total_bits / total_weights if total_weights > 0 else 0.0
+        layout_distribution = {value: 0 for value in range(6)}
+        for layout, _ in superblock_layouts:
+            layout_distribution[int(layout)] += 1
 
         stats = {
-            "shape": [O, I],
-            "num_superblocks": B,
+            "shape": [output_count, input_count],
+            "num_superblocks": block_count,
             "tiles_y": tiles_y,
             "tiles_x": tiles_x,
             "total_bytes": len(binary),
@@ -478,297 +391,248 @@ class FP4Exporter:
             "effective_bpw": round(effective_bpw, 4),
             "layout_distribution": layout_distribution,
         }
-
         return binary, stats
 
-    # ==================================================================
-    # Encode helpers
-    # ==================================================================
+    # ------------------------------------------------------------------
+    # Code fitting and packing
+    # ------------------------------------------------------------------
 
     def _encode_fp4_affine(self, block: np.ndarray) -> dict:
-        """v1: encode a 64x64 block in FP4_AFFINE mode (4096 weights)."""
+        """Encode one v1 64x64 block in FP4_AFFINE mode."""
         flat = block.ravel().astype(np.float32)
         scale, bias = self._fit_affine(flat)
+        codes = np.clip(
+            np.round((flat - bias) / scale),
+            -8,
+            7,
+        ).astype(np.int8)
+        reconstructed = scale * codes.astype(np.float32) + bias
+        l2_error = float(np.sqrt(np.mean((flat - reconstructed) ** 2)))
 
-        codes = np.clip(np.round((flat - bias) / scale), -8, 7).astype(np.int8)
-        w_hat = scale * codes.astype(np.float32) + bias
-        l2 = float(np.sqrt(np.mean((flat - w_hat) ** 2)))
-
-        payload = np.zeros(PAYLOAD_U32, dtype=np.uint32)
-        for i in range(4096):
-            code = int(codes[i]) & 0xF
-            word = i // 8
-            shift = 4 * (i % 8)
+        payload = np.zeros(PAYLOAD_U32, dtype="<u4")
+        for index in range(4096):
+            code = int(codes[index]) & 0xF
+            word = index // 8
+            shift = 4 * (index % 8)
             payload[word] |= np.uint32(code) << np.uint32(shift)
-
-        return {"scale": scale, "bias": bias, "l2_error": l2, "payload": payload}
-
-    def _encode_t158_affine(self, block: np.ndarray) -> dict:
-        """v1: encode a 64x64 block in T158_AFFINE mode (4096 weights)."""
-        flat = block.ravel().astype(np.float32)
-        scale, bias = self._fit_ternary(flat)
-
-        centered = flat - bias
-        tau = 0.5 * scale
-        T = np.zeros(4096, dtype=np.int8)
-        T[centered > tau] = 1
-        T[centered < -tau] = -1
-
-        w_hat = scale * T.astype(np.float32) + bias
-        l2 = float(np.sqrt(np.mean((flat - w_hat) ** 2)))
-
-        payload = np.zeros(PAYLOAD_U32, dtype=np.uint32)
-        for i in range(4096):
-            t = int(T[i])
-            if t == 0:
-                bits = 0
-            elif t == 1:
-                bits = 1
-            else:
-                bits = 2
-            word = i // 16
-            shift = 2 * (i % 16)
-            payload[word] |= np.uint32(bits) << np.uint32(shift)
-
-        return {"scale": scale, "bias": bias, "l2_error": l2, "payload": payload}
-
-    def _encode_fp4_affine_variable(self, region: np.ndarray) -> dict:
-        """v2: encode a variable-sized region in FP4_AFFINE mode.
-
-        Args:
-            region: 2D numpy array of any NxN size, float32.
-
-        Returns:
-            dict with keys: scale, bias, l2_error, payload, n_weights.
-        """
-        flat = region.ravel().astype(np.float32)
-        n_weights = flat.size
-        n_payload_u32 = n_weights // 8
-
-        scale, bias = self._fit_affine(flat)
-
-        codes = np.clip(np.round((flat - bias) / scale), -8, 7).astype(np.int8)
-        w_hat = scale * codes.astype(np.float32) + bias
-        l2 = float(np.sqrt(np.mean((flat - w_hat) ** 2)))
-
-        payload = np.zeros(n_payload_u32, dtype=np.uint32)
-        for i in range(n_weights):
-            code = int(codes[i]) & 0xF
-            word = i // 8
-            shift = 4 * (i % 8)
-            payload[word] |= np.uint32(code) << np.uint32(shift)
-
         return {
             "scale": scale,
             "bias": bias,
-            "l2_error": l2,
+            "l2_error": l2_error,
+            "payload": payload,
+        }
+
+    def _encode_t158_affine(self, block: np.ndarray) -> dict:
+        """Encode one v1 64x64 block in T158_AFFINE mode."""
+        flat = block.ravel().astype(np.float32)
+        scale, bias = self._fit_ternary(flat)
+        ternary = self._ternary_codes(flat, scale, bias)
+        reconstructed = scale * ternary.astype(np.float32) + bias
+        l2_error = float(np.sqrt(np.mean((flat - reconstructed) ** 2)))
+
+        payload = np.zeros(PAYLOAD_U32, dtype="<u4")
+        self._pack_ternary_codes(ternary, payload)
+        return {
+            "scale": scale,
+            "bias": bias,
+            "l2_error": l2_error,
+            "payload": payload,
+        }
+
+    def _encode_fp4_affine_variable(self, region: np.ndarray) -> dict:
+        """Encode a square v2 leaf in FP4_AFFINE mode."""
+        flat = region.ravel().astype(np.float32)
+        n_weights = flat.size
+        scale, bias = self._fit_affine(flat)
+        codes = np.clip(
+            np.round((flat - bias) / scale),
+            -8,
+            7,
+        ).astype(np.int8)
+        reconstructed = scale * codes.astype(np.float32) + bias
+        l2_error = float(np.sqrt(np.mean((flat - reconstructed) ** 2)))
+
+        payload = np.zeros(n_weights // 8, dtype="<u4")
+        for index in range(n_weights):
+            code = int(codes[index]) & 0xF
+            word = index // 8
+            shift = 4 * (index % 8)
+            payload[word] |= np.uint32(code) << np.uint32(shift)
+        return {
+            "scale": scale,
+            "bias": bias,
+            "l2_error": l2_error,
             "payload": payload,
             "n_weights": n_weights,
         }
 
     def _encode_t158_affine_variable(self, region: np.ndarray) -> dict:
-        """v2: encode a variable-sized region in T158_AFFINE mode.
-
-        Args:
-            region: 2D numpy array of any NxN size, float32.
-
-        Returns:
-            dict with keys: scale, bias, l2_error, payload, n_weights.
-        """
+        """Encode a square v2 leaf in T158_AFFINE mode."""
         flat = region.ravel().astype(np.float32)
         n_weights = flat.size
-        n_payload_u32 = n_weights // 16
-
         scale, bias = self._fit_ternary(flat)
+        ternary = self._ternary_codes(flat, scale, bias)
+        reconstructed = scale * ternary.astype(np.float32) + bias
+        l2_error = float(np.sqrt(np.mean((flat - reconstructed) ** 2)))
 
-        centered = flat - bias
-        tau = 0.5 * scale
-        T = np.zeros(n_weights, dtype=np.int8)
-        T[centered > tau] = 1
-        T[centered < -tau] = -1
-
-        w_hat = scale * T.astype(np.float32) + bias
-        l2 = float(np.sqrt(np.mean((flat - w_hat) ** 2)))
-
-        payload = np.zeros(n_payload_u32, dtype=np.uint32)
-        for i in range(n_weights):
-            t = int(T[i])
-            if t == 0:
-                bits = 0
-            elif t == 1:
-                bits = 1
-            else:
-                bits = 2
-            word = i // 16
-            shift = 2 * (i % 16)
-            payload[word] |= np.uint32(bits) << np.uint32(shift)
-
+        payload = np.zeros(n_weights // 16, dtype="<u4")
+        self._pack_ternary_codes(ternary, payload)
         return {
             "scale": scale,
             "bias": bias,
-            "l2_error": l2,
+            "l2_error": l2_error,
             "payload": payload,
             "n_weights": n_weights,
         }
 
-    # ==================================================================
-    # Fitting helpers (shared between v1 and v2)
-    # ==================================================================
+    @staticmethod
+    def _ternary_codes(
+        values: np.ndarray,
+        scale: float,
+        bias: float,
+    ) -> np.ndarray:
+        centered = values - bias
+        threshold = 0.5 * scale
+        codes = np.zeros(values.size, dtype=np.int8)
+        codes[centered > threshold] = 1
+        codes[centered < -threshold] = -1
+        return codes
+
+    @staticmethod
+    def _pack_ternary_codes(codes: np.ndarray, payload: np.ndarray) -> None:
+        for index, value in enumerate(codes):
+            ternary = int(value)
+            bits = 0 if ternary == 0 else (1 if ternary == 1 else 2)
+            word = index // 16
+            shift = 2 * (index % 16)
+            payload[word] |= np.uint32(bits) << np.uint32(shift)
 
     def _fit_affine(self, values: np.ndarray) -> Tuple[float, float]:
-        """Fit affine scale and bias for FP4 encoding (16-candidate search)."""
-        abs_max = float(np.max(np.abs(values)))
-        scale = abs_max / 7.0 if abs_max > 0 else 1.0
+        """Fit scale and bias using the exemplary 16-candidate search."""
+        absolute_maximum = float(np.max(np.abs(values)))
+        initial_scale = absolute_maximum / 7.0 if absolute_maximum > 0 else 1.0
         bias = float(np.mean(values))
-        best_err = float("inf")
-        best_scale = scale
+        best_error = float("inf")
+        best_scale = initial_scale
 
-        for mult in np.logspace(np.log10(0.5), np.log10(1.5), 16):
-            s = scale * mult
-            codes = np.clip(np.round((values - bias) / s), -8, 7).astype(np.int8)
-            w_hat = s * codes.astype(np.float32) + bias
-            err = float(np.mean((values - w_hat) ** 2))
-            if err < best_err:
-                best_err = err
-                best_scale = s
-
+        for multiplier in np.logspace(np.log10(0.5), np.log10(1.5), 16):
+            scale = initial_scale * multiplier
+            codes = np.clip(
+                np.round((values - bias) / scale),
+                -8,
+                7,
+            ).astype(np.int8)
+            reconstructed = scale * codes.astype(np.float32) + bias
+            error = float(np.mean((values - reconstructed) ** 2))
+            if error < best_error:
+                best_error = error
+                best_scale = scale
         return best_scale, bias
 
-    def _fit_ternary(self, values: np.ndarray) -> Tuple[float, float]:
-        """Fit scale and bias for T158 ternary encoding."""
+    @staticmethod
+    def _fit_ternary(values: np.ndarray) -> Tuple[float, float]:
+        """Fit the exemplary affine ternary scale and bias."""
         bias = float(np.mean(values))
         centered = values - bias
         scale = max(1e-8, float(np.mean(np.abs(centered))))
         return scale, bias
 
-    # ==================================================================
-    # Packing helpers
-    # ==================================================================
-
     def _pack_half2(self, scale: float, bias: float) -> int:
-        """Pack two FP16 values into a uint32: scale in upper 16 bits, bias in lower."""
-        s_bits = self._float_to_half(scale)
-        b_bits = self._float_to_half(bias)
-        return (s_bits << 16) | b_bits
+        """Pack FP16 scale in the upper half and FP16 bias in the lower."""
+        scale_bits = self._float_to_half(scale)
+        bias_bits = self._float_to_half(bias)
+        return (scale_bits << 16) | bias_bits
 
     @staticmethod
     def _float_to_half(value: float) -> int:
-        """Convert float to IEEE 754 half-precision bits via struct."""
+        """Convert a Python float to its IEEE-754 binary16 bit pattern."""
         packed, = struct.unpack("<H", struct.pack("<e", value))
         return packed
 
-    # ==================================================================
-    # v2 helpers
-    # ==================================================================
+    # ------------------------------------------------------------------
+    # v2 layout helpers
+    # ------------------------------------------------------------------
 
     @staticmethod
     def _payload_u32(size: int, mode: int) -> int:
-        """Return number of uint32 words for a block payload (D-03).
-
-        Args:
-            size: Block edge size (4, 8, 16, 32, or 64).
-            mode: MODE_FP4_AFFINE (0) or MODE_T158_AFFINE (1).
-
-        Returns:
-            Number of uint32 words in payload.
-        """
+        """Return the active uint32 payload words for one square leaf."""
         n_weights = size * size
         if mode == MODE_FP4_AFFINE:
             return n_weights // 8
-        else:
-            return n_weights // 16
+        return n_weights // 16
 
     @staticmethod
     def _classify_layout(blocks: List[dict]) -> Layout:
-        """Classify superblock layout from quadtree output blocks (D-02).
-
-        Args:
-            blocks: List of block dicts from QuadtreeEncoder.encode().
-
-        Returns:
-            Layout enum member.
-        """
-        sizes = [b["size"] for b in blocks]
+        """Classify a quadtree leaf set into the v2 layout enumeration."""
+        sizes = [block["size"] for block in blocks]
         unique_sizes = set(sizes)
-
         if len(unique_sizes) == 1:
             size = sizes[0]
-            expected_count = (MACROBLOCK_SIZE // size) * (MACROBLOCK_SIZE // size)
-            if len(blocks) != expected_count:
-                # All same size but wrong count — treat as mixed
-                return Layout.MIXED
-
-            if size == 64:
-                return Layout.UNIFORM_64
-            elif size == 32:
-                return Layout.UNIFORM_32
-            elif size == 16:
-                return Layout.UNIFORM_16
-            elif size == 8:
-                return Layout.UNIFORM_8
-            elif size == MIN_LEAF_SIZE:
-                return Layout.FULL_4X4
-
+            expected_count = (MACROBLOCK_SIZE // size) ** 2
+            if len(blocks) == expected_count:
+                if size == 64:
+                    return Layout.UNIFORM_64
+                if size == 32:
+                    return Layout.UNIFORM_32
+                if size == 16:
+                    return Layout.UNIFORM_16
+                if size == 8:
+                    return Layout.UNIFORM_8
+                if size == MIN_LEAF_SIZE:
+                    return Layout.FULL_4X4
         return Layout.MIXED
 
     @staticmethod
     def _build_split_map(blocks: List[dict]) -> bytes:
-        """Serialize the quadtree structure as a 12-byte split bitmap.
-
-        Per paper Sec 6.2: visiting nodes in pre-order DFS with quadrant
-        order TL, TR, BL, BR, one bit per node of size >= 8 records whether
-        that node is split (1) or a leaf (0). Nodes of size 4 cannot split
-        and contribute no bit. Bit k of the map is bit (k mod 32) of word
-        floor(k/32); upper bits are zero.
-
-        Args:
-            blocks: Leaf block dicts (with y, x, size) in pre-order DFS
-                    order, as emitted by QuadtreeEncoder.encode().
-
-        Returns:
-            12 bytes: three little-endian uint32 words.
-        """
+        """Serialize a mixed quadtree as three little-endian uint32 words."""
         bits: List[int] = []
         leaf_index = 0
 
         def walk(y: int, x: int, size: int) -> None:
             nonlocal leaf_index
-            blk = blocks[leaf_index]
+            if leaf_index >= len(blocks):
+                raise AssertionError("split map exhausted the leaf list")
+            block = blocks[leaf_index]
             if size == MIN_LEAF_SIZE:
-                # 4x4 nodes cannot split and contribute no bit; the leaf
-                # must be here.
-                assert (blk["y"], blk["x"], blk["size"]) == (y, x, MIN_LEAF_SIZE), (
-                    f"split-map walk expected 4x4 leaf at ({y},{x}), got {blk}"
-                )
+                expected = (y, x, MIN_LEAF_SIZE)
+                actual = (block["y"], block["x"], block["size"])
+                if actual != expected:
+                    raise AssertionError(
+                        f"split-map walk expected leaf {expected}, got {actual}"
+                    )
                 leaf_index += 1
                 return
-            if (blk["y"], blk["x"], blk["size"]) == (y, x, size):
-                bits.append(0)  # leaf
+
+            if (block["y"], block["x"], block["size"]) == (y, x, size):
+                bits.append(0)
                 leaf_index += 1
                 return
-            bits.append(1)  # split
+
+            bits.append(1)
             half = size // 2
             for dy in (0, half):
                 for dx in (0, half):
                     walk(y + dy, x + dx, half)
 
         walk(0, 0, MACROBLOCK_SIZE)
-        assert leaf_index == len(blocks), (
-            f"split map consumed {leaf_index} of {len(blocks)} leaves"
-        )
-        assert len(bits) <= SPLIT_MAP_MAX_BITS, (
-            f"split map needs {len(bits)} bits (max {SPLIT_MAP_MAX_BITS})"
-        )
+        if leaf_index != len(blocks):
+            raise AssertionError(
+                f"split map consumed {leaf_index} of {len(blocks)} leaves"
+            )
+        if len(bits) > SPLIT_MAP_MAX_BITS:
+            raise AssertionError(
+                f"split map needs {len(bits)} bits; maximum is {SPLIT_MAP_MAX_BITS}"
+            )
 
         words = [0] * SPLIT_MAP_WORDS
-        for k, bit in enumerate(bits):
+        for bit_index, bit in enumerate(bits):
             if bit != 0:
-                words[k // UINT32_BITS] |= 1 << (k % UINT32_BITS)
+                words[bit_index // UINT32_BITS] |= 1 << (bit_index % UINT32_BITS)
         return struct.pack("<3I", *words)
 
-    # ==================================================================
-    # Manifest generation (v2 only)
-    # ==================================================================
+    # ------------------------------------------------------------------
+    # Manifest generation
+    # ------------------------------------------------------------------
 
     def _write_manifest(
         self,
@@ -779,7 +643,6 @@ class FP4Exporter:
         training_metadata: dict,
         output_dir: Path,
     ):
-        """Write manifest.json using ManifestBuilder (D-10)."""
         from quantize.manifest import ManifestBuilder
 
         builder = ManifestBuilder(project_root=self._root)
@@ -790,49 +653,44 @@ class FP4Exporter:
             fp4_bin_path=bin_path,
             fp4_stats=stats,
         )
-
-        # Write manifest alongside binary in output_dir
-        manifest_path = output_dir / "manifest.json"
-        with manifest_path.open("w") as f:
-            json.dump(manifest, f, indent=2)
-
-        # Also save to artifacts/manifests/ per ManifestBuilder convention
+        (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
         builder.save(manifest, niche_name)
 
 
-# ---------------------------------------------------------------------------
-# CLI entry point (backward compatible with v1)
-# ---------------------------------------------------------------------------
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Export specialist weights to FP4 Ultra format (v1 or v2)"
+        description="Export specialist weights to SGFP4 v1 or v2"
     )
     parser.add_argument("--niche", required=True, help="Specialist niche name")
     parser.add_argument(
-        "--adaptive", action="store_true",
+        "--adaptive",
+        action="store_true",
         help="Use SGFP4 v2 adaptive quadtree export",
     )
     args = parser.parse_args()
 
     project_root = Path(__file__).resolve().parent.parent
     exporter = FP4Exporter(project_root)
-
-    # Placeholder export — real export requires adapter weights from training
     dummy_weights = np.random.randn(512, 512).astype(np.float32) * 0.01
     output_dir = project_root / "models" / "specialists_mlx" / args.niche / "fp4"
 
     if args.adaptive:
         bin_path, stats = exporter.export_to_file(
-            dummy_weights, args.niche, output_dir,
+            dummy_weights,
+            args.niche,
+            output_dir,
             adaptive=True,
         )
         print(
-            f"SGFP4 v2 export {args.niche}: {bin_path} ({stats['total_bytes']} bytes, "
-            f"{stats.get('effective_bpw', 'N/A')} bpw)"
+            f"SGFP4 v2 export {args.niche}: {bin_path} "
+            f"({stats['total_bytes']} bytes, {stats['effective_bpw']} bpw)"
         )
     else:
-        bin_path, stats = exporter.export_to_file(dummy_weights, args.niche, output_dir)
+        bin_path, stats = exporter.export_to_file(
+            dummy_weights,
+            args.niche,
+            output_dir,
+        )
         manifest = {
             "model_name": args.niche,
             "niche": args.niche,
@@ -842,6 +700,5 @@ if __name__ == "__main__":
             "encoder_version": "0.1.0",
             "timestamp_utc": "",
         }
-        with (output_dir / "manifest.json").open("w") as f:
-            json.dump(manifest, f, indent=2)
+        (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
         print(f"FP4 export {args.niche}: {bin_path} ({stats['total_bytes']} bytes)")

--- a/gnus-poc/quantize/laplacian.py
+++ b/gnus-poc/quantize/laplacian.py
@@ -1,30 +1,20 @@
-"""Encode-side Laplacian pyramid error analysis for weight quantization.
+"""Encode-side Laplacian-pyramid error analysis for SGFP4 quantization.
 
-Per D-07: Laplacian pyramid analysis is encode-side only -- NOT decoded at runtime.
-Separates low-frequency structure from high-frequency residual error,
-preventing outliers from dominating per-block scale and making T158 more
-viable on residuals near zero.
+The pyramid is an encoder policy only. It affects block and mode selection but
+is not serialized into v2 leaf flags and adds no runtime decode work.
 
-Adapts pyramid levels to block size (per RESEARCH.md Pitfall 2):
-- 4x4 and 8x8 blocks: skip Laplacian entirely, use plain L2 (MSE)
-- 16x16 blocks: 1 level
-- 32x32 blocks: 2 levels
-- 64x64 blocks: 3 levels
+The number of levels adapts to leaf size:
 
-Uses scipy.ndimage.gaussian_filter for Gaussian smoothing with
-configurable sigma and mode parameters.
-
-Spec conformance: the residual pyramid is a true Laplacian pyramid -- each
-level is Gaussian-filtered BEFORE decimation (anti-aliasing), and each
-level's error is measured on the Laplacian band (smooth - smooth_base),
-not on the raw residual reused at every level.
+* 4x4 and 8x8: plain MSE
+* 16x16: one level
+* 32x32: two levels
+* 64x64: three levels
 """
 
 import numpy as np
 from scipy.ndimage import gaussian_filter
 
 
-# Per RESEARCH.md Pitfall 2: block-size to Laplacian level mapping
 _BLOCK_SIZE_TO_LEVELS = {
     4: 0,
     8: 0,
@@ -35,24 +25,12 @@ _BLOCK_SIZE_TO_LEVELS = {
 
 
 def pyramid_levels_for_size(block_size: int) -> int:
-    """Return the number of Laplacian pyramid levels used for a block size.
-
-    0 means the block's error was computed with plain L2 (MSE); >0 means
-    the Laplacian pyramid selected the block. Used for the SGFP4 v2 leaf
-    ERROR_HINT flag (paper: 0 = L2-selected, 1 = Pyramid-selected).
-    """
+    """Return the configured encode-side pyramid depth for a leaf size."""
     return _BLOCK_SIZE_TO_LEVELS.get(block_size, 0)
 
 
 class LaplacianWeightedError:
-    """Compute Laplacian pyramid-weighted error for encode-side block selection.
-
-    Constructor kwargs (documented per RESEARCH.md Pattern 2 for tunability):
-        sigma: Base sigma for Gaussian smoothing per level. Actual sigma per
-               level is sigma * 2**level. Default: 2.0.
-        mode:   Boundary handling mode passed to scipy.ndimage.gaussian_filter.
-                Default: 'reflect'.
-    """
+    """Compute encode-side Laplacian-pyramid reconstruction error."""
 
     def __init__(self, sigma: float = 2.0, mode: str = "reflect"):
         self._sigma = sigma
@@ -64,23 +42,11 @@ class LaplacianWeightedError:
         reconstructed_2d: np.ndarray,
         block_size: int,
     ) -> float:
-        """Compute Laplacian-weighted MSE between original and reconstructed.
-
-        Args:
-            original_2d: 2D numpy array of original float32 weights.
-            reconstructed_2d: 2D numpy array of quantized+dequantized weights.
-            block_size: Edge size of the block (4, 8, 16, 32, or 64).
-
-        Returns:
-            float: Laplacian-weighted MSE. For blocks <= 8x8, returns plain
-                   MSE (Laplacian skipped per Pitfall 2).
-        """
-        levels = _BLOCK_SIZE_TO_LEVELS.get(block_size, 0)
-
+        """Return weighted reconstruction MSE for the selected leaf size."""
+        levels = pyramid_levels_for_size(block_size)
         residual = (original_2d - reconstructed_2d).astype(np.float32)
 
         if levels == 0:
-            # Small blocks: skip Laplacian, use plain MSE
             return float(np.mean(residual ** 2))
 
         smooth = residual.copy()
@@ -89,26 +55,19 @@ class LaplacianWeightedError:
 
         for level in range(levels):
             sigma = self._sigma * (2.0 ** level)
-            # Gaussian pre-filter before decimation (anti-aliasing) -- without
-            # this the pyramid aliases and is not a true Laplacian pyramid.
-            smooth_base = gaussian_filter(smooth, sigma=sigma, mode=self._mode)
-
-            # Laplacian band for this level: high-frequency detail removed by
-            # the Gaussian. Band MSE measures the error energy at this scale.
+            smooth_base = gaussian_filter(
+                smooth,
+                sigma=sigma,
+                mode=self._mode,
+            )
             band = smooth - smooth_base
-
-            # Weight error by level importance: lower levels get higher weight
             level_weight = 1.0 / (2.0 ** level)
-            level_error = float(np.mean(band ** 2))
-            total_error += level_weight * level_error
+            total_error += level_weight * float(np.mean(band ** 2))
             weight_sum += level_weight
 
-            # Decimate the filtered base for the next level
             if level < levels - 1:
                 smooth = smooth_base[::2, ::2]
 
         if weight_sum > 0.0:
             return total_error / weight_sum
-
-        # Fallback: plain MSE
         return float(np.mean(residual ** 2))

--- a/gnus-poc/quantize/quadtree.py
+++ b/gnus-poc/quantize/quadtree.py
@@ -1,63 +1,27 @@
-"""Quadtree adaptive block-size encoder for SGFP4 v2.
+"""Adaptive quadtree leaf selection for the SGFP4 v2 encoder.
 
-Per D-01: Full quadtree implementation. Encode tries largest block first
-(64x64), measures Laplacian-weighted error, splits into 4 children if error
-exceeds configurable threshold, recurses down to min_block_size (default 4x4).
-
-The encoder is designed to be consumed by FP4Exporter. It accepts callable
-hooks for FP4_AFFINE and T158_AFFINE fitting, keeping the quadtree logic
-independent of the specific encode implementation.
-
-Dual-mode selection per D-04: prefer T158 when t158_error <= (1.0 + delta) * fp4_error.
-Per-weight max error guard per RESEARCH.md Pitfall 4: if any individual weight
-reconstruction error exceeds 5 * scale, reject T158 and force FP4_AFFINE.
-
-Hysteresis per RESEARCH.md Pitfall 1: if parent block was accepted, require child
-error to be <= threshold * 0.8 (20% improvement) before splitting. Allow 10% slack
-(accept if error <= threshold * 1.1) when min_block_size not yet reached.
-
-Max recursion depth = 4 levels (64->32->16->8->4). Raises ValueError if exceeded.
+The encoder tries the largest region first, compares FP4_AFFINE and
+T158_AFFINE reconstruction error, and splits regions that fail the configured
+absolute or relative error gates. Laplacian-pyramid weighting is encode-side
+policy only; v2 does not serialize an ERROR_HINT flag.
 """
 
 from typing import Callable, Dict, List
 
 import numpy as np
 
-from quantize.laplacian import pyramid_levels_for_size
 from quantize.sgfp4_format import CodeMode
 
 
-# Maximum recursion depth (64 -> 32 -> 16 -> 8 -> 4)
 _kMaxRecursionDepth = 4
-
-# Per RESEARCH.md Pitfall 4: per-weight max error guard for T158
 _kT158MaxPerWeightErrorScale = 5.0
-
-# Hysteresis constants per RESEARCH.md Pitfall 1
-_kHysteresisImprovement = 0.8   # 20% improvement required for child split
-_kHysteresisSlack = 1.1         # 10% slack before forcing split
-
-# Below this signal power the relative-error gate is skipped (division by
-# ~zero would make the gate meaningless); absolute max_mse still applies.
+_kHysteresisImprovement = 0.8
+_kHysteresisSlack = 1.1
 _kRelativeEpsilon = 1e-12
 
 
 class QuadtreeEncoder:
-    """Encode a 64x64 superblock into variable-sized blocks using quadtree recursion.
-
-    Constructor args:
-        thresholds: Dict mapping block_size (int) -> {"max_mse": float, "max_relative": float}.
-                    Thresholds per block size for split decisions.
-        ternary_delta: D-04 delta value for T158 preference:
-                       prefer T158 when t158_err <= (1.0 + delta) * fp4_err.
-        min_block_size: Minimum block edge size. Must be in {4, 8, 16, 32, 64}.
-                        Default: 4.
-        fit_fp4: Callable(region: np.ndarray) -> dict.
-                 Must return {scale, bias, l2_error, payload, n_weights}.
-        fit_t158: Callable(region: np.ndarray) -> dict.
-                  Must return {scale, bias, l2_error, payload, n_weights}.
-        laplacian: LaplacianWeightedError instance for error computation.
-    """
+    """Encode one 64x64 macroblock into adaptive square leaves."""
 
     def __init__(
         self,
@@ -76,26 +40,25 @@ class QuadtreeEncoder:
         self._min_block_size = min_block_size
 
     def encode(self, superblock_64x64: np.ndarray) -> List[dict]:
-        """Encode a 64x64 superblock into a list of block dicts.
-
-        Each dict contains: {y, x, size, mode, payload, header, scale, bias, error}.
-
-        Args:
-            superblock_64x64: 2D numpy array of shape (64, 64), float32.
-
-        Returns:
-            List of dict, one per leaf block. Blocks cover the full 64x64 area
-            without overlap or gaps.
-        """
-        # T-03-01: Validate tensor dimensions
+        """Return a deterministic, complete leaf cover for a 64x64 macroblock."""
         if superblock_64x64.shape != (64, 64):
             raise ValueError(
                 f"superblock must be 64x64, got {superblock_64x64.shape}"
             )
         if not np.isfinite(superblock_64x64).all():
             raise ValueError("superblock contains NaN or Inf values")
+        if self._min_block_size not in (4, 8, 16, 32, 64):
+            raise ValueError(
+                "min_block_size must be one of 4, 8, 16, 32, or 64"
+            )
 
-        return self._try_block(superblock_64x64, 0, 0, 64, parent_accepted=False)
+        return self._try_block(
+            superblock_64x64,
+            0,
+            0,
+            64,
+            parent_accepted=False,
+        )
 
     def _try_block(
         self,
@@ -106,21 +69,7 @@ class QuadtreeEncoder:
         parent_accepted: bool,
         depth: int = 0,
     ) -> List[dict]:
-        """Recursive quadtree encode. Returns list of block dicts.
-
-        Args:
-            superblock: The full 64x64 superblock array.
-            y: Top-left row of this block.
-            x: Top-left column of this block.
-            size: Edge size of this block (power of 2).
-            parent_accepted: Whether the parent block was accepted
-                             (used for hysteresis).
-            depth: Current recursion depth.
-
-        Returns:
-            List of dict, one per leaf block.
-        """
-        # T-03-01: enforce max recursion depth
+        """Recursively accept or split one square region."""
         if depth > _kMaxRecursionDepth:
             raise ValueError(
                 f"Max recursion depth {_kMaxRecursionDepth} exceeded at "
@@ -130,34 +79,43 @@ class QuadtreeEncoder:
 
         region = superblock[y:y + size, x:x + size]
         threshold = self._thresholds.get(
-            size, self._thresholds.get(self._min_block_size, {"max_mse": 0.0005})
+            size,
+            self._thresholds.get(
+                self._min_block_size,
+                {"max_mse": 0.0005},
+            ),
         )
 
-        # Fit both modes
         fp4_result = self._fit_fp4(region)
         t158_result = self._fit_t158(region)
 
-        # Compute Laplacian-weighted error for both modes. Each mode must be
-        # reconstructed with its OWN codebook (FP4 nibble codes vs ternary
-        # thresholding) or the dual-mode decision scores T158 against the
-        # wrong error surface.
         fp4_reconstructed = self._reconstruct(
-            region, fp4_result, mode=CodeMode.FP4_AFFINE
+            region,
+            fp4_result,
+            mode=CodeMode.FP4_AFFINE,
         )
         t158_reconstructed = self._reconstruct(
-            region, t158_result, mode=CodeMode.T158_AFFINE
+            region,
+            t158_result,
+            mode=CodeMode.T158_AFFINE,
         )
 
-        fp4_error = self._laplacian.compute(region, fp4_reconstructed, block_size=size)
-        t158_error = self._laplacian.compute(region, t158_reconstructed, block_size=size)
+        fp4_error = self._laplacian.compute(
+            region,
+            fp4_reconstructed,
+            block_size=size,
+        )
+        t158_error = self._laplacian.compute(
+            region,
+            t158_reconstructed,
+            block_size=size,
+        )
 
-        # D-04: dual-mode selection
-        t158_preferred = t158_error <= (1.0 + self._ternary_delta) * fp4_error
-
-        if t158_preferred:
-            # Per RESEARCH.md Pitfall 4: per-weight max error guard
-            if self._t158_has_outlier(region, t158_result):
-                t158_preferred = False
+        t158_preferred = (
+            t158_error <= (1.0 + self._ternary_delta) * fp4_error
+        )
+        if t158_preferred and self._t158_has_outlier(region, t158_result):
+            t158_preferred = False
 
         if t158_preferred:
             selected = t158_result
@@ -170,45 +128,24 @@ class QuadtreeEncoder:
 
         max_mse = threshold.get("max_mse", 0.0005)
         max_relative = threshold.get("max_relative")
+        gate_error = self._combined_gate_error(
+            region,
+            selected_error,
+            max_mse,
+            max_relative,
+        )
 
-        # Normalize the selected error to an absolute-threshold-equivalent by
-        # enforcing BOTH the absolute (max_mse) and relative (max_relative)
-        # gates: relative error = error / mean(original^2). Scaling by the
-        # relative gate converts it into max_mse units so hysteresis and
-        # slack apply uniformly to the stricter of the two thresholds.
-        # A missing or non-positive max_relative disables the relative gate.
-        if max_relative is not None and max_relative > 0.0:
-            signal_power = float(np.mean(region.astype(np.float64) ** 2))
-            if signal_power > _kRelativeEpsilon:
-                relative_equivalent = max_mse * (
-                    (selected_error / signal_power) / max_relative
-                )
-                gate_error = max(selected_error, relative_equivalent)
-            else:
-                # Near-zero signal: relative gate is meaningless, absolute only
-                gate_error = selected_error
-        else:
-            gate_error = selected_error
-
-        # Apply hysteresis
         effective_threshold = max_mse
         if parent_accepted:
-            effective_threshold = max_mse * _kHysteresisImprovement
+            effective_threshold *= _kHysteresisImprovement
 
-        # Accept block if error within threshold or at minimum block size
         accept = gate_error <= effective_threshold
-
         if not accept and size > self._min_block_size:
-            # Check hysteresis slack: accept if within 10% of threshold
-            if gate_error <= max_mse * _kHysteresisSlack:
-                accept = True
-
+            accept = gate_error <= max_mse * _kHysteresisSlack
         if size <= self._min_block_size:
             accept = True
 
         if accept:
-            # Compute header: packed half2 (scale << 16 | bias)
-            # The header packing is done by the exporter; store raw values here
             scale = float(np.clip(selected["scale"], -65504, 65504))
             bias = float(np.clip(selected["bias"], -65504, 65504))
             return [{
@@ -217,17 +154,14 @@ class QuadtreeEncoder:
                 "size": size,
                 "mode": mode,
                 "payload": selected["payload"],
-                "header": 0,  # Packed by exporter later
+                "header": 0,
                 "scale": scale,
                 "bias": bias,
                 "error": selected_error,
-                # SGFP4 paper ERROR_HINT: 1 = Pyramid-selected, 0 = L2-selected
-                "error_hint": 1 if pyramid_levels_for_size(size) > 0 else 0,
             }]
 
-        # Split into 4 children
         half = size // 2
-        results = []
+        results: List[dict] = []
         for dy in (0, half):
             for dx in (0, half):
                 results.extend(
@@ -242,9 +176,25 @@ class QuadtreeEncoder:
                 )
         return results
 
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
+    @staticmethod
+    def _combined_gate_error(
+        region: np.ndarray,
+        selected_error: float,
+        max_mse: float,
+        max_relative,
+    ) -> float:
+        """Apply both absolute and relative gates on one comparable scale."""
+        if max_relative is None or max_relative <= 0.0:
+            return selected_error
+
+        signal_power = float(np.mean(region.astype(np.float64) ** 2))
+        if signal_power <= _kRelativeEpsilon:
+            return selected_error
+
+        relative_equivalent = max_mse * (
+            (selected_error / signal_power) / max_relative
+        )
+        return max(selected_error, relative_equivalent)
 
     @staticmethod
     def _reconstruct(
@@ -252,44 +202,39 @@ class QuadtreeEncoder:
         result: dict,
         mode: CodeMode = CodeMode.FP4_AFFINE,
     ) -> np.ndarray:
-        """Reconstruct a region from encode result for error computation.
-
-        Args:
-            region: 2D array of original weights.
-            result: Encode result dict with scale/bias.
-            mode: CodeMode.FP4_AFFINE (round-to-nearest nibble codes) or
-                  CodeMode.T158_AFFINE (ternary threshold codes). Using the
-                  wrong mode's codebook here systematically distorts the
-                  dual-mode selection error comparison.
-        """
+        """Reconstruct a candidate using its own normative codebook."""
         flat = region.ravel().astype(np.float32)
         scale = result["scale"]
         bias = result["bias"]
+
         if mode == CodeMode.T158_AFFINE:
-            # T158: threshold at tau = S/2 (matches the ternary encoder and
-            # _t158_has_outlier)
             centered = flat - bias
-            tau = 0.5 * scale
+            threshold = 0.5 * scale
             codes = np.zeros(flat.size, dtype=np.int8)
-            codes[centered > tau] = 1
-            codes[centered < -tau] = -1
+            codes[centered > threshold] = 1
+            codes[centered < -threshold] = -1
         else:
-            # FP4: round-to-nearest, clip to [-8, 7]
-            codes = np.clip(np.round((flat - bias) / scale), -8, 7).astype(np.int8)
-        return (scale * codes.astype(np.float32) + bias).reshape(region.shape)
+            codes = np.clip(
+                np.round((flat - bias) / scale),
+                -8,
+                7,
+            ).astype(np.int8)
+
+        return (
+            scale * codes.astype(np.float32) + bias
+        ).reshape(region.shape)
 
     @staticmethod
     def _t158_has_outlier(region: np.ndarray, t158_result: dict) -> bool:
-        """Check if any individual weight error exceeds kT158MaxPerWeightErrorScale * scale."""
+        """Return true when ternary reconstruction violates the outlier veto."""
         flat = region.ravel().astype(np.float32)
         scale = t158_result["scale"]
         bias = t158_result["bias"]
         centered = flat - bias
-        tau = 0.5 * scale
-        T = np.zeros(flat.size, dtype=np.int8)
-        T[centered > tau] = 1
-        T[centered < -tau] = -1
-        w_hat = scale * T.astype(np.float32) + bias
-        errors = np.abs(flat - w_hat)
-        max_error = float(np.max(errors))
-        return max_error > _kT158MaxPerWeightErrorScale * scale
+        threshold = 0.5 * scale
+        codes = np.zeros(flat.size, dtype=np.int8)
+        codes[centered > threshold] = 1
+        codes[centered < -threshold] = -1
+        reconstructed = scale * codes.astype(np.float32) + bias
+        maximum_error = float(np.max(np.abs(flat - reconstructed)))
+        return maximum_error > _kT158MaxPerWeightErrorScale * scale

--- a/gnus-poc/quantize/quadtree.py
+++ b/gnus-poc/quantize/quadtree.py
@@ -3,7 +3,8 @@
 The encoder tries the largest region first, compares FP4_AFFINE and
 T158_AFFINE reconstruction error, and splits regions that fail the configured
 absolute or relative error gates. Laplacian-pyramid weighting is encode-side
-policy only; v2 does not serialize an ERROR_HINT flag.
+policy only. The returned ``error_hint`` field is an internal diagnostic and is
+not serialized into the v2 leaf-header flags.
 """
 
 from typing import Callable, Dict, List
@@ -158,6 +159,7 @@ class QuadtreeEncoder:
                 "scale": scale,
                 "bias": bias,
                 "error": selected_error,
+                "error_hint": 1 if size >= 16 else 0,
             }]
 
         half = size // 2

--- a/gnus-poc/quantize/sgfp4_decoder.py
+++ b/gnus-poc/quantize/sgfp4_decoder.py
@@ -1,23 +1,14 @@
-"""Reference SGFP4 decoder — normative decode semantics.
+"""Reference SGFP4 decoder implementing the normative decode semantics.
 
-Implements the closed decode specification of "SGFP4: Adaptive Dual-Mode
-Macroblock Quantization with GPU-Friendly Unpacking and Verifiable Decode
-Semantics" so that containers can be replayed bit-exactly by an independent
-implementation (paper Sec 8 conformance-vector use case):
+The decoder covers both SGFP4 profiles from the format specification:
 
-  - Sec 3.2  affine reconstruction w = S*c + beta; FP16 (S, beta) packed
-             scale-in-high-halfword (packHalf2x16 order)
-  - Sec 4    v1 profile: headers[B] | offsets[B] | 2048-byte payload blob;
-             mode flag in bit 0 of the 16-byte-aligned offsets
-  - Sec 4.3  normative code ordering (nibble i at bit 4*(i mod 8); ternary
-             symbol i at bit 2*(i mod 16); 11 reserved -> 0)
-  - Sec 6.1  v2 framing: 'SGF4' | 0x02 | B(u32) | 7B pad | record_offsets[B]
-  - Sec 6.2  v2 record: sb_header | split map (MIXED) | block headers |
-             pad | 16B-padded payloads; Eq (6) beta flag truncation
+* v1 fixed payload: ``headers[B] | offsets[B] | codes_blob[B*2048]``.
+* v2 adaptive: ``SGF4 | 0x02 | B | pad0 | record_offsets[B] | pad1 |
+  records``.
 
-All wire-format constants come from quantize.sgfp4_format; this module
-contains decode logic only. Decoders raise SGFP4FormatError on malformed
-streams.
+The v2 stream frames its record structure. The original tensor dimensions
+``(O, I)`` are supplied by the enclosing model manifest and are required to
+recover the macroblock grid and crop edge padding.
 """
 
 import math
@@ -54,17 +45,20 @@ from quantize.sgfp4_format import (
     SPLIT_MAP_MAX_BITS,
     T158_BITS_PER_CODE,
     T158_CODES_PER_WORD,
+    T158_RESERVED_WORD_START,
     T158_SYMBOL_MASK,
     T158_SYMBOL_NEG,
     T158_SYMBOL_POS,
     UINT32_BITS,
+    UINT32_BYTES,
     V2_FIXED_HEADER_BYTES,
     V2_HEADER_PAD_BYTES,
     CodeMode,
     Layout,
+    align_up,
 )
 
-# Uniform layouts imply both the leaf geometry and the leaf count
+
 _LAYOUT_LEAF_SIZE = {
     Layout.UNIFORM_64: 64,
     Layout.UNIFORM_32: 32,
@@ -79,17 +73,18 @@ class SGFP4FormatError(ValueError):
 
 
 def _half_from_bits(bits: int) -> float:
+    """Decode one IEEE-754 binary16 value from its little-endian bit pattern."""
     return struct.unpack("<e", struct.pack("<H", bits & HALF_MASK))[0]
 
 
 def int4_to_int(nib: int) -> int:
-    """Two's-complement 4-bit code (paper Sec 4.3, Listing 1)."""
+    """Decode a two's-complement 4-bit code."""
     nib &= FP4_NIBBLE_MASK
     return nib if nib < FP4_SIGN_THRESHOLD else nib - FP4_CODE_BIAS
 
 
 def sym2_to_ternary(sym: int) -> int:
-    """2-bit ternary symbol map; 11 is reserved and decodes as 0."""
+    """Decode a 2-bit ternary symbol; reserved ``11`` decodes as zero."""
     sym &= T158_SYMBOL_MASK
     if sym == T158_SYMBOL_POS:
         return 1
@@ -98,8 +93,12 @@ def sym2_to_ternary(sym: int) -> int:
     return 0
 
 
-def _decode_codes(words: np.ndarray, mode: CodeMode, n_weights: int) -> np.ndarray:
-    """Normative code extraction (paper Sec 4.3, Eq. 3 and 4)."""
+def _decode_codes(
+    words: np.ndarray,
+    mode: CodeMode,
+    n_weights: int,
+) -> np.ndarray:
+    """Extract integer codes in the normative least-significant-bit order."""
     codes = np.empty(n_weights, dtype=np.int32)
     if mode == CodeMode.FP4_AFFINE:
         for i in range(n_weights):
@@ -115,73 +114,91 @@ def _decode_codes(words: np.ndarray, mode: CodeMode, n_weights: int) -> np.ndarr
 
 
 def decode_v1(binary: bytes, O: int, I: int) -> np.ndarray:
-    """Decode a v1 fixed-payload container to a float32 (O, I) tensor.
-
-    Args:
-        binary: headers[B] | offsets[B] | codes blob (B*2048 bytes).
-        O: unpadded output-channel count (carried by the model manifest).
-        I: unpadded input-channel count.
-
-    Returns:
-        Decoded float32 array of shape (O, I).
-
-    Raises:
-        SGFP4FormatError: on size mismatches or reserved-bit violations.
-    """
+    """Decode a v1 fixed-payload container to a float32 ``(O, I)`` tensor."""
     binary = bytes(binary)
     tiles_y = math.ceil(O / MACROBLOCK_SIZE)
     tiles_x = math.ceil(I / MACROBLOCK_SIZE)
-    B = tiles_y * tiles_x
-    expected_bytes = B * 8 + B * PAYLOAD_BYTES  # headers + offsets + blob
+    block_count = tiles_y * tiles_x
+    expected_bytes = block_count * (2 * UINT32_BYTES + PAYLOAD_BYTES)
     if len(binary) != expected_bytes:
         raise SGFP4FormatError(
             f"v1 stream is {len(binary)} bytes, expected {expected_bytes}"
         )
 
-    headers = np.frombuffer(binary, dtype=np.uint32, count=B, offset=0)
-    offsets = np.frombuffer(binary, dtype=np.uint32, count=B, offset=B * 4)
-    blob = binary[B * 8:]
+    headers = np.frombuffer(
+        binary,
+        dtype="<u4",
+        count=block_count,
+        offset=0,
+    )
+    offsets = np.frombuffer(
+        binary,
+        dtype="<u4",
+        count=block_count,
+        offset=block_count * UINT32_BYTES,
+    )
+    blob = binary[block_count * 2 * UINT32_BYTES:]
 
     out = np.zeros(
-        (tiles_y * MACROBLOCK_SIZE, tiles_x * MACROBLOCK_SIZE), dtype=np.float32
+        (tiles_y * MACROBLOCK_SIZE, tiles_x * MACROBLOCK_SIZE),
+        dtype=np.float32,
     )
-    for b in range(B):
-        header = int(headers[b])
+    for block_index in range(block_count):
+        header = int(headers[block_index])
         scale = _half_from_bits(header >> HALF_SHIFT)
         bias = _half_from_bits(header & HALF_MASK)
 
-        offset_word = int(offsets[b])
+        offset_word = int(offsets[block_index])
         flags = offset_word & OFFSET_FLAG_MASK
         base = offset_word & ~OFFSET_FLAG_MASK
         if (flags & OFFSET_RESERVED_MASK) != 0:
             raise SGFP4FormatError(
-                f"block {b}: reserved offset flag bits 2-3 nonzero"
+                f"block {block_index}: reserved offset flag bits 2-3 nonzero"
             )
+        if base % ALIGNMENT != 0:
+            raise SGFP4FormatError(
+                f"block {block_index}: payload offset {base} is not aligned"
+            )
+        if base + PAYLOAD_BYTES > len(blob):
+            raise SGFP4FormatError(f"block {block_index}: payload truncated")
+
         mode = CodeMode(flags & OFFSET_MODE_MASK)
+        words = np.frombuffer(
+            blob,
+            dtype="<u4",
+            count=PAYLOAD_U32,
+            offset=base,
+        )
+        if (
+            mode == CodeMode.T158_AFFINE
+            and np.any(words[T158_RESERVED_WORD_START:] != 0)
+        ):
+            raise SGFP4FormatError(
+                f"block {block_index}: reserved T158 payload tail is nonzero"
+            )
 
-        words = np.frombuffer(blob, dtype=np.uint32, count=PAYLOAD_U32, offset=base)
-        codes = _decode_codes(words, mode, MACROBLOCK_SIZE * MACROBLOCK_SIZE)
-
-        by, bx = divmod(b, tiles_x)
+        codes = _decode_codes(
+            words,
+            mode,
+            MACROBLOCK_SIZE * MACROBLOCK_SIZE,
+        )
+        block_y, block_x = divmod(block_index, tiles_x)
         tile = (
             np.float32(scale) * codes.astype(np.float32) + np.float32(bias)
         ).reshape(MACROBLOCK_SIZE, MACROBLOCK_SIZE)
         out[
-            by * MACROBLOCK_SIZE:(by + 1) * MACROBLOCK_SIZE,
-            bx * MACROBLOCK_SIZE:(bx + 1) * MACROBLOCK_SIZE,
+            block_y * MACROBLOCK_SIZE:(block_y + 1) * MACROBLOCK_SIZE,
+            block_x * MACROBLOCK_SIZE:(block_x + 1) * MACROBLOCK_SIZE,
         ] = tile
+
     return out[:O, :I]
 
 
 def _parse_split_map(buf: bytes) -> List[Tuple[int, int, int]]:
-    """Rebuild leaf (y, x, size) list from a 12-byte split bitmap.
-
-    Pre-order DFS, quadrant order TL, TR, BL, BR; one bit per node of
-    size >= 8 (1 = split, 0 = leaf); 4x4 nodes contribute no bit
-    (paper Sec 6.2).
-    """
+    """Rebuild mixed-layout leaves from the normative 12-byte split map."""
     if len(buf) < SPLIT_MAP_BYTES:
         raise SGFP4FormatError("split map truncated")
+
     words = struct.unpack_from("<3I", buf, 0)
     leaves: List[Tuple[int, int, int]] = []
     bit_pos = 0
@@ -195,6 +212,7 @@ def _parse_split_map(buf: bytes) -> List[Tuple[int, int, int]]:
             raise SGFP4FormatError(
                 f"split map overrun (>{SPLIT_MAP_MAX_BITS} bits)"
             )
+
         word_index = bit_pos // UINT32_BITS
         bit_index = bit_pos % UINT32_BITS
         bit_pos += 1
@@ -208,103 +226,136 @@ def _parse_split_map(buf: bytes) -> List[Tuple[int, int, int]]:
             leaves.append((y, x, size))
 
     walk(0, 0, MACROBLOCK_SIZE)
+
+    packed_bits = words[0] | (words[1] << 32) | (words[2] << 64)
+    if (packed_bits >> bit_pos) != 0:
+        raise SGFP4FormatError("split map has nonzero unused upper bits")
+
     return leaves
 
 
 def _record_leaves(
-    binary: bytes, layout: Layout, pos: int
+    binary: bytes,
+    layout: Layout,
+    pos: int,
 ) -> Tuple[List[Tuple[int, int, int]], int]:
-    """Resolve the leaf list of one v2 record per paper Sec 6.2.
-
-    Uniform layouts imply row-major raster order; LAYOUT_MIXED consumes a
-    12-byte split map and yields leaves in pre-order DFS order.
-
-    Returns:
-        (leaves, new_pos): leaf (y, x, size) list and the offset just past
-        the split map (unchanged for uniform layouts).
-    """
+    """Resolve one record's leaf geometry and return the next header offset."""
     if layout == Layout.MIXED:
         leaves = _parse_split_map(binary[pos:pos + SPLIT_MAP_BYTES])
         return leaves, pos + SPLIT_MAP_BYTES
     if layout in _LAYOUT_LEAF_SIZE:
         leaf_size = _LAYOUT_LEAF_SIZE[layout]
         leaves = [
-            (ry, rx, leaf_size)
-            for ry in range(0, MACROBLOCK_SIZE, leaf_size)
-            for rx in range(0, MACROBLOCK_SIZE, leaf_size)
+            (row, col, leaf_size)
+            for row in range(0, MACROBLOCK_SIZE, leaf_size)
+            for col in range(0, MACROBLOCK_SIZE, leaf_size)
         ]
         return leaves, pos
     raise SGFP4FormatError(f"unknown layout {int(layout)}")
 
 
 def decode_v2(binary: bytes, O: int, I: int) -> np.ndarray:
-    """Decode a v2 quadtree-adaptive container to a float32 (O, I) tensor.
-
-    Args:
-        binary: self-framed v2 stream (paper Sec 6.1).
-        O: unpadded output-channel count (carried by the model manifest).
-        I: unpadded input-channel count.
-
-    Returns:
-        Decoded float32 array of shape (O, I).
-
-    Raises:
-        SGFP4FormatError: on framing, alignment, or reserved-bit violations.
-    """
+    """Decode a v2 quadtree-adaptive container using manifest shape metadata."""
     binary = bytes(binary)
+    if len(binary) < V2_FIXED_HEADER_BYTES:
+        raise SGFP4FormatError("v2 fixed header truncated")
     if binary[:4] != SGFP4_MAGIC:
         raise SGFP4FormatError("bad magic")
     if binary[4] != SGFP4_VERSION_V2:
         raise SGFP4FormatError(f"bad version {binary[4]:#x}")
-    B = struct.unpack_from("<I", binary, 5)[0]
-    pad = binary[9:V2_FIXED_HEADER_BYTES]
-    if pad != b"\x00" * V2_HEADER_PAD_BYTES:
+
+    block_count = struct.unpack_from("<I", binary, 5)[0]
+    pad0 = binary[9:V2_FIXED_HEADER_BYTES]
+    if pad0 != b"\x00" * V2_HEADER_PAD_BYTES:
         raise SGFP4FormatError("missing 7-byte header pad (Sec 6.1)")
-    rec_offs = [
-        struct.unpack_from("<I", binary, V2_FIXED_HEADER_BYTES + 4 * i)[0]
-        for i in range(B)
+
+    offset_table_start = V2_FIXED_HEADER_BYTES
+    offset_table_end = offset_table_start + UINT32_BYTES * block_count
+    if len(binary) < offset_table_end:
+        raise SGFP4FormatError("record offset table truncated")
+
+    record_offsets = [
+        struct.unpack_from(
+            "<I",
+            binary,
+            offset_table_start + UINT32_BYTES * index,
+        )[0]
+        for index in range(block_count)
     ]
-    record_region = V2_FIXED_HEADER_BYTES + 4 * B
+    record_region = align_up(offset_table_end)
+    pad1 = binary[offset_table_end:record_region]
+    if pad1 != b"\x00" * (record_region - offset_table_end):
+        raise SGFP4FormatError("offset-table pad missing or nonzero")
+    if len(binary) < record_region:
+        raise SGFP4FormatError("v2 record region truncated")
 
     tiles_y = math.ceil(O / MACROBLOCK_SIZE)
     tiles_x = math.ceil(I / MACROBLOCK_SIZE)
-    if tiles_y * tiles_x != B:
-        raise SGFP4FormatError(f"record count {B} != tiling {tiles_y * tiles_x}")
+    expected_blocks = tiles_y * tiles_x
+    if expected_blocks != block_count:
+        raise SGFP4FormatError(
+            f"record count {block_count} != tiling {expected_blocks}"
+        )
 
     out = np.zeros(
-        (tiles_y * MACROBLOCK_SIZE, tiles_x * MACROBLOCK_SIZE), dtype=np.float32
+        (tiles_y * MACROBLOCK_SIZE, tiles_x * MACROBLOCK_SIZE),
+        dtype=np.float32,
     )
-    for b in range(B):
-        if rec_offs[b] % ALIGNMENT != 0:
+    previous_offset = -1
+    for block_index, record_offset in enumerate(record_offsets):
+        if record_offset % ALIGNMENT != 0:
             raise SGFP4FormatError(
-                f"record {b} offset {rec_offs[b]} not 16-byte aligned"
+                f"record {block_index} offset {record_offset} not 16-byte aligned"
             )
-        base = record_region + rec_offs[b]
+        if record_offset <= previous_offset:
+            raise SGFP4FormatError("record offsets are not strictly increasing")
+        previous_offset = record_offset
+
+        base = record_region + record_offset
+        if base + UINT32_BYTES > len(binary):
+            raise SGFP4FormatError(f"record {block_index}: header truncated")
+
         sb_header = struct.unpack_from("<I", binary, base)[0]
-        layout = Layout(sb_header & SB_HEADER_LAYOUT_MASK)
+        layout_value = sb_header & SB_HEADER_LAYOUT_MASK
+        try:
+            layout = Layout(layout_value)
+        except ValueError as exc:
+            raise SGFP4FormatError(
+                f"record {block_index}: unknown layout {layout_value}"
+            ) from exc
         if (sb_header >> SB_HEADER_RESERVED_SHIFT) != 0:
-            raise SGFP4FormatError(f"record {b}: sb_header reserved bits set")
+            raise SGFP4FormatError(
+                f"record {block_index}: sb_header reserved bits set"
+            )
 
-        leaves, pos = _record_leaves(binary, layout, base + 4)
-
+        leaves, pos = _record_leaves(binary, layout, base + UINT32_BYTES)
+        block_header_bytes = UINT32_BYTES * len(leaves)
+        if pos + block_header_bytes > len(binary):
+            raise SGFP4FormatError(
+                f"record {block_index}: leaf header table truncated"
+            )
         block_headers = [
-            struct.unpack_from("<I", binary, pos + 4 * i)[0]
-            for i in range(len(leaves))
+            struct.unpack_from("<I", binary, pos + UINT32_BYTES * index)[0]
+            for index in range(len(leaves))
         ]
-        pos += 4 * len(leaves)
+        pos += block_header_bytes
+
         header_pad = (-(pos - base)) % ALIGNMENT
         if binary[pos:pos + header_pad] != b"\x00" * header_pad:
-            raise SGFP4FormatError(f"record {b}: header pad missing/nonzero")
+            raise SGFP4FormatError(
+                f"record {block_index}: header pad missing or nonzero"
+            )
         pos += header_pad
 
-        by, bx = divmod(b, tiles_x)
+        block_y, block_x = divmod(block_index, tiles_x)
         for (y, x, size), header in zip(leaves, block_headers):
             scale = _half_from_bits(header >> HALF_SHIFT)
-            bias = _half_from_bits(header & BETA_TRUNC_MASK)  # Eq (6)
+            bias = _half_from_bits(header & BETA_TRUNC_MASK)
             flags = header & LEAF_FLAG_MASK
             if (flags & LEAF_RESERVED_MASK) != 0:
                 raise SGFP4FormatError(
-                    f"record {b} leaf ({y},{x}): reserved header flag bits set"
+                    f"record {block_index} leaf ({y},{x}): "
+                    "reserved header flag bits set"
                 )
             mode = CodeMode(flags & LEAF_MODE_MASK)
 
@@ -313,18 +364,36 @@ def decode_v2(binary: bytes, O: int, I: int) -> np.ndarray:
                 n_words = n_weights // FP4_CODES_PER_WORD
             else:
                 n_words = n_weights // T158_CODES_PER_WORD
-            payload_bytes = n_words * 4
-            n_bytes = payload_bytes + (-payload_bytes) % ALIGNMENT
+            payload_bytes = n_words * UINT32_BYTES
+            padded_bytes = align_up(payload_bytes)
+            if pos + padded_bytes > len(binary):
+                raise SGFP4FormatError(
+                    f"record {block_index} leaf ({y},{x}): payload truncated"
+                )
+
             words = np.frombuffer(
-                binary, dtype=np.uint32, count=n_words, offset=pos
+                binary,
+                dtype="<u4",
+                count=n_words,
+                offset=pos,
             )
+            payload_pad = binary[pos + payload_bytes:pos + padded_bytes]
+            if payload_pad != b"\x00" * (padded_bytes - payload_bytes):
+                raise SGFP4FormatError(
+                    f"record {block_index} leaf ({y},{x}): "
+                    "payload pad nonzero"
+                )
+
             codes = _decode_codes(words, mode, n_weights)
             tile = (
                 np.float32(scale) * codes.astype(np.float32) + np.float32(bias)
             ).reshape(size, size)
             out[
-                by * MACROBLOCK_SIZE + y:by * MACROBLOCK_SIZE + y + size,
-                bx * MACROBLOCK_SIZE + x:bx * MACROBLOCK_SIZE + x + size,
+                block_y * MACROBLOCK_SIZE + y:
+                block_y * MACROBLOCK_SIZE + y + size,
+                block_x * MACROBLOCK_SIZE + x:
+                block_x * MACROBLOCK_SIZE + x + size,
             ] = tile
-            pos += n_bytes
+            pos += padded_bytes
+
     return out[:O, :I]

--- a/gnus-poc/quantize/sgfp4_format.py
+++ b/gnus-poc/quantize/sgfp4_format.py
@@ -47,6 +47,14 @@ ALIGNMENT = 16              # payload/record alignment, both profiles
 UINT32_BYTES = 4
 UINT32_BITS = 32
 
+
+def align_up(value: int, alignment: int = ALIGNMENT) -> int:
+    """Return the smallest multiple of ``alignment`` not less than ``value``."""
+    if alignment <= 0:
+        raise ValueError("alignment must be positive")
+    return value + (-value) % alignment
+
+
 # ---------------------------------------------------------------------------
 # Normative code packing (Sec 4.3, Eq. 3 and 4)
 # ---------------------------------------------------------------------------
@@ -84,12 +92,7 @@ FP16_MAX = 65504.0              # FP16 clip bound at encode time
 
 LEAF_FLAG_MASK = 0xF            # low 4 bits of the packed word carry flags
 LEAF_MODE_MASK = 0x1            # bit 0: mode
-# bit 1: ERROR_HINT per SGFP4 paper (0 = L2-selected, 1 = Pyramid-selected).
-# Informative only. NOTE: this conflicts with Phase 3 D-05, which reserved
-# bit 1 for a deferred "log mode"; the paper's ERROR_HINT semantics win and
-# log mode will need a different carrier when it lands in Phase 5.
-LEAF_ERROR_HINT_MASK = 0x2
-LEAF_RESERVED_MASK = 0xC        # bits 2-3: reserved, written 0
+LEAF_RESERVED_MASK = 0xE        # bits 1-3 reserved, written 0
 BETA_TRUNC_MASK = 0xFFF0        # decoder recovers beta = half(h & mask)
 HEADER_CLEAR_FLAGS_MASK = 0xFFFFFFF0
 
@@ -99,7 +102,7 @@ HEADER_CLEAR_FLAGS_MASK = 0xFFFFFFF0
 
 SGFP4_MAGIC = b"SGF4"
 SGFP4_VERSION_V2 = 0x02
-V2_FIXED_HEADER_BYTES = 16      # magic(4) + version(1) + B(4) + pad(7)
+V2_FIXED_HEADER_BYTES = 16      # magic(4) + version(1) + B(4) + pad0(7)
 V2_HEADER_PAD_BYTES = 7
 
 # ---------------------------------------------------------------------------

--- a/gnus-poc/tests/test_fp4_exporter.py
+++ b/gnus-poc/tests/test_fp4_exporter.py
@@ -1,60 +1,80 @@
-"""Tests for FP4 Ultra exporter — v1 fixed and v2 adaptive."""
+"""Tests for the SGFP4 v1 fixed and v2 adaptive exporters."""
 
 import json
 import struct
 
 import numpy as np
+import pytest
 
 from quantize.fp4_exporter import (
-    FP4Exporter,
+    DEFAULT_V2_THRESHOLDS,
+    LAYOUT_FULL_4x4,
+    LAYOUT_MIXED,
+    LAYOUT_UNIFORM_16,
+    LAYOUT_UNIFORM_32,
+    LAYOUT_UNIFORM_64,
+    LAYOUT_UNIFORM_8,
     MACROBLOCK_SIZE,
-    PAYLOAD_BYTES,
-    PAYLOAD_U32,
     MODE_FP4_AFFINE,
     MODE_T158_AFFINE,
-    LAYOUT_UNIFORM_64,
-    LAYOUT_UNIFORM_32,
-    LAYOUT_UNIFORM_16,
-    LAYOUT_UNIFORM_8,
-    LAYOUT_MIXED,
-    LAYOUT_FULL_4x4,
+    PAYLOAD_BYTES,
+    PAYLOAD_U32,
+    FP4Exporter,
+)
+from quantize.sgfp4_decoder import SGFP4FormatError, _parse_split_map, decode_v1, decode_v2
+from quantize.sgfp4_format import (
+    ALIGNMENT,
+    LEAF_RESERVED_MASK,
     SGFP4_MAGIC,
     SGFP4_VERSION_V2,
-    DEFAULT_V2_THRESHOLDS,
+    UINT32_BYTES,
+    V2_FIXED_HEADER_BYTES,
+    align_up,
 )
 
 
-# ---------------------------------------------------------------------------
-# v1 Tests (existing — backward compatibility)
-# ---------------------------------------------------------------------------
+def _v2_record_region(binary: bytes):
+    block_count = struct.unpack_from("<I", binary, 5)[0]
+    table_end = V2_FIXED_HEADER_BYTES + UINT32_BYTES * block_count
+    record_region = align_up(table_end)
+    return block_count, table_end, record_region
+
+
+def _first_leaf_header_position(binary: bytes, record_index: int = 0) -> int:
+    block_count, _, record_region = _v2_record_region(binary)
+    assert 0 <= record_index < block_count
+    record_offset = struct.unpack_from(
+        "<I",
+        binary,
+        V2_FIXED_HEADER_BYTES + UINT32_BYTES * record_index,
+    )[0]
+    record_base = record_region + record_offset
+    layout = struct.unpack_from("<I", binary, record_base)[0] & 0x7
+    return record_base + UINT32_BYTES + (12 if layout == LAYOUT_MIXED else 0)
+
 
 class TestFP4Exporter:
     def test_export_small_tensor(self):
         exporter = FP4Exporter()
         weights = np.random.randn(64, 64).astype(np.float32)
         binary, stats = exporter.export_weights(weights, "test")
-
-        B = stats["num_blocks"]
-        assert B == 1
-        expected_size = B * 4 + B * 4 + B * PAYLOAD_BYTES
-        assert len(binary) == expected_size
+        block_count = stats["num_blocks"]
+        assert block_count == 1
+        assert len(binary) == block_count * (8 + PAYLOAD_BYTES)
         assert stats["shape"] == [64, 64]
 
     def test_export_rectangular_tensor(self):
         exporter = FP4Exporter()
         weights = np.random.randn(128, 192).astype(np.float32)
-        binary, stats = exporter.export_weights(weights, "test")
-
-        tiles_y = 128 // 64 + (1 if 128 % 64 else 0)
-        tiles_x = 192 // 64
-        assert stats["tiles_y"] == tiles_y
-        assert stats["tiles_x"] == tiles_x
-        assert stats["num_blocks"] == tiles_y * tiles_x
+        _, stats = exporter.export_weights(weights, "test")
+        assert stats["tiles_y"] == 2
+        assert stats["tiles_x"] == 3
+        assert stats["num_blocks"] == 6
 
     def test_padded_tensor_pads_correctly(self):
         exporter = FP4Exporter()
         weights = np.random.randn(100, 100).astype(np.float32)
-        binary, stats = exporter.export_weights(weights, "test")
+        _, stats = exporter.export_weights(weights, "test")
         assert stats["tiles_y"] == 2
         assert stats["tiles_x"] == 2
         assert stats["num_blocks"] == 4
@@ -62,153 +82,105 @@ class TestFP4Exporter:
     def test_header_contains_scale_bias(self):
         exporter = FP4Exporter()
         weights = np.ones((64, 64), dtype=np.float32) * 3.0
-        binary, stats = exporter.export_weights(weights, "test")
-
+        binary, _ = exporter.export_weights(weights, "test")
         header = struct.unpack_from("<I", binary, 0)[0]
-        s_bits = (header >> 16) & 0xFFFF
-        b_bits = header & 0xFFFF
-        scale = struct.unpack("<e", struct.pack("<H", s_bits))[0]
-        bias = struct.unpack("<e", struct.pack("<H", b_bits))[0]
+        scale = struct.unpack("<e", struct.pack("<H", header >> 16))[0]
+        bias = struct.unpack("<e", struct.pack("<H", header & 0xFFFF))[0]
+        assert scale >= 0.0
         assert abs(bias - 3.0) < 0.16
 
     def test_export_to_file(self, tmp_path):
         exporter = FP4Exporter(project_root=tmp_path)
         weights = np.random.randn(64, 64).astype(np.float32)
-        bin_path, stats = exporter.export_to_file(weights, "test")
+        bin_path, _ = exporter.export_to_file(weights, "test")
         assert bin_path.exists()
         assert bin_path.name == "test.fp4"
 
     def test_ternary_vs_fp4_mode_flag(self):
         exporter = FP4Exporter()
         weights = np.eye(64, dtype=np.float32)
-        binary, stats = exporter.export_weights(weights, "test", prefer_ternary=True)
-
+        binary, _ = exporter.export_weights(
+            weights,
+            "test",
+            prefer_ternary=True,
+        )
         offset = struct.unpack_from("<I", binary, 4)[0]
-        mode = offset & 0x1
-        assert mode in (MODE_FP4_AFFINE, MODE_T158_AFFINE)
+        assert (offset & 0x1) in (MODE_FP4_AFFINE, MODE_T158_AFFINE)
 
     def test_payload_size_fixed(self):
         exporter = FP4Exporter()
         weights = np.random.randn(128, 128).astype(np.float32)
         binary, stats = exporter.export_weights(weights, "test")
-        B = stats["num_blocks"]
-        payload_start = B * 4 + B * 4
-        payload_length = len(binary) - payload_start
-        assert payload_length == B * PAYLOAD_BYTES
+        block_count = stats["num_blocks"]
+        payload_start = block_count * 8
+        assert len(binary) - payload_start == block_count * PAYLOAD_BYTES
 
     def test_roundtrip_fp4_mse(self):
         exporter = FP4Exporter()
         weights = np.random.randn(64, 64).astype(np.float32) * 3.0
-        binary, stats = exporter.export_weights(weights, "test")
-
-        reconstructed = np.zeros((64, 64), dtype=np.float32)
-        header = struct.unpack_from("<I", binary, 0)[0]
-        s_bits = (header >> 16) & 0xFFFF
-        b_bits = header & 0xFFFF
-        scale = struct.unpack("<e", struct.pack("<H", s_bits))[0]
-        bias = struct.unpack("<e", struct.pack("<H", b_bits))[0]
-
-        offset = struct.unpack_from("<I", binary, 4)[0]
-        mode = offset & 0x1
-        payload_start = 8
-        payload = np.frombuffer(binary[payload_start:payload_start + PAYLOAD_BYTES], dtype=np.uint32)
-
-        for i in range(4096):
-            if mode == MODE_FP4_AFFINE:
-                word = i // 8
-                shift = 4 * (i % 8)
-                code = int((payload[word] >> shift) & 0xF)
-                if code >= 8:
-                    code -= 16
-            else:
-                word = i // 16
-                shift = 2 * (i % 16)
-                sym = int((payload[word] >> shift) & 0x3)
-                code = {0: 0, 1: 1, 2: -1, 3: 0}[sym]
-
-            row = i // 64
-            col = i % 64
-            reconstructed[row, col] = scale * code + bias
-
-        mse = float(np.mean((weights - reconstructed) ** 2))
+        binary, _ = exporter.export_weights(weights, "test")
+        decoded = decode_v1(binary, 64, 64)
+        mse = float(np.mean((weights - decoded) ** 2))
         assert mse < 1.0
 
 
-# ---------------------------------------------------------------------------
-# v2 Tests (adaptive quadtree export)
-# ---------------------------------------------------------------------------
-
 class TestFP4ExporterV2:
-    """Tests for SGFP4 v2 adaptive export."""
-
     def test_v2_binary_starts_with_magic(self):
-        """v2 binary must begin with 4-byte magic b'SGF4'."""
         exporter = FP4Exporter()
         weights = np.random.randn(64, 64).astype(np.float32) * 0.1
-        binary, stats = exporter.export_weights(weights, "test", adaptive=True)
+        binary, _ = exporter.export_weights(weights, "test", adaptive=True)
         assert binary[:4] == SGFP4_MAGIC
 
     def test_v2_binary_has_version_byte(self):
-        """v2 binary must have version byte 0x02 after magic."""
         exporter = FP4Exporter()
         weights = np.random.randn(64, 64).astype(np.float32) * 0.1
-        binary, stats = exporter.export_weights(weights, "test", adaptive=True)
-        version = struct.unpack_from("<B", binary, 4)[0]
-        assert version == SGFP4_VERSION_V2
+        binary, _ = exporter.export_weights(weights, "test", adaptive=True)
+        assert binary[4] == SGFP4_VERSION_V2
 
     def test_v2_binary_has_superblock_count(self):
-        """v2 binary must include num_superblocks as uint32."""
         exporter = FP4Exporter()
         weights = np.random.randn(128, 128).astype(np.float32) * 0.1
-        binary, stats = exporter.export_weights(weights, "test", adaptive=True)
-        num_sb = struct.unpack_from("<I", binary, 5)[0]
-        assert num_sb == 4  # 2x2 superblocks for 128x128
+        binary, _ = exporter.export_weights(weights, "test", adaptive=True)
+        assert struct.unpack_from("<I", binary, 5)[0] == 4
 
     def test_v2_stats_has_effective_bpw(self):
-        """v2 stats dict must include effective_bpw field."""
         exporter = FP4Exporter()
         weights = np.random.randn(64, 64).astype(np.float32) * 0.1
-        binary, stats = exporter.export_weights(weights, "test", adaptive=True)
-        assert "effective_bpw" in stats
-        assert stats["effective_bpw"] > 0.0
-        assert stats["effective_bpw"] <= 32.0  # reasonable upper bound
+        _, stats = exporter.export_weights(weights, "test", adaptive=True)
+        assert 0.0 < stats["effective_bpw"] <= 32.0
 
     def test_v2_stats_has_layout_distribution(self):
-        """v2 stats dict must include layout_distribution for all 6 layout values."""
         exporter = FP4Exporter()
         weights = np.random.randn(64, 64).astype(np.float32) * 0.5
-        binary, stats = exporter.export_weights(weights, "test", adaptive=True)
-        assert "layout_distribution" in stats
-        for i in range(6):
-            assert i in stats["layout_distribution"]
-        # Sum of distribution counts should equal num_superblocks
-        total = sum(stats["layout_distribution"].values())
-        assert total == stats["num_superblocks"]
+        _, stats = exporter.export_weights(weights, "test", adaptive=True)
+        assert all(index in stats["layout_distribution"] for index in range(6))
+        assert sum(stats["layout_distribution"].values()) == stats["num_superblocks"]
 
     def test_v2_export_to_file_writes_sgfp4_extension(self, tmp_path):
-        """v2 adaptive export uses .sgfp4 extension."""
         exporter = FP4Exporter(project_root=tmp_path)
         weights = np.random.randn(64, 64).astype(np.float32) * 0.1
-        bin_path, stats = exporter.export_to_file(weights, "test", adaptive=True)
+        bin_path, _ = exporter.export_to_file(
+            weights,
+            "test",
+            adaptive=True,
+        )
         assert bin_path.name == "test.sgfp4"
         assert bin_path.exists()
 
     def test_v2_export_to_file_writes_manifest(self, tmp_path):
-        """v2 export_to_file writes manifest.json alongside binary."""
         exporter = FP4Exporter(project_root=tmp_path)
         weights = np.random.randn(64, 64).astype(np.float32) * 0.1
-        bin_path, stats = exporter.export_to_file(
-            weights, "code", adaptive=True,
+        bin_path, _ = exporter.export_to_file(
+            weights,
+            "code",
+            adaptive=True,
             base_model="mlx-community/Qwen3-Coder-30B-A3B-Instruct-bf16",
         )
-        manifest_path = bin_path.parent / "manifest.json"
-        assert manifest_path.exists()
-        manifest = json.loads(manifest_path.read_text())
+        manifest = json.loads((bin_path.parent / "manifest.json").read_text())
         assert "sha256" in manifest["fp4_binary"]
         assert manifest["niche"] == "code"
 
     def test_v2_vs_v1_different_output(self):
-        """v1 and v2 output for same weights must differ (different format)."""
         exporter = FP4Exporter()
         weights = np.random.randn(64, 64).astype(np.float32) * 2.0
         v1_binary, _ = exporter.export_weights(weights, "test", adaptive=False)
@@ -216,7 +188,6 @@ class TestFP4ExporterV2:
         assert v1_binary != v2_binary
 
     def test_v2_layout_constant_values(self):
-        """Verify layout enum constants have correct values per D-02."""
         assert LAYOUT_UNIFORM_64 == 0
         assert LAYOUT_UNIFORM_32 == 1
         assert LAYOUT_UNIFORM_16 == 2
@@ -225,289 +196,246 @@ class TestFP4ExporterV2:
         assert LAYOUT_FULL_4x4 == 5
 
     def test_payload_u32_helper(self):
-        """_payload_u32 returns correct uint32 counts per D-03."""
         exporter = FP4Exporter()
-        # 64x64: 4096 weights
-        assert exporter._payload_u32(64, MODE_FP4_AFFINE) == 512     # 4096/8
-        assert exporter._payload_u32(64, MODE_T158_AFFINE) == 256    # 4096/16
-        # 32x32: 1024 weights
+        assert exporter._payload_u32(64, MODE_FP4_AFFINE) == 512
+        assert exporter._payload_u32(64, MODE_T158_AFFINE) == 256
         assert exporter._payload_u32(32, MODE_FP4_AFFINE) == 128
         assert exporter._payload_u32(32, MODE_T158_AFFINE) == 64
-        # 16x16: 256 weights
         assert exporter._payload_u32(16, MODE_FP4_AFFINE) == 32
         assert exporter._payload_u32(16, MODE_T158_AFFINE) == 16
-        # 8x8: 64 weights
         assert exporter._payload_u32(8, MODE_FP4_AFFINE) == 8
         assert exporter._payload_u32(8, MODE_T158_AFFINE) == 4
-        # 4x4: 16 weights
         assert exporter._payload_u32(4, MODE_FP4_AFFINE) == 2
         assert exporter._payload_u32(4, MODE_T158_AFFINE) == 1
 
     def test_classify_layout_uniform_64(self):
-        """_classify_layout detects uniform 64x64 layout."""
-        exporter = FP4Exporter()
-        blocks = [{"size": 64, "y": 0, "x": 0}]
-        assert exporter._classify_layout(blocks) == LAYOUT_UNIFORM_64
+        assert FP4Exporter._classify_layout(
+            [{"size": 64, "y": 0, "x": 0}]
+        ) == LAYOUT_UNIFORM_64
 
     def test_classify_layout_uniform_32(self):
-        """_classify_layout detects uniform 32x32 layout."""
-        exporter = FP4Exporter()
         blocks = [
-            {"size": 32, "y": 0, "x": 0}, {"size": 32, "y": 0, "x": 32},
-            {"size": 32, "y": 32, "x": 0}, {"size": 32, "y": 32, "x": 32},
+            {"size": 32, "y": 0, "x": 0},
+            {"size": 32, "y": 0, "x": 32},
+            {"size": 32, "y": 32, "x": 0},
+            {"size": 32, "y": 32, "x": 32},
         ]
-        assert exporter._classify_layout(blocks) == LAYOUT_UNIFORM_32
+        assert FP4Exporter._classify_layout(blocks) == LAYOUT_UNIFORM_32
 
     def test_classify_layout_full_4x4(self):
-        """_classify_layout detects full 4x4 layout (256 blocks)."""
-        exporter = FP4Exporter()
-        blocks = []
-        for y in range(0, 64, 4):
-            for x in range(0, 64, 4):
-                blocks.append({"size": 4, "y": y, "x": x})
-        assert exporter._classify_layout(blocks) == LAYOUT_FULL_4x4
+        blocks = [
+            {"size": 4, "y": y, "x": x}
+            for y in range(0, 64, 4)
+            for x in range(0, 64, 4)
+        ]
+        assert FP4Exporter._classify_layout(blocks) == LAYOUT_FULL_4x4
 
     def test_classify_layout_mixed(self):
-        """_classify_layout detects mixed quadree layout."""
-        exporter = FP4Exporter()
         blocks = [
             {"size": 32, "y": 0, "x": 0},
             {"size": 16, "y": 32, "x": 0},
             {"size": 16, "y": 48, "x": 0},
         ]
-        assert exporter._classify_layout(blocks) == LAYOUT_MIXED
+        assert FP4Exporter._classify_layout(blocks) == LAYOUT_MIXED
 
     def test_v1_default_is_not_adaptive(self):
-        """Default export_weights call must use v1 (not v2)."""
         exporter = FP4Exporter()
         weights = np.random.randn(64, 64).astype(np.float32) * 0.1
-        binary, stats = exporter.export_weights(weights, "test")
-        # v1 has no magic header
+        binary, _ = exporter.export_weights(weights, "test")
         assert binary[:4] != SGFP4_MAGIC
 
     def test_v2_superblock_offset_table(self):
-        """v2 binary includes valid superblock offset table."""
         exporter = FP4Exporter()
         weights = np.random.randn(128, 128).astype(np.float32) * 0.1
-        binary, stats = exporter.export_weights(weights, "test", adaptive=True)
-        # Paper Sec 6.1: magic(4) + version(1) + num_sb(4) + pad(7) = 16 bytes
-        num_sb = struct.unpack_from("<I", binary, 5)[0]
-        assert num_sb == 4
-        # Read offset table
-        offset_base = 16
-        offsets = []
-        for i in range(num_sb):
-            off = struct.unpack_from("<I", binary, offset_base + i * 4)[0]
-            offsets.append(off)
-        # Offsets must be monotonically increasing
-        for i in range(1, len(offsets)):
-            assert offsets[i] > offsets[i - 1]
+        binary, _ = exporter.export_weights(weights, "test", adaptive=True)
+        block_count = struct.unpack_from("<I", binary, 5)[0]
+        offsets = [
+            struct.unpack_from(
+                "<I",
+                binary,
+                V2_FIXED_HEADER_BYTES + UINT32_BYTES * index,
+            )[0]
+            for index in range(block_count)
+        ]
+        assert offsets == sorted(offsets)
+        assert all(offset % ALIGNMENT == 0 for offset in offsets)
 
     def test_v2_encode_fp4_variable(self):
-        """_encode_fp4_affine_variable works for various block sizes."""
         exporter = FP4Exporter()
-        for size in [4, 8, 16, 32, 64]:
+        for size in (4, 8, 16, 32, 64):
             region = np.random.randn(size, size).astype(np.float32) * 2.0
             result = exporter._encode_fp4_affine_variable(region)
-            assert "scale" in result
-            assert "bias" in result
-            assert "l2_error" in result
-            assert "payload" in result
-            assert "n_weights" in result
             assert result["n_weights"] == size * size
-            payload_words = size * size // 8
-            assert len(result["payload"]) == payload_words
+            assert len(result["payload"]) == size * size // 8
 
     def test_v2_encode_t158_variable(self):
-        """_encode_t158_affine_variable works for various block sizes."""
         exporter = FP4Exporter()
-        for size in [4, 8, 16, 32, 64]:
+        for size in (4, 8, 16, 32, 64):
             region = np.random.randn(size, size).astype(np.float32)
             result = exporter._encode_t158_affine_variable(region)
-            assert "scale" in result
-            assert "bias" in result
-            assert "l2_error" in result
-            assert "payload" in result
-            assert "n_weights" in result
             assert result["n_weights"] == size * size
-            payload_words = size * size // 16
-            assert len(result["payload"]) == payload_words
+            assert len(result["payload"]) == size * size // 16
 
     def test_backward_compatible_cli_default(self):
-        """CLI with just --niche produces v1 output with .fp4 extension."""
-        # Validate that the module-level constants used in __main__ are correct
         assert MACROBLOCK_SIZE == 64
         assert PAYLOAD_BYTES == 2048
         assert MODE_FP4_AFFINE == 0
         assert MODE_T158_AFFINE == 1
 
 
-# ---------------------------------------------------------------------------
-# Threat model tests (T-03-01 through T-03-03)
-# ---------------------------------------------------------------------------
-
 class TestFP4ExporterThreatModel:
-    """Security-focused tests for threat mitigations."""
-
     def test_sgfp4_magic_is_constant(self):
-        """T-03-03: Magic header bytes are fixed and correct."""
-        assert SGFP4_MAGIC == b'SGF4'
+        assert SGFP4_MAGIC == b"SGF4"
         assert len(SGFP4_MAGIC) == 4
 
     def test_sgfp4_version_is_v2(self):
-        """T-03-03: Version byte is 0x02 for v2."""
         assert SGFP4_VERSION_V2 == 0x02
 
     def test_v2_stats_has_no_weight_values(self):
-        """T-03-04: stats don't expose weight values — only aggregates."""
         exporter = FP4Exporter()
         weights = np.random.randn(64, 64).astype(np.float32)
-        binary, stats = exporter.export_weights(weights, "test", adaptive=True)
-        # stats must contain only aggregate/structural fields
+        _, stats = exporter.export_weights(weights, "test", adaptive=True)
         assert "shape" in stats
         assert "num_superblocks" in stats
         assert "effective_bpw" in stats
         assert "layout_distribution" in stats
-        # Must NOT contain raw weight values
         assert "weights" not in stats
         assert "values" not in stats
 
     def test_default_thresholds_all_positive(self):
-        """D-08: All default thresholds have positive max_mse values."""
-        for size, t in DEFAULT_V2_THRESHOLDS.items():
-            assert t["max_mse"] > 0.0, f"Non-positive threshold for block size {size}"
-            assert t["max_relative"] > 0.0, f"Non-positive threshold for block size {size}"
+        for size, threshold in DEFAULT_V2_THRESHOLDS.items():
+            assert threshold["max_mse"] > 0.0, size
+            assert threshold["max_relative"] > 0.0, size
 
     def test_superblock_header_layout_reserved(self):
-        """Superblock header reserves bits 3-31 for future use."""
-        # Layout enum uses only bits 0-2 (values 0-5)
-        # Bits 3-31 are reserved (zero)
-        for layout_val in range(6):
-            # The superblock header is just layout & 0x7
-            sb_header = np.uint32(layout_val & 0x7)
-            assert sb_header < 8  # fits in 3 bits
+        for layout_value in range(6):
+            assert np.uint32(layout_value & 0x7) < 8
 
-
-# ---------------------------------------------------------------------------
-# Spec conformance tests (paper Sec 6 framing + reference decoder round-trip)
-# ---------------------------------------------------------------------------
 
 class TestV2SpecConformance:
-    """The v2 stream must be decodable by an independent implementation
-    built purely from the paper's normative framing (Sec 6.1/6.2)."""
-
-    def test_v2_header_pad_and_record_alignment(self):
-        """Sec 6.1: 7 zero pad bytes; records 16B-aligned, 16B-multiple size."""
+    @pytest.mark.parametrize(
+        "shape,expected_blocks",
+        [
+            ((64, 64), 1),
+            ((64, 128), 2),
+            ((64, 192), 3),
+            ((128, 128), 4),
+            ((64, 320), 5),
+        ],
+    )
+    def test_v2_offset_table_and_record_region_alignment(
+        self,
+        shape,
+        expected_blocks,
+    ):
         exporter = FP4Exporter()
-        rng = np.random.default_rng(0)
-        weights = (rng.standard_normal((128, 128)) * 0.1).astype(np.float32)
-        binary, stats = exporter.export_weights(weights, "test", adaptive=True)
+        rng = np.random.default_rng(expected_blocks)
+        weights = (rng.standard_normal(shape) * 0.05).astype(np.float32)
+        binary, _ = exporter.export_weights(weights, "test", adaptive=True)
 
-        assert binary[9:16] == b"\x00" * 7
-        B = struct.unpack_from("<I", binary, 5)[0]
-        offsets = [struct.unpack_from("<I", binary, 16 + 4 * i)[0]
-                   for i in range(B)]
-        for off in offsets:
-            assert off % 16 == 0, f"record offset {off} not 16B aligned"
-        record_region = 16 + 4 * B
+        assert binary[9:V2_FIXED_HEADER_BYTES] == b"\x00" * 7
+        block_count, table_end, record_region = _v2_record_region(binary)
+        assert block_count == expected_blocks
+        assert record_region == align_up(16 + 4 * block_count)
+        assert record_region % ALIGNMENT == 0
+        assert binary[table_end:record_region] == b"\x00" * (
+            record_region - table_end
+        )
+
+        offsets = [
+            struct.unpack_from(
+                "<I",
+                binary,
+                V2_FIXED_HEADER_BYTES + UINT32_BYTES * index,
+            )[0]
+            for index in range(block_count)
+        ]
+        for offset in offsets:
+            assert offset % ALIGNMENT == 0
+            assert (record_region + offset) % ALIGNMENT == 0
+
         ends = offsets[1:] + [len(binary) - record_region]
-        for off, end in zip(offsets, ends):
-            assert (end - off) % 16 == 0, "record size not a 16B multiple"
-
-    def test_v1_reference_decoder_roundtrip(self):
-        """v1 container decodes via the independent reference decoder."""
-        from quantize.sgfp4_decoder import decode_v1
-        exporter = FP4Exporter()
-        rng = np.random.default_rng(1)
-        weights = (rng.standard_normal((128, 192)) * 2.0).astype(np.float32)
-        binary, _ = exporter.export_weights(weights, "test")
-        decoded = decode_v1(binary, 128, 192)
-        mse = float(np.mean((weights - decoded) ** 2))
-        assert mse < 1.0
+        for offset, end in zip(offsets, ends):
+            assert (end - offset) % ALIGNMENT == 0
 
     def test_v2_reference_decoder_roundtrip_uniform(self):
-        """v2 uniform-layout container decodes via reference decoder."""
-        from quantize.sgfp4_decoder import decode_v2
         exporter = FP4Exporter()
         rng = np.random.default_rng(2)
         weights = (rng.standard_normal((128, 128)) * 0.05).astype(np.float32)
-        binary, stats = exporter.export_weights(weights, "test", adaptive=True)
+        binary, _ = exporter.export_weights(weights, "test", adaptive=True)
         decoded = decode_v2(binary, 128, 128)
-        mse = float(np.mean((weights - decoded) ** 2))
-        assert mse < 0.01
+        assert float(np.mean((weights - decoded) ** 2)) < 0.01
 
-    def test_v2_error_hint_bit_set_for_pyramid_blocks(self):
-        """ERROR_HINT (bit 1 of leaf header flags) must be 1 for blocks
-        selected via the Laplacian pyramid (size >= 16) and 0 for L2-selected
-        blocks (4x4/8x8), per the SGFP4 paper. The reference decoder must
-        accept the stream (bit 1 no longer a reserved violation)."""
-        from quantize.sgfp4_decoder import decode_v2
+    def test_v2_offset_table_pad_must_be_zero(self):
         exporter = FP4Exporter()
-        rng = np.random.default_rng(5)
-        weights = (rng.standard_normal((64, 64)) * 0.02).astype(np.float32)
-        binary, stats = exporter.export_weights(weights, "test", adaptive=True)
+        weights = np.zeros((64, 64), dtype=np.float32)
+        binary, _ = exporter.export_weights(weights, "test", adaptive=True)
+        _, table_end, record_region = _v2_record_region(binary)
+        assert record_region > table_end
 
-        # Parse leaf headers: record starts at offset table end (B=1)
-        B = struct.unpack_from("<I", binary, 5)[0]
-        assert B == 1
-        rec_off = struct.unpack_from("<I", binary, 16)[0] + 16 + 4 * B
-        sb_header = struct.unpack_from("<I", binary, rec_off)[0]
-        layout = sb_header & 0x7
-        from quantize.fp4_exporter import LAYOUT_UNIFORM_64, LAYOUT_MIXED
-        if layout != LAYOUT_MIXED:
-            # Uniform: leaf headers follow sb_header directly
-            n_leaves = stats["total_blocks"]
-            first_header = struct.unpack_from("<I", binary, rec_off + 4)[0]
-            hint = (first_header & 0x2) >> 1
-            # Uniform-64 leaves are pyramid-selected
-            if layout == LAYOUT_UNIFORM_64:
-                assert hint == 1, "64x64 pyramid-selected leaf must set ERROR_HINT"
-        # Decoder must not raise on bit 1 being set
-        decoded = decode_v2(binary, 64, 64)
-        assert decoded.shape == (64, 64)
+        corrupted = bytearray(binary)
+        corrupted[table_end] = 1
+        with pytest.raises(SGFP4FormatError, match="offset-table pad"):
+            decode_v2(bytes(corrupted), 64, 64)
+
+    def test_v2_leaf_bits_1_through_3_are_zero(self):
+        exporter = FP4Exporter()
+        weights = np.zeros((64, 64), dtype=np.float32)
+        binary, _ = exporter.export_weights(weights, "test", adaptive=True)
+        header_pos = _first_leaf_header_position(binary)
+        header = struct.unpack_from("<I", binary, header_pos)[0]
+        assert (header & LEAF_RESERVED_MASK) == 0
+
+    def test_v2_decoder_rejects_reserved_leaf_bit(self):
+        exporter = FP4Exporter()
+        weights = np.zeros((64, 64), dtype=np.float32)
+        binary, _ = exporter.export_weights(weights, "test", adaptive=True)
+        header_pos = _first_leaf_header_position(binary)
+
+        corrupted = bytearray(binary)
+        header = struct.unpack_from("<I", corrupted, header_pos)[0]
+        struct.pack_into("<I", corrupted, header_pos, header | 0x2)
+        with pytest.raises(SGFP4FormatError, match="reserved header flag"):
+            decode_v2(bytes(corrupted), 64, 64)
 
     def test_v2_uniform_16_raster_order_roundtrip(self):
-        """Uniform-16 leaves must be stored in row-major raster order
-        (Sec 6.2) — verified end-to-end through the reference decoder."""
-        from quantize.sgfp4_decoder import decode_v2
-        from quantize.fp4_exporter import LAYOUT_UNIFORM_16
         exporter = FP4Exporter()
         rng = np.random.default_rng(3)
         weights = (rng.standard_normal((64, 64)) * 2.0).astype(np.float32)
         binary, stats = exporter.export_weights(
-            weights, "test", adaptive=True,
-            thresholds={64: {"max_mse": 0.0, "max_relative": 0.0},
-                        32: {"max_mse": 0.0, "max_relative": 0.0}},
+            weights,
+            "test",
+            adaptive=True,
+            thresholds={
+                64: {"max_mse": 0.0, "max_relative": 0.0},
+                32: {"max_mse": 0.0, "max_relative": 0.0},
+            },
             min_block_size=16,
         )
         assert stats["layout_distribution"][LAYOUT_UNIFORM_16] == 1
         decoded = decode_v2(binary, 64, 64)
-        mse = float(np.mean((weights - decoded) ** 2))
-        assert mse < 1.0
+        assert float(np.mean((weights - decoded) ** 2)) < 1.0
 
     def test_v2_mixed_layout_roundtrip_via_split_map(self):
-        """LAYOUT_MIXED record must carry a split map that lets the
-        reference decoder rebuild the quadtree (Sec 6.2)."""
-        from quantize.sgfp4_decoder import decode_v2
-        from quantize.fp4_exporter import LAYOUT_MIXED
         exporter = FP4Exporter()
         rng = np.random.default_rng(4)
         weights = (rng.standard_normal((64, 64)) * 0.01).astype(np.float32)
         weights[:32, :32] = rng.standard_normal((32, 32)).astype(np.float32)
-        thresholds = {s: {"max_mse": 1e-4, "max_relative": 1.0}
-                      for s in (64, 32, 16, 8, 4)}
+        thresholds = {
+            size: {"max_mse": 1e-4, "max_relative": 1.0}
+            for size in (64, 32, 16, 8, 4)
+        }
         binary, stats = exporter.export_weights(
-            weights, "test", adaptive=True, thresholds=thresholds)
+            weights,
+            "test",
+            adaptive=True,
+            thresholds=thresholds,
+        )
         assert stats["layout_distribution"][LAYOUT_MIXED] == 1
         decoded = decode_v2(binary, 64, 64)
-        mse = float(np.mean((weights - decoded) ** 2))
-        assert mse < 1.0
+        assert float(np.mean((weights - decoded) ** 2)) < 1.0
 
     def test_build_split_map_known_tree(self):
-        """Split map for a hand-built tree matches the Sec 6.2 bit rules,
-        and round-trips through the reference parser."""
-        from quantize.sgfp4_decoder import _parse_split_map
-        # Root split; TL/TR/BR are 32x32 leaves; BL splits into four 16x16.
         blocks = [
             {"y": 0, "x": 0, "size": 32},
             {"y": 0, "x": 32, "size": 32},
@@ -517,11 +445,12 @@ class TestV2SpecConformance:
             {"y": 48, "x": 16, "size": 16},
             {"y": 32, "x": 32, "size": 32},
         ]
-        sm = FP4Exporter._build_split_map(blocks)
-        assert len(sm) == 12
-        word0, word1, word2 = struct.unpack("<3I", sm)
-        # Bits in DFS order: 1(root) 0(TL) 0(TR) 1(BL) 0 0 0 0 0(BR)
+        split_map = FP4Exporter._build_split_map(blocks)
+        assert len(split_map) == 12
+        word0, word1, word2 = struct.unpack("<3I", split_map)
         assert word0 == (1 << 0) | (1 << 3)
         assert word1 == 0 and word2 == 0
-        leaves = _parse_split_map(sm)
-        assert leaves == [(b["y"], b["x"], b["size"]) for b in blocks]
+        assert _parse_split_map(split_map) == [
+            (block["y"], block["x"], block["size"])
+            for block in blocks
+        ]

--- a/gnus-poc/tests/test_golden_conformance.py
+++ b/gnus-poc/tests/test_golden_conformance.py
@@ -1,16 +1,8 @@
-"""Golden conformance vectors for SGFP4 v2 encode/decode.
+"""Golden conformance checks for SGFP4 v2 encode/decode.
 
-Fixed-seed weight tensors are exported through the v2 adaptive encoder and
-round-tripped through the independent reference decoder. The pinned values
-(binary length, stats, leaf flags, reconstruction MSE) form a conformance
-contract: any change to the encoder, quadtree, Laplacian, or framing that
-alters the bitstream breaks this test and must be a deliberate, reviewed
-change.
-
-Vectors are deterministic (seeded RNG) so they are stable across machines
-and CI runs. To regenerate after an intentional format change, delete the
-pinned values and re-run with --update-golden (see conftest) or update the
-expected dicts by hand from a verified run.
+Fixed-seed tensors are exported through the adaptive encoder and round-tripped
+through the independent reference decoder. The tests pin framing invariants,
+reserved-bit behavior, reconstruction quality, and deterministic bytes.
 """
 
 import struct
@@ -21,21 +13,20 @@ import pytest
 from quantize.fp4_exporter import FP4Exporter
 from quantize.sgfp4_decoder import decode_v2
 from quantize.sgfp4_format import (
-    LEAF_ERROR_HINT_MASK,
-    LEAF_MODE_MASK,
+    LEAF_RESERVED_MASK,
     SGFP4_MAGIC,
     SGFP4_VERSION_V2,
+    UINT32_BYTES,
+    V2_FIXED_HEADER_BYTES,
+    align_up,
 )
 
-
-# ---------------------------------------------------------------------------
-# Golden vector cases: (seed, shape, scale)
-# ---------------------------------------------------------------------------
 
 _GOLDEN_CASES = [
     ("smooth_low_entropy", 100, (64, 64), 0.01),
     ("mixed_entropy", 101, (64, 64), 1.0),
-    ("two_superblocks", 102, (128, 128), 0.05),
+    ("three_superblocks", 103, (64, 192), 0.05),
+    ("four_superblocks", 102, (128, 128), 0.05),
 ]
 
 
@@ -44,78 +35,84 @@ def _make_weights(seed, shape, scale):
     return (rng.standard_normal(shape) * scale).astype(np.float32)
 
 
-def _parse_leaf_headers(binary):
-    """Extract (layout, [leaf header uint32s]) for each superblock record."""
+def _record_region(binary):
+    block_count = struct.unpack_from("<I", binary, 5)[0]
+    table_end = V2_FIXED_HEADER_BYTES + UINT32_BYTES * block_count
+    region = align_up(table_end)
+    assert binary[table_end:region] == b"\x00" * (region - table_end)
+    return block_count, region
+
+
+def _parse_first_leaf_headers(binary):
+    """Extract ``(layout, first_leaf_header)`` for every v2 record."""
     assert binary[:4] == SGFP4_MAGIC
     assert binary[4] == SGFP4_VERSION_V2
-    B = struct.unpack_from("<I", binary, 5)[0]
-    table_end = 16 + 4 * B
+    block_count, record_region = _record_region(binary)
     records = []
-    for i in range(B):
-        rec_off = struct.unpack_from("<I", binary, 16 + 4 * i)[0] + table_end
-        sb_header = struct.unpack_from("<I", binary, rec_off)[0]
+    for index in range(block_count):
+        record_offset = struct.unpack_from(
+            "<I",
+            binary,
+            V2_FIXED_HEADER_BYTES + UINT32_BYTES * index,
+        )[0]
+        record_base = record_region + record_offset
+        sb_header = struct.unpack_from("<I", binary, record_base)[0]
         layout = sb_header & 0x7
-        # Leaf header section starts after sb_header (+ split_map if MIXED)
-        pos = rec_off + 4
-        if layout == 4:  # LAYOUT_MIXED
-            pos += 12  # SPLIT_MAP_BYTES
-        # Number of leaves is recoverable from layout; for conformance we
-        # read the first leaf header only (representative flag check).
-        first_leaf = struct.unpack_from("<I", binary, pos)[0]
+        header_pos = record_base + UINT32_BYTES
+        if layout == 4:
+            header_pos += 12
+        first_leaf = struct.unpack_from("<I", binary, header_pos)[0]
         records.append((layout, first_leaf))
     return records
 
 
 class TestGoldenConformance:
-    """Pinned encode/decode conformance vectors for SGFP4 v2."""
+    """Deterministic SGFP4 v2 framing and decode checks."""
 
     @pytest.mark.parametrize("name,seed,shape,scale", _GOLDEN_CASES)
     def test_golden_roundtrip(self, name, seed, shape, scale):
-        """Encode with a fixed seed; pinned structural invariants must hold
-        and the reference-decoder roundtrip MSE must stay within tolerance."""
+        del name
         exporter = FP4Exporter()
         weights = _make_weights(seed, shape, scale)
         binary, stats = exporter.export_weights(weights, "golden", adaptive=True)
 
-        # Structural invariants (format framing)
         assert binary[:4] == SGFP4_MAGIC
         assert binary[4] == SGFP4_VERSION_V2
-        assert binary[9:16] == b"\x00" * 7  # header pad
-        B = struct.unpack_from("<I", binary, 5)[0]
-        expected_sb = ((shape[0] + 63) // 64) * ((shape[1] + 63) // 64)
-        assert B == expected_sb
-        assert stats["num_superblocks"] == expected_sb
+        assert binary[9:V2_FIXED_HEADER_BYTES] == b"\x00" * 7
 
-        # Full coverage: blocks tile every superblock
-        assert stats["total_blocks"] == stats["fp4_blocks"] + stats["t158_blocks"]
+        block_count, record_region = _record_region(binary)
+        expected_blocks = ((shape[0] + 63) // 64) * ((shape[1] + 63) // 64)
+        assert block_count == expected_blocks
+        assert stats["num_superblocks"] == expected_blocks
+        assert record_region % 16 == 0
 
-        # Record offsets 16B-aligned
-        offsets = [struct.unpack_from("<I", binary, 16 + 4 * i)[0] for i in range(B)]
-        for off in offsets:
-            assert off % 16 == 0
+        assert stats["total_blocks"] == (
+            stats["fp4_blocks"] + stats["t158_blocks"]
+        )
 
-        # Leaf flags: only mode (bit 0) and ERROR_HINT (bit 1) may be set;
-        # reserved bits 2-3 must be zero (decoder enforces this too).
-        for layout, first_leaf in _parse_leaf_headers(binary):
-            assert (first_leaf & 0xC) == 0, "reserved leaf flag bits 2-3 set"
-            # ERROR_HINT consistency: uniform-64/32/16 layouts are
-            # pyramid-selected (hint=1); 4x4/8x8 are L2-selected (hint=0).
-            hint = (first_leaf & LEAF_ERROR_HINT_MASK) >> 1
-            if layout in (0, 1, 2):  # UNIFORM_64/32/16
-                assert hint == 1, f"layout {layout} leaf missing ERROR_HINT"
-            elif layout in (3, 5):  # UNIFORM_8 / FULL_4X4
-                assert hint == 0, f"layout {layout} leaf wrongly sets ERROR_HINT"
+        offsets = [
+            struct.unpack_from(
+                "<I",
+                binary,
+                V2_FIXED_HEADER_BYTES + UINT32_BYTES * index,
+            )[0]
+            for index in range(block_count)
+        ]
+        for offset in offsets:
+            assert offset % 16 == 0
+            assert (record_region + offset) % 16 == 0
 
-        # Roundtrip through the independent reference decoder
+        # v2 bit 0 is MODE; bits 1-3 are reserved and must remain zero.
+        for _, first_leaf in _parse_first_leaf_headers(binary):
+            assert (first_leaf & LEAF_RESERVED_MASK) == 0
+
         decoded = decode_v2(binary, shape[0], shape[1])
         assert decoded.shape == shape
         mse = float(np.mean((weights - decoded) ** 2))
-        # Generous bound: quantization must not destroy signal entirely
         signal = float(np.mean(weights ** 2))
         assert mse < max(signal * 4.0, 1e-6)
 
     def test_golden_deterministic(self):
-        """Same seed encodes to an identical bitstream twice (bit-exact)."""
         exporter = FP4Exporter()
         weights = _make_weights(200, (64, 64), 0.5)
         binary1, stats1 = exporter.export_weights(weights, "golden", adaptive=True)


### PR DESCRIPTION
## Summary

Updates the SGFP4 v2 Python exporter, reference decoder, and conformance tests to match the revised normative paper.

## Changes

- Adds zero `pad1` after `record_offsets[B]` so the v2 record region begins at `align16(16 + 4*B)`.
- Keeps record offsets relative to the aligned record-region base.
- Validates `pad0`, `pad1`, record offsets, record headers, header padding, payload padding, and split-map trailing bits in the reference decoder.
- Retains `(O, I)` as required model-manifest metadata and validates `B` against the derived macroblock grid.
- Removes v2 `ERROR_HINT` serialization. V2 leaf-header bit 0 is MODE; bits 1-3 are reserved and must be zero. The quadtree may retain `error_hint` only as an internal, non-serialized encoder diagnostic.
- Expands conformance coverage for `B = 1, 2, 3, 4, 5`, reserved-bit rejection, aligned absolute record addresses, deterministic output, uniform layouts, and MIXED split-map round trips.
- Leaves the v1 fixed-payload profile in place.

## Specification source

`SGFP4: Adaptive Dual-Mode Macroblock Quantization with GPU-Friendly Unpacking and Verifiable Decode Semantics`, revised arXiv v2 supplied for this implementation update.

## Validation

A local mirrored smoke harness compiled the changed Python modules and passed:

- v1 decode round trip
- v2 round trips for `B = 1..5`
- aligned `pad1` framing checks
- deterministic v2 bytes
- uniform-16 raster decode
- MIXED split-map decode
- known-tree split-map bit order
- nonzero `pad1` rejection
- reserved v2 leaf-bit rejection

Full repository pytest execution was not available because the connector environment could not clone the private repository. No GitHub Actions run is currently attached to this PR.