### PR TITLE
Use IPFS package directory variables

### DIFF
--- a/cmake/CommonBuildParameters.cmake
+++ b/cmake/CommonBuildParameters.cmake
@@ -263,12 +263,10 @@ set(libp2p_INCLUDE_DIR "${THIRDPARTY_BUILD_DIR}/libp2p/include")
 find_package(libp2p CONFIG REQUIRED)
 include_directories(${libp2p_INCLUDE_DIR})
 
-find_package(ipfs-bitswap-cpp CONFIG REQUIRED
-    PATHS "${THIRDPARTY_BUILD_DIR}/ipfs-bitswap-cpp/lib/cmake/ipfs-bitswap-cpp"
-    NO_DEFAULT_PATH)
-find_package(ipfs-lite-cpp CONFIG REQUIRED
-    PATHS "${THIRDPARTY_BUILD_DIR}/ipfs-lite-cpp/lib/cmake/ipfs-lite-cpp"
-    NO_DEFAULT_PATH)
+set(ipfs-bitswap-cpp_DIR "${THIRDPARTY_BUILD_DIR}/ipfs-bitswap-cpp/lib/cmake/ipfs-bitswap-cpp")
+find_package(ipfs-bitswap-cpp CONFIG REQUIRED)
+set(ipfs-lite-cpp_DIR "${THIRDPARTY_BUILD_DIR}/ipfs-lite-cpp/lib/cmake/ipfs-lite-cpp")
+find_package(ipfs-lite-cpp CONFIG REQUIRED)
 
 # --------------------------------------------------------
 # Find and include cares if libp2p have not included it


### PR DESCRIPTION
## What changed
- Set `ipfs-bitswap-cpp_DIR` and call `find_package(ipfs-bitswap-cpp CONFIG REQUIRED)`.
- Set `ipfs-lite-cpp_DIR` and call `find_package(ipfs-lite-cpp CONFIG REQUIRED)`.
- Remove the equivalent `PATHS ... NO_DEFAULT_PATH` arguments.

## Why
This matches the existing third-party package configuration style and keeps package discovery simple and explicit.

## Validation
- Branch is based directly on `develop`.
- Diff is limited to `cmake/CommonBuildParameters.cmake`: 4 additions and 6 deletions.